### PR TITLE
Change Manipulator to manipulator

### DIFF
--- a/industrial_extrinsic_cal/src/nodes/ros_robot_scene_trigger_action_server.cpp
+++ b/industrial_extrinsic_cal/src/nodes/ros_robot_scene_trigger_action_server.cpp
@@ -40,7 +40,7 @@ public:
   {
     joint_value_server_.start();
     pose_server_.start();
-    move_group_ = new moveit::planning_interface::MoveGroup("Manipulator");
+    move_group_ = new moveit::planning_interface::MoveGroup("manipulator");
     move_group_->setPlanningTime(10.0); // give it 10 seconds to plan
     move_group_->setNumPlanningAttempts(30.0); // Allow parallel planner to hybridize this many plans
     move_group_->setPlannerId("RRTConnectkConfigDefault"); // use this planner


### PR DESCRIPTION
MoveIt generates a `manipulator` kinematic chain by default (all lower-case).

:warning: The down-side of this PR is that every package using the `industrial_calibration` package will need to change it's kinematic chain from `Manipulator` to `manipulator`.
