### PR TITLE
Include directory does not exist

### DIFF
--- a/intrinsic_cal/CMakeLists.txt
+++ b/intrinsic_cal/CMakeLists.txt
@@ -95,7 +95,6 @@ set(CMAKE_CXX_FLAGS ${CMAKE_CSS_FLAGS} "-fPIC")
 ## CATKIN_DEPENDS: catkin_packages dependent projects also need
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
-  INCLUDE_DIRS include /usr/include/eigen3
 #  LIBRARIES intrinsic_cal
   CATKIN_DEPENDS  roscpp rospy std_msgs geometry_msgs
 #  DEPENDS system_lib


### PR DESCRIPTION
Fixes configuration error:
```cmake
CMake Error at /opt/ros/indigo/share/catkin/cmake/catkin_package.cmake:296 (message):
  catkin_package() include dir 'include' does not exist relative to
  '/home/victor/HiveSync/catkin_workspace/src/industrial_calibration/intrinsic_cal'
Call Stack (most recent call first):
  /opt/ros/indigo/share/catkin/cmake/catkin_package.cmake:98 (_catkin_package)
  industrial_calibration/intrinsic_cal/CMakeLists.txt:97 (catkin_package)


-- Configuring incomplete, errors occurred!
See also "/home/victor/HiveSync/catkin_workspace/build/CMakeFiles/CMakeOutput.log".
See also "/home/victor/HiveSync/catkin_workspace/build/CMakeFiles/CMakeError.log".
Invoking "cmake" failed
```