### PR TITLE
Fix CMakeLists.txt

### DIFF
--- a/industrial_extrinsic_cal/CMakeLists.txt
+++ b/industrial_extrinsic_cal/CMakeLists.txt
@@ -20,9 +20,6 @@ find_package(catkin REQUIRED COMPONENTS
   tf_conversions
 )
 
-set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-fPIC -pthread")
-
-
 find_package(Boost REQUIRED)
 
 find_package(Ceres REQUIRED)


### PR DESCRIPTION
I don't know what this is for but because of this the compilation fails on my (64 bits) machine.
Tested on Chris computer, compilation works on a 32 bits machine too after the fix.

```
[ 57%] Building CXX object industrial_calibration/industrial_extrinsic_cal/CMakeFiles/mono_ex_cal.dir/src/nodes/mono_ex_cal.cpp.o
c++: fatal error: no input files
compilation terminated.
/bin/sh: 1: -fPIC: not found
make[2]: *** [industrial_calibration/industrial_extrinsic_cal/CMakeFiles/mono_ex_cal.dir/src/nodes/mono_ex_cal.cpp.o] Erreur 127
[ 57%] [ 57%] make[1]: *** [industrial_calibration/industrial_extrinsic_cal/CMakeFiles/mono_ex_cal.dir/all] Erreur 2
make[1]: *** Attente des tâches non terminées....[ 57%] 
[ 57%] [ 57%] Built target _intrinsic_cal_generate_messages_check_deps_rail_ical_run
Built target dynamic_reconfigure_generate_messages_py
Built target pcl_msgs_generate_messages_lisp
Built target pcl_ros_gencfg
Built target bond_generate_messages_cpp
[ 57%] [ 57%] Built target _target_finder_generate_messages_check_deps_target_locater
Built target topic_tools_generate_messages_py
make: *** [all] Erreur 2
Invoking "make -j8 -l8" failed
```