### PR TITLE
Option to normalize the detection image

### DIFF
--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/ros_camera_observer.h
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/ros_camera_observer.h
@@ -233,6 +233,11 @@ namespace industrial_extrinsic_cal
     bool load_observation_images_;
 
     /**
+     *  @brief Flag to indicate if the image used in pattern detection should be normalized.
+     */
+    bool normalize_calibration_image_;
+
+    /**
      *  @brief image_directory_ place to save images
      */
     std::string image_directory_;


### PR DESCRIPTION
This adds an option in `ROSCameraObserver` for a user to specify that the image sent to the opencv pattern detector should be first normalized. I've found this is sometimes necessary because the whole image might have good contrast, but the desired region-of-interest does not, and so some further processing is needed after the subimage is extracted.

@drchrislewis let me know what you think. Also, what would be the recommended way to document the new parameter?

Thanks!