### PR TITLE
[indigo] Use ceres binary 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,5 +30,4 @@ install:
   - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
 
 script:
-  - source .travis_ceres.sh
   - source .ci_config/travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,11 @@ env:
       ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
       NOT_TEST_BUILD=true
       NOT_TEST_INSTALL=true
-
+    - ROS_DISTRO="indigo"
+      PRERELEASE=true
+matrix:
+  allow_failures:
+    - env: ROS_DISTRO="indigo" PRERELEASE=true
 install:
   - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
 

--- a/industrial_extrinsic_cal/CMakeLists.txt
+++ b/industrial_extrinsic_cal/CMakeLists.txt
@@ -25,6 +25,8 @@ find_package(Boost REQUIRED)
 find_package(Ceres REQUIRED)
 message("-- Found Ceres version ${CERES_VERSION}: ${CERES_INCLUDE_DIRS}")
 
+find_package(Eigen3 REQUIRED)
+
 find_package(OpenCV 2 REQUIRED)
 message("-- Found OpenCV version ${OpenCV_VERSION}: ${OpenCV_INCLUDE_DIRS}")
 
@@ -108,6 +110,7 @@ catkin_package(
   DEPENDS
     Boost
     CERES
+    EIGEN3
 )
 
 
@@ -116,10 +119,10 @@ include_directories(
   include
   ${catkin_INCLUDE_DIRS}
   ${CERES_INCLUDE_DIRS}
+  ${EIGEN3_INCLUDE_DIRS}
   ${OpenCV_INCLUDE_DIRS}
   ${yaml_cpp_INCLUDE_DIR}
 )
-
 
 # target: main library
 add_library(

--- a/industrial_extrinsic_cal/package.xml
+++ b/industrial_extrinsic_cal/package.xml
@@ -23,6 +23,7 @@
   <build_depend>eigen</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>image_transport</build_depend>
+  <build_depend>libceres-dev</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>moveit_ros_planning_interface</build_depend>
   <build_depend>rosconsole</build_depend>
@@ -44,6 +45,7 @@
   <run_depend>geometry_msgs</run_depend>
   <run_depend>image_transport</run_depend>
   <run_depend>image_view</run_depend>
+  <run_depend>libceres-dev</run_depend>
   <run_depend>message_runtime</run_depend>
   <run_depend>motoman_driver</run_depend>
   <run_depend>motoman_sia20d_support</run_depend>

--- a/industrial_extrinsic_cal/package.xml
+++ b/industrial_extrinsic_cal/package.xml
@@ -20,6 +20,7 @@
   <build_depend>actionlib_msgs</build_depend>
   <build_depend>boost</build_depend>
   <build_depend>cv_bridge</build_depend>
+  <build_depend>eigen</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>image_transport</build_depend>
   <build_depend>message_generation</build_depend>
@@ -31,6 +32,7 @@
   <build_depend>sensor_msgs</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>std_srvs</build_depend>
+  <build_depend>suitesparse</build_depend>
   <build_depend>tf</build_depend>
   <build_depend>tf_conversions</build_depend>
   <build_depend>yaml-cpp</build_depend>
@@ -38,6 +40,7 @@
   <run_depend>actionlib</run_depend>
   <run_depend>actionlib_msgs</run_depend>
   <run_depend>cv_bridge</run_depend>
+  <run_depend>eigen</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>image_transport</run_depend>
   <run_depend>image_view</run_depend>
@@ -56,6 +59,7 @@
   <run_depend>sensor_msgs</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>std_srvs</run_depend>
+  <run_depend>suitesparse</run_depend>
   <run_depend>tf</run_depend>
   <run_depend>tf_conversions</run_depend>
   <run_depend>yaml-cpp</run_depend>


### PR DESCRIPTION
This PR makes `industrial_calibration` binary release ready.

Address https://github.com/ros-industrial/industrial_calibration/issues/32. 
And even more, with this PR merged in, this package will become ready for binary release IMO.

- As noted there, binary of  `libceres-dev` has been available for 2 years already. Add some more missing dependency
- On my forked repo,
  - [I confirmed that this PR builds on Travis CI](https://travis-ci.org/130s/industrial_calibration/jobs/265673122#L756).

  ```
  -- Found Ceres version 1.8.0: /usr/include;/usr/include/eigen3;/usr/include
  ```

  - ROS pre-release test failed only because the testcases still seem to have some issues (that's why tests are disabled for Travis CI https://github.com/ros-industrial/industrial_calibration/pull/81).