### PR TITLE
Added and applied .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,66 @@
+---
+BasedOnStyle:  Google
+AccessModifierOffset: -2
+ConstructorInitializerIndentWidth: 2
+AlignEscapedNewlinesLeft: false
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakTemplateDeclarations: true
+AlwaysBreakBeforeMultilineStrings: false
+BreakBeforeBinaryOperators: false
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializersBeforeComma: true
+BinPackParameters: true
+ColumnLimit:    120
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+DerivePointerBinding: false
+PointerBindsToType: true
+ExperimentalAutoDetectBinPacking: false
+IndentCaseLabels: true
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 60
+PenaltyBreakString: 1
+PenaltyBreakFirstLessLess: 1000
+PenaltyExcessCharacter: 1000
+PenaltyReturnTypeOnItsOwnLine: 90
+SpacesBeforeTrailingComments: 2
+Cpp11BracedListStyle: false
+Standard:        Auto
+IndentWidth:     2
+TabWidth:        2
+UseTab:          Never
+IndentFunctionDeclarationAfterType: false
+SpacesInParentheses: false
+SpacesInAngles:  true
+SpaceInEmptyParentheses: false
+SpacesInCStyleCastParentheses: false
+SpaceAfterControlStatementKeyword: true
+SpaceBeforeAssignmentOperators: true
+ContinuationIndentWidth: 4
+SortIncludes: false
+SpaceAfterCStyleCast: false
+
+# Configure each individual brace in BraceWrapping
+BreakBeforeBraces: Custom
+
+# Control of individual brace wrapping cases
+BraceWrapping: {
+    AfterClass: 'true'
+    AfterControlStatement: 'true'
+    AfterEnum : 'true'
+    AfterFunction : 'true'
+    AfterNamespace : 'true'
+    AfterStruct : 'true'
+    AfterUnion : 'true'
+    BeforeCatch : 'true'
+    BeforeElse : 'true'
+    IndentBraces : 'false'
+}
+...

--- a/caljob_creator/src/main.cpp
+++ b/caljob_creator/src/main.cpp
@@ -16,8 +16,7 @@
 class CalJob
 {
 public:
-  CalJob(const std::string& outfile, const std::string& camera_name)
-    : file_(outfile.c_str()), camera_name_(camera_name)
+  CalJob(const std::string& outfile, const std::string& camera_name) : file_(outfile.c_str()), camera_name_(camera_name)
   {
     if (!file_) throw std::runtime_error("Could not open outfile");
     write_headers(file_);
@@ -41,36 +40,37 @@ public:
     image_height_ = height;
     image_width_ = width;
   }
+
 private:
   void write_headers(std::ostream& os) const
   {
-    const static char* header = "---\nreference_frame: world\nscenes:\n"; 
+    const static char* header = "---\nreference_frame: world\nscenes:\n";
     os << header;
   }
 
-  void write_joint_scene(std::ostream& os, const std::vector<double>& joints) const
+  void write_joint_scene(std::ostream& os, const std::vector< double >& joints) const
   {
     os << "-\n";
     os << "     trigger: ROS_ROBOT_JOINT_VALUES_ACTION_TRIGGER\n";
     os << "     trig_action_server: rosRobotSceneTrigger_joint_values\n";
     os << "     joint_values:\n";
     for (size_t i = 0; i < joints.size(); ++i)
-      {
-	os << "        - " << joints[i] << '\n';
-      } 
+    {
+      os << "        - " << joints[i] << '\n';
+    }
     os << "     observations:\n";
     os << "     -\n";
-    os << "          camera: " << camera_name_ <<"\n";
+    os << "          camera: " << camera_name_ << "\n";
     os << "          target: modified_circle_10x10\n";
     os << "          roi_x_min: 0\n";
-    os << "          roi_x_max: " << image_width_ <<"\n";
+    os << "          roi_x_max: " << image_width_ << "\n";
     os << "          roi_y_min: 0\n";
-    os << "          roi_y_max: " << image_height_ <<"\n";
+    os << "          roi_y_max: " << image_height_ << "\n";
     os << "          cost_type: PosedTargetCameraReprjErrorPK\n";
 
     return;
   }
-  void write_pose_scene(std::ostream& os,  tf::StampedTransform transform) const
+  void write_pose_scene(std::ostream& os, tf::StampedTransform transform) const
   {
     os << "-\n";
     os << "     trigger: ROS_ROBOT_POSE_ACTION_TRIGGER\n";
@@ -103,7 +103,6 @@ private:
   std::string camera_name_;
 };
 
-
 static const std::string OPENCV_WINDOW = "Image window";
 
 static void imageCb(const sensor_msgs::ImageConstPtr& msg)
@@ -126,100 +125,115 @@ static void imageCb(const sensor_msgs::ImageConstPtr& msg)
   cv::waitKey(3);
 }
 
-//sensor_msgs::PointCloud2ConstPtr msg = ros::topic::waitForMessage<sensor_msgs::PointCloud2>(params_.scan_topic,ros::Duration(WAIT_MSG_DURATION));
+// sensor_msgs::PointCloud2ConstPtr msg =
+// ros::topic::waitForMessage<sensor_msgs::PointCloud2>(params_.scan_topic,ros::Duration(WAIT_MSG_DURATION));
 
 int main(int argc, char** argv)
 {
   ros::init(argc, argv, "caljob_creator");
 
-  ros::NodeHandle nh ("~");
+  ros::NodeHandle nh("~");
 
   // Load options from param server
   std::string image_topic_name;
   int image_height;
   int image_width;
   std::string camera_name;
-  nh.param<std::string>("image_topic", image_topic_name, "/kinect2/rgb_rect/image");
-  nh.param<int>("image_width", image_width, 640);
-  nh.param<int>("image_height", image_height, 480);
-  nh.param<std::string>("camera_name", camera_name, "basler1");
+  nh.param< std::string >("image_topic", image_topic_name, "/kinect2/rgb_rect/image");
+  nh.param< int >("image_width", image_width, 640);
+  nh.param< int >("image_height", image_height, 480);
+  nh.param< std::string >("camera_name", camera_name, "basler1");
   std::string output_file_name;
-  nh.param<std::string>("output_file", output_file_name, "caljob.yaml");
+  nh.param< std::string >("output_file", output_file_name, "caljob.yaml");
 
   std::string joints_topic_name;
-  nh.param<std::string>("joints_topic", joints_topic_name, "motoman/joint_states");
+  nh.param< std::string >("joints_topic", joints_topic_name, "motoman/joint_states");
 
   std::string motion_type;
-  nh.param<std::string>("motion_type", motion_type, "joint");
+  nh.param< std::string >("motion_type", motion_type, "joint");
 
   std::string to_frame("none");
   std::string from_frame("none");
-  if(motion_type == "pose"){
-    if(!nh.getParam("to_frame", to_frame)) {
+  if (motion_type == "pose")
+  {
+    if (!nh.getParam("to_frame", to_frame))
+    {
       ROS_ERROR("must set to_frame for motion type: pose");
     }
-    if(!nh.getParam("from_frame", from_frame)) {
+    if (!nh.getParam("from_frame", from_frame))
+    {
       ROS_ERROR("must set from_frame for motion type: pose");
     }
     ROS_INFO("to_frame: %s from_frame %s", to_frame.c_str(), from_frame.c_str());
   }
-  // Handlers for images 
-  image_transport::ImageTransport image_trans (nh);
+  // Handlers for images
+  image_transport::ImageTransport image_trans(nh);
 
   // OpenCV window scopegaurd
-  struct CvScopeGaurd {
-    CvScopeGaurd() { cv::namedWindow(OPENCV_WINDOW); }
-    ~CvScopeGaurd() { cv::destroyWindow(OPENCV_WINDOW); }
+  struct CvScopeGaurd
+  {
+    CvScopeGaurd()
+    {
+      cv::namedWindow(OPENCV_WINDOW);
+    }
+    ~CvScopeGaurd()
+    {
+      cv::destroyWindow(OPENCV_WINDOW);
+    }
   } scope_gaurd;
 
   // Create subscribers for images
   image_transport::Subscriber image_sub = image_trans.subscribe(image_topic_name, 1, imageCb);
 
-  CalJob caljob (output_file_name, camera_name);
+  CalJob caljob(output_file_name, camera_name);
   caljob.setImageSize(image_height, image_width);
 
   tf::TransformListener tf_listener;
   tf::StampedTransform tf_transform;
 
-
   // Main loop
   while (ros::ok())
   {
-    bool capture_scene=false;
-    bool quit=false;
+    bool capture_scene = false;
+    bool quit = false;
     nh.getParam("capture_scene", capture_scene);
     nh.getParam("quit", quit);
-    if (quit) break; 
+    if (quit)
+      break;
     else if (capture_scene)
     {
       nh.setParam("capture_scene", false);
       ROS_INFO("Attempting to capture robot state");
       // get robot joint state
-      sensor_msgs::JointStateConstPtr joints 
-          = ros::topic::waitForMessage<sensor_msgs::JointState>(joints_topic_name, ros::Duration(1.0));
+      sensor_msgs::JointStateConstPtr joints =
+          ros::topic::waitForMessage< sensor_msgs::JointState >(joints_topic_name, ros::Duration(1.0));
 
       // get robot pose state
       ros::Time now = ros::Time::now();
-      while(!tf_listener.waitForTransform(from_frame, to_frame, now, ros::Duration(1.0))){
-	ROS_INFO("waiting for tranform from %s to  %s",from_frame.c_str(),to_frame.c_str());
+      while (!tf_listener.waitForTransform(from_frame, to_frame, now, ros::Duration(1.0)))
+      {
+        ROS_INFO("waiting for tranform from %s to  %s", from_frame.c_str(), to_frame.c_str());
       }
       tf_listener.lookupTransform(from_frame, to_frame, now, tf_transform);
-      
+
       if (!joints)
       {
         ROS_ERROR("Could not capture joint states within capture timeframe");
       }
       else
       {
-	if(motion_type == "joint"){
-	  caljob.new_joint_scene(*joints);
-	}
-	else if(motion_type == "pose"){
-	  caljob.new_pose_scene(tf_transform);
-	}
-	else{
-	  ROS_ERROR("motion type invalid, [joint or pose]: %s", motion_type.c_str());
-	}
+        if (motion_type == "joint")
+        {
+          caljob.new_joint_scene(*joints);
+        }
+        else if (motion_type == "pose")
+        {
+          caljob.new_pose_scene(tf_transform);
+        }
+        else
+        {
+          ROS_ERROR("motion type invalid, [joint or pose]: %s", motion_type.c_str());
+        }
       }
     }
 

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/basic_types.h
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/basic_types.h
@@ -27,203 +27,202 @@
 
 namespace industrial_extrinsic_cal
 {
+typedef double* P_BLOCK;
 
-  typedef double* P_BLOCK;
+/*! \brief A region of interest in an image */
+typedef struct
+{
+  int x_min;
+  int x_max;
+  int y_min;
+  int y_max;
+} Roi;
 
-  /*! \brief A region of interest in an image */
-  typedef struct
+/*! Brief Point3d defines a ceres_structure for a point in 3D space */
+typedef struct
+{
+  union
   {
-    int x_min;
-    int x_max;
-    int y_min;
-    int y_max;
-  } Roi;
-
-  /*! Brief Point3d defines a ceres_structure for a point in 3D space */
-  typedef struct
-  {
-    union
+    struct
     {
-      struct
-      {
-	double x; /**< position x */
-	double y; /**< position y */
-	double z; /**< position z */
-      };
-      double pb[3]; /**< a parameter block with all three elements */
+      double x; /**< position x */
+      double y; /**< position y */
+      double z; /**< position z */
     };
-  } Point3d;
+    double pb[3]; /**< a parameter block with all three elements */
+  };
+} Point3d;
 
-  /*! Brief Pose6d defines a ceres_structure for a pose in 3D space 
-   *   x,y,z have their natrual meanging
-   *   ax,ay,az define the rotation part of the pose using angle axis notation
+/*! Brief Pose6d defines a ceres_structure for a pose in 3D space
+ *   x,y,z have their natrual meanging
+ *   ax,ay,az define the rotation part of the pose using angle axis notation
+ */
+class Pose6d
+{
+public:
+  /** @brief constructor with complete information
+   *    @param tx translation in x
+   *    @param ty translation in y
+   *    @param tz translation in z
+   *    @param aax x component of angle axis vector
+   *    @param aay y component of angle axis vector
+   *    @param aaz z component of angle axis vector
+  */
+  Pose6d(double tx, double ty, double tz, double aax, double aay, double aaz);
+
+  /** @brief default constructor*/
+  Pose6d();
+
+  /** @brief set the rotational part of pose using a tf::Matrix3x3
+   *    @param m a 3x3 matrix representing the rotation
    */
-  class Pose6d
-  {
-  public:
-    /** @brief constructor with complete information 
-     *    @param tx translation in x
-     *    @param ty translation in y
-     *    @param tz translation in z
-     *    @param aax x component of angle axis vector
-     *    @param aay y component of angle axis vector
-     *    @param aaz z component of angle axis vector
-    */
-    Pose6d(double tx, double ty, double tz, double aax, double aay, double aaz);
+  void setBasis(tf::Matrix3x3& m);
 
-    /** @brief default constructor*/
-    Pose6d();
+  /** @brief set the translational part of pose using a tf::Vector3
+   *    @param v the translation components as a 3 vector
+  */
+  void setOrigin(tf::Vector3& v);
 
-    /** @brief set the rotational part of pose using a tf::Matrix3x3 
-     *    @param m a 3x3 matrix representing the rotation
-     */
-    void setBasis( tf::Matrix3x3 & m);
+  /** @brief set the translational part of pose
+   *    @param tx  the x value of the translation vector
+   *    @param ty  the y value of the translation vector
+   *    @param tz  the z value of the translation vector
+  */
+  void setOrigin(double tx, double ty, double tz);
 
-    /** @brief set the translational part of pose using a tf::Vector3 
-     *    @param v the translation components as a 3 vector
-    */
-    void setOrigin(tf::Vector3 & v);
-
-    /** @brief set the translational part of pose 
-     *    @param tx  the x value of the translation vector
-     *    @param ty  the y value of the translation vector
-     *    @param tz  the z value of the translation vector
-    */
-    void setOrigin(double tx, double ty, double tz);
-
-    /** @brief set the rotational part of pose using Euler Z-Y-Z rotations
-     *   @param  ez Rotation angle around Z axis
-     *   @param  ey Rotation angle around y axis
-     *   @param  ex Rotation angle around x axis
-     */
-    void setEulerZYX(double ez, double ey, double ex);
-
-    /** @brief set the rotational part of pose using a quaternion
-     *   @param qx quaternion x value
-     *   @param qy quaternion y value
-     *   @param qz quaternion z value
-     *   @param qw quaternion w value
-     */
-    void setQuaternion(double qx, double qy, double qz, double qw);
-
-    /** @brief set the rotational part of pose using the angle axis notation
-     *    @param aax x component of angle axis vector
-     *    @param aay y component of angle axis vector
-     *    @param aaz z component of angle axis vector
-    */
-    void setAngleAxis(double aax, double aay, double aaz);
-
-    /** @brief get the rotational part of pose as a tf::Matrix3x3 */
-    tf::Matrix3x3 getBasis() const;
-
-    /** @brief get the euler angles  
-     * @param ez angle of rotation around z axis 
-     * @param ey angle of rotation around y axis 
-     * @param ex angle of rotation around x axis 
-     */
-    void getEulerZYX(double &ez, double &ey, double &ex) const;
-
-    /** @brief get the translationalpart of pose as a tf::Vector3*/
-    tf::Vector3 getOrigin() const;
-
-    //TODO  void get_eulerZYX(double &ez, double &ey, double &ex);
-
-    /** @brief get the translationalpart of pose as a quaternion
-     *   @param qx quaternion x value
-     *   @param qy quaternion y value
-     *   @param qz quaternion z value
-     *   @param qw quaternion w value
-    */
-    void getQuaternion(double &qx,  double &qy, double &qz, double &qw) const;
-
-    /** @brief get the inverse of the pose_*/
-    Pose6d getInverse() const;
-
-    /** @brief output pose info 
-     *    @param message to display along with pose info
-     */
-    void show(std::string message);
-
-    /** @brief multiplication operator*/
-    Pose6d operator * ( Pose6d pose2) const;
-    union
-    {
-      struct
-      {
-	double ax; /**< angle axis x value */
-	double ay; /**< angle axis y value */
-	double az; /**< angle axis z value */
-	double x; /**< position x */
-	double y; /**< position y */
-	double z; /**< position z */
-      };
-      struct
-      {
-	double pb_aa[3]; /**< parameter block for rotation */
-	double pb_loc[3]; /**< parameter block for position */
-      };
-      struct
-      {
-	double pb_pose[6]; /**< a third option with a single block for 6dof pose */
-      };
-    }; // end of union
-  };// end of class Pose6d
-  
-  /** @brief Parameters defining checker board target   */
-  typedef struct
-  {
-    int pattern_rows;
-    int pattern_cols;
-  } CheckerBoardParameters;
-
-  /** @brief Parameters defining circle grid target  */
-  typedef struct
-  {
-    int pattern_rows;		// number of rows
-    int pattern_cols;		// number of colulmns
-    bool is_symmetric;		// not sure
-    double circle_diameter;	// size of each circle
-  } CircleGridParameters;
-
-  /** @brief Parameters defining AR target */
-  typedef struct
-  {
-    double marker_width;
-  } ARTargetParameters;
-
-  /*! Brief CameraParameters defines both the intrinsic and extrinsic parameters of a camera
+  /** @brief set the rotational part of pose using Euler Z-Y-Z rotations
+   *   @param  ez Rotation angle around Z axis
+   *   @param  ey Rotation angle around y axis
+   *   @param  ex Rotation angle around x axis
    */
-  typedef struct
-  {
-    union
-    {
-      struct
-      {
-	double angle_axis[3]; /**< angle axis data */
-	double position[3]; /**< position data */
-	double focal_length_x; /**< focal length in x */
-	double focal_length_y; /**< focal length in y */
-	double center_x; /**< central pixel x value */
-	double center_y; /**< central pixel y value */
-	double distortion_k1; /**< 2nd order radial distortion parameter */
-	double distortion_k2; /**< 4th order radial distortion parameter */
-	double distortion_k3; /**< 6th order radial distortion parameter */
-	double distortion_p1; /**< 1st tangential distortion parameter */
-	double distortion_p2; /**< 2nd tangential distortion parameter */
-      };
-      struct
-      { /** parameter blocks for ceres */
-	double pb_extrinsics[6]; /** parameter block for intrinsics */
-	double pb_intrinsics[9]; /** parameter block for extrinsics */
-      };
-      struct
-      {
-	double pb_all[15]; /** parameter block for both */
-      };
-    };// end of union
-    int height;
-    int width;
-  } CameraParameters;
+  void setEulerZYX(double ez, double ey, double ex);
 
-}//end namespace industrial_extrinsiac_cal
+  /** @brief set the rotational part of pose using a quaternion
+   *   @param qx quaternion x value
+   *   @param qy quaternion y value
+   *   @param qz quaternion z value
+   *   @param qw quaternion w value
+   */
+  void setQuaternion(double qx, double qy, double qz, double qw);
+
+  /** @brief set the rotational part of pose using the angle axis notation
+   *    @param aax x component of angle axis vector
+   *    @param aay y component of angle axis vector
+   *    @param aaz z component of angle axis vector
+  */
+  void setAngleAxis(double aax, double aay, double aaz);
+
+  /** @brief get the rotational part of pose as a tf::Matrix3x3 */
+  tf::Matrix3x3 getBasis() const;
+
+  /** @brief get the euler angles
+   * @param ez angle of rotation around z axis
+   * @param ey angle of rotation around y axis
+   * @param ex angle of rotation around x axis
+   */
+  void getEulerZYX(double& ez, double& ey, double& ex) const;
+
+  /** @brief get the translationalpart of pose as a tf::Vector3*/
+  tf::Vector3 getOrigin() const;
+
+  // TODO  void get_eulerZYX(double &ez, double &ey, double &ex);
+
+  /** @brief get the translationalpart of pose as a quaternion
+   *   @param qx quaternion x value
+   *   @param qy quaternion y value
+   *   @param qz quaternion z value
+   *   @param qw quaternion w value
+  */
+  void getQuaternion(double& qx, double& qy, double& qz, double& qw) const;
+
+  /** @brief get the inverse of the pose_*/
+  Pose6d getInverse() const;
+
+  /** @brief output pose info
+   *    @param message to display along with pose info
+   */
+  void show(std::string message);
+
+  /** @brief multiplication operator*/
+  Pose6d operator*(Pose6d pose2) const;
+  union
+  {
+    struct
+    {
+      double ax; /**< angle axis x value */
+      double ay; /**< angle axis y value */
+      double az; /**< angle axis z value */
+      double x;  /**< position x */
+      double y;  /**< position y */
+      double z;  /**< position z */
+    };
+    struct
+    {
+      double pb_aa[3];  /**< parameter block for rotation */
+      double pb_loc[3]; /**< parameter block for position */
+    };
+    struct
+    {
+      double pb_pose[6]; /**< a third option with a single block for 6dof pose */
+    };
+  };  // end of union
+};    // end of class Pose6d
+
+/** @brief Parameters defining checker board target   */
+typedef struct
+{
+  int pattern_rows;
+  int pattern_cols;
+} CheckerBoardParameters;
+
+/** @brief Parameters defining circle grid target  */
+typedef struct
+{
+  int pattern_rows;        // number of rows
+  int pattern_cols;        // number of colulmns
+  bool is_symmetric;       // not sure
+  double circle_diameter;  // size of each circle
+} CircleGridParameters;
+
+/** @brief Parameters defining AR target */
+typedef struct
+{
+  double marker_width;
+} ARTargetParameters;
+
+/*! Brief CameraParameters defines both the intrinsic and extrinsic parameters of a camera
+ */
+typedef struct
+{
+  union
+  {
+    struct
+    {
+      double angle_axis[3];  /**< angle axis data */
+      double position[3];    /**< position data */
+      double focal_length_x; /**< focal length in x */
+      double focal_length_y; /**< focal length in y */
+      double center_x;       /**< central pixel x value */
+      double center_y;       /**< central pixel y value */
+      double distortion_k1;  /**< 2nd order radial distortion parameter */
+      double distortion_k2;  /**< 4th order radial distortion parameter */
+      double distortion_k3;  /**< 6th order radial distortion parameter */
+      double distortion_p1;  /**< 1st tangential distortion parameter */
+      double distortion_p2;  /**< 2nd tangential distortion parameter */
+    };
+    struct
+    {                          /** parameter blocks for ceres */
+      double pb_extrinsics[6]; /** parameter block for intrinsics */
+      double pb_intrinsics[9]; /** parameter block for extrinsics */
+    };
+    struct
+    {
+      double pb_all[15]; /** parameter block for both */
+    };
+  };  // end of union
+  int height;
+  int width;
+} CameraParameters;
+
+}  // end namespace industrial_extrinsiac_cal
 #endif

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/calibration_job.hpp
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/calibration_job.hpp
@@ -20,7 +20,7 @@
 #define CALIBRATION_JOB_HPP_
 
 #include <iostream>
-#include <industrial_extrinsic_cal/basic_types.h> /** needed for Roi */
+#include <industrial_extrinsic_cal/basic_types.h>       /** needed for Roi */
 #include <industrial_extrinsic_cal/camera_observer.hpp> /** needed for CameraObserver */
 #include <boost/shared_ptr.hpp>
 #include "ceres/ceres.h"
@@ -28,7 +28,6 @@
 
 namespace industrial_extrinsic_cal
 {
-
 /*! \brief a high level camera wraper including its parameters, and its observer */
 class Camera
 {
@@ -38,7 +37,7 @@ public:
 
   /*! \brief Constructor
    *  \param name name of camera
-   *  \param camera_parameters intrinsic and extrinsic camera parameters 
+   *  \param camera_parameters intrinsic and extrinsic camera parameters
    *  \param is_moving static camera = false, moving camera=true
    */
   Camera(std::string name, CameraParameters camera_parameters, bool is_moving);
@@ -46,13 +45,13 @@ public:
   /*! \brief default destructor, nothing to do really */
   ~Camera();
 
-  /*!  is the camera's location fixed or not? 
+  /*!  is the camera's location fixed or not?
    moving cameras get multiple pose parameters
    static cameras get but one set of pose parameters
    */
   bool is_moving();
-  boost::shared_ptr<DummyCameraObserver> camera_observer_;/*!< processes images, does CameraObservations */
-  CameraParameters camera_parameters_;/*!< The intrinsic and extrinsic parameters */
+  boost::shared_ptr< DummyCameraObserver > camera_observer_; /*!< processes images, does CameraObservations */
+  CameraParameters camera_parameters_;                       /*!< The intrinsic and extrinsic parameters */
   //    ::std::ostream& operator<<(::std::ostream& os, const Camera& C){ return os<< "TODO";};
 
   std::string camera_name_; /*!< string camera_name_ unique name of a camera */
@@ -75,8 +74,8 @@ typedef struct
 /*! @brief unique observation command */
 typedef struct
 {
-  boost::shared_ptr<Camera> camera;
-  boost::shared_ptr<Target> target;
+  boost::shared_ptr< Camera > camera;
+  boost::shared_ptr< Target > target;
   Roi roi;
 } ObservationCmd;
 
@@ -84,27 +83,22 @@ typedef struct
 class ObservationScene
 {
 public:
-  /*! \brief Constructor, 
+  /*! \brief Constructor,
    *   \param Trigger Trig the type of trigger to initiate this observation
    */
-  ObservationScene(Trigger trigger, int scene_id) :
-      trigger_(trigger), scene_id_(scene_id)
-  {
-  }
-  ;
+  ObservationScene(Trigger trigger, int scene_id) : trigger_(trigger), scene_id_(scene_id){};
 
   /*! \brief destructor, clears observation command list*/
   ObservationScene()
   {
     observation_command_list_.clear();
     cameras_in_scene_.clear();
-  }
-  ;
+  };
 
   /*! \brief  Clears all observations from the command */
   void clear();
 
-  /*! \brief Adds and observation of a target by a specific camera in a region of interest 
+  /*! \brief Adds and observation of a target by a specific camera in a region of interest
    *  \param observation_command: the camera to make the observation
    *  \param target: the target to be observed
    *  \param roi:    the region of interest in the camera's field of view to look for target
@@ -114,22 +108,20 @@ public:
   int get_id()
   {
     return (scene_id_);
-  }
-  ;
+  };
 
   /*! \brief gets the trigger of this scene */
   Trigger get_trigger()
   {
     return (trigger_);
-  }
-  ;
+  };
 
-  std::vector<ObservationCmd> observation_command_list_; /*!< list of observations for a scene */
-  std::vector<boost::shared_ptr<Camera> > cameras_in_scene_; /*!< list of cameras in this scened */
+  std::vector< ObservationCmd > observation_command_list_;      /*!< list of observations for a scene */
+  std::vector< boost::shared_ptr< Camera > > cameras_in_scene_; /*!< list of cameras in this scened */
 
 private:
   Trigger trigger_; /*!< event to trigger the observations in this command */
-  int scene_id_; /*!< unique identifier of this scene */
+  int scene_id_;    /*!< unique identifier of this scene */
 };
 // end of class ObservationScene
 
@@ -137,21 +129,20 @@ private:
 /*! \brief moving cameras need a new pose with each scene in which they are used */
 typedef struct MovingCamera
 {
-  boost::shared_ptr<Camera> cam; // must hold a copy of the camera extrinsic parameters
-  int scene_id; // but copy of intrinsics may be and unused duplicate
+  boost::shared_ptr< Camera > cam;  // must hold a copy of the camera extrinsic parameters
+  int scene_id;                     // but copy of intrinsics may be and unused duplicate
 } MovingCamera;
 
 /*! \brief moving  need a new pose with each scene in which they are used */
 typedef struct MovingTarget
 {
-  boost::shared_ptr<Target> targ; // must hold a copy of the target pose parameters,
-  int scene_id; // but point parameters may be unused duplicates
+  boost::shared_ptr< Target > targ;  // must hold a copy of the target pose parameters,
+  int scene_id;                      // but point parameters may be unused duplicates
 } MovingTarget;
 
 class ObservationDataPoint
 {
 public:
-
   /**
    *
    * @param c_name camera name
@@ -178,13 +169,9 @@ public:
     point_position_ = p_position;
     image_x_ = image_x;
     image_y_ = image_y;
-  }
-  ;
+  };
 
-  ~ObservationDataPoint()
-  {
-  }
-  ;
+  ~ObservationDataPoint(){};
 
   std::string camera_name_;
   std::string target_name_;
@@ -200,7 +187,8 @@ public:
 // end of class ObservationDataPoint
 
 /**
- * @brief a list of observation data points which allows all the collected information about the observations to be easily submitted to ceres
+ * @brief a list of observation data points which allows all the collected information about the observations to be
+ * easily submitted to ceres
  *        It also allows the problem data to be printed to files for debugging and external analysis
  */
 class ObservationDataPointList
@@ -212,7 +200,7 @@ public:
 
   void addObservationPoint(ObservationDataPoint new_data_point);
 
-  std::vector<ObservationDataPoint> items;
+  std::vector< ObservationDataPoint > items;
 };
 
 /** \brief These blocks of data hold the ceres parameters upon which the optimizaition proceeds
@@ -232,55 +220,55 @@ public:
   /*! \brief clear all static and moving cameras and targets */
   void clearCamerasTargets();
 
-  /*! \brief adds a static camera to job's list of cameras 
+  /*! \brief adds a static camera to job's list of cameras
    *  \param camera_to_add this is the camera added to the list
    *  \return true on success
    */
-  bool addStaticCamera(boost::shared_ptr<Camera> camera_to_add);
+  bool addStaticCamera(boost::shared_ptr< Camera > camera_to_add);
 
   /*! \brief adds a static target to job's list of static targets
    *  \param target_to_add this is the target added to the list
    *  \return true on success
    */
-  bool addStaticTarget(boost::shared_ptr<Target> target_to_add);
+  bool addStaticTarget(boost::shared_ptr< Target > target_to_add);
 
-  /*! \brief adds a moving camera to job's list of cameras 
+  /*! \brief adds a moving camera to job's list of cameras
    *  \param camera_to_add this is the camera added to the list
    *  \param scene_id the scene's id, only one camera of given name existe in each scene
    *  \return true on success
    */
-  bool addMovingCamera(boost::shared_ptr<Camera> camera_to_add, int scene_id);
+  bool addMovingCamera(boost::shared_ptr< Camera > camera_to_add, int scene_id);
 
   /*! \brief adds a static target to job's list of static targets
    *  \param target_to_add this is the target added to the list
    *  \param scene_id the scene's id, only one target of given name exist in each scene
    *  \return true on success
    */
-  bool addMovingTarget(boost::shared_ptr<Target> target_to_add, int scene_id);
+  bool addMovingTarget(boost::shared_ptr< Target > target_to_add, int scene_id);
 
-  /*! @brief gets a pointer to the intrinsic parameters of a static camera 
+  /*! @brief gets a pointer to the intrinsic parameters of a static camera
    *  @param camera_name the camera's name
    *  @return pointer to the only existing set of intrinsics for this camera
    */
   P_BLOCK getStaticCameraParameterBlockIntrinsics(std::string camera_name);
 
-  /*! @brief gets a pointer to the intrinsic parameters of a moving camera 
+  /*! @brief gets a pointer to the intrinsic parameters of a moving camera
    *  @param camera_name the camera's name
    *  @return pointer to the intrinsic parameters for this camera, note that
    *          a number of copies of the intrinsics exist, because the camera
    *          was duplicated in each scene it made an observation
-   *          however, the first scene in which the camera was used contains the 
+   *          however, the first scene in which the camera was used contains the
    *          only set of intrinsics to be adjusted, and therefore is the only one returned
    */
   P_BLOCK getMovingCameraParameterBlockIntrinsics(std::string camera_name);
 
-  /*! @brief gets a pointer to the extrinsics parameters of a static camera 
+  /*! @brief gets a pointer to the extrinsics parameters of a static camera
    *  @param camera_name the camera's name
    *  @return pointer to the only existing set of extrinsics for this camera
    */
   P_BLOCK getStaticCameraParameterBlockExtrinsics(std::string camera_name);
 
-  /*! @brief gets a pointer to the extrisic parameters of a moving camera 
+  /*! @brief gets a pointer to the extrisic parameters of a moving camera
    *  @param camera_name the camera's name
    *  @return pointer to the intrinsic parameters for this camera, note that
    *          a number of copies of the intrinsics exist, because the camera
@@ -290,7 +278,7 @@ public:
    */
   P_BLOCK getMovingCameraParameterBlockExtrinsics(std::string camera_name, int scene_id);
 
-  /*! @brief gets a pointer to the pose parameters of a static target 
+  /*! @brief gets a pointer to the pose parameters of a static target
    *  @param target_name the target's name
    *  @return pointer to the only existing set of pose parameters for this target
    */
@@ -325,11 +313,11 @@ public:
    */
   P_BLOCK getMovingTargetPointParameterBlock(std::string target_name, int pnt_id);
 
-  //private:
-  std::vector<boost::shared_ptr<Camera> > static_cameras_; /*!< all non-moving cameras in job */
-  std::vector<boost::shared_ptr<MovingCamera> > moving_cameras_; /*! only one camera of a given name per scene */
-  std::vector<boost::shared_ptr<Target> > static_targets_; /*!< all non-moving targets in job */
-  std::vector<boost::shared_ptr<MovingTarget> > moving_targets_; /*! only one target of a given name per scene */
+  // private:
+  std::vector< boost::shared_ptr< Camera > > static_cameras_;       /*!< all non-moving cameras in job */
+  std::vector< boost::shared_ptr< MovingCamera > > moving_cameras_; /*! only one camera of a given name per scene */
+  std::vector< boost::shared_ptr< Target > > static_targets_;       /*!< all non-moving targets in job */
+  std::vector< boost::shared_ptr< MovingTarget > > moving_targets_; /*! only one target of a given name per scene */
 };
 
 /*! @brief defines and exececutes the calibration script */
@@ -337,84 +325,78 @@ class CalibrationJob
 {
 public:
   /** @brief constructor */
-  CalibrationJob(std::string camera_fn, std::string target_fn, std::string caljob_fn) :
-      camera_def_file_name_(camera_fn), target_def_file_name_(target_fn), caljob_def_file_name_(caljob_fn)
-  {
-  }
-  ;
+  CalibrationJob(std::string camera_fn, std::string target_fn, std::string caljob_fn)
+    : camera_def_file_name_(camera_fn), target_def_file_name_(target_fn), caljob_def_file_name_(caljob_fn){};
 
   /** @brief default destructor */
-  ~CalibrationJob()
-  {
-  }
-  ;
+  ~CalibrationJob(){};
 
-  /** @brief reads input files to create a calibration job 
-   * @return true if successful 
+  /** @brief reads input files to create a calibration job
+   * @return true if successful
    */
   bool load();
 
-  /** @brief stores calibration job as 3 files 
-   * @return true if successful 
+  /** @brief stores calibration job as 3 files
+   * @return true if successful
    */
   bool store();
 
-  /** @brief runs both data collection and optimization 
-   * @return true if successful 
+  /** @brief runs both data collection and optimization
+   * @return true if successful
    */
   bool run();
 
-  /** @brief runs the data collection portion of the job 
-   * @return true if successful 
+  /** @brief runs the data collection portion of the job
+   * @return true if successful
    */
   bool runObservations();
 
-  /** @brief runs the optimization portion of the job 
-   * @return true if successful 
+  /** @brief runs the optimization portion of the job
+   * @return true if successful
    */
   bool runOptimization();
 
   /** @brief Adds a new camera
    *  @param camera_to_add camera to add
-   *  @return true if successful 
+   *  @return true if successful
    */
   bool addCameraObserver(Camera camera_to_add);
 
   /** @brief Adds a new target to defined target set
    *  @param target_to_add target to add
-   *  @return true if successful 
+   *  @return true if successful
    */
   bool addTarget(Target target_to_add);
 
-  /** @brief removes all camera observers from job 
-   *  @return true if successful 
+  /** @brief removes all camera observers from job
+   *  @return true if successful
    */
   bool clearJobCameraObservers();
 
   /** @brief removes all targets from job
-   *  @return true if successful 
+   *  @return true if successful
    */
   bool clearJobTargets();
 
-  /** @brief clears all previously collected data 
-   *  @return true if successful 
+  /** @brief clears all previously collected data
+   *  @return true if successful
    */
   bool clearObservationData();
 
-  /** @brief select active scene for modification  
+  /** @brief select active scene for modification
    *  @return true if sucessful
    */
   bool selectScene(int scene_id);
 
-  /** @brief adds an observation from a particular camera to current scene  
+  /** @brief adds an observation from a particular camera to current scene
    *  @param camera_observer a pointer to the camera observer
    *  @param target a pointer to the target
    *  @return true if sucessful
    */
-  bool addObservationToCurrentScene(boost::shared_ptr<DummyCameraObserver> camera_observer,
-                                    boost::shared_ptr<Target> target);
+  bool addObservationToCurrentScene(boost::shared_ptr< DummyCameraObserver > camera_observer,
+                                    boost::shared_ptr< Target > target);
 
-  /** @brief removes all cameras and targets from current scene 
+  /** @brief removes all cameras and targets from current scene
    *  @return true if sucessful
    */
   bool clearCurrentScene();
@@ -429,17 +411,16 @@ public:
 
   //    ::std::ostream& operator<<(::std::ostream& os, const CalibrationJob& C){ return os<< "TODO";}
 private:
-  std::string camera_def_file_name_; /*!< this file describes all cameras in job */
-  std::string target_def_file_name_; /*!< this file describes all targets in job */
-  std::string caljob_def_file_name_; /*!< this file describes all observations in job */
-  std::vector<ObservationScene> scene_list_; /*!< contains list of scenes which define the job */
-  int current_scene_; /*!< id of current scene under review or construction */
-  std::vector<DummyCameraObserver> camera_observers_; /*!< interface to images from cameras */
-  std::vector<Target> defined_target_set_; /*!< TODO Not sure if I'll use this one */
-  CeresBlocks ceres_blocks_; /*!< This structure maintains the parameter sets for ceres */
+  std::string camera_def_file_name_;                    /*!< this file describes all cameras in job */
+  std::string target_def_file_name_;                    /*!< this file describes all targets in job */
+  std::string caljob_def_file_name_;                    /*!< this file describes all observations in job */
+  std::vector< ObservationScene > scene_list_;          /*!< contains list of scenes which define the job */
+  int current_scene_;                                   /*!< id of current scene under review or construction */
+  std::vector< DummyCameraObserver > camera_observers_; /*!< interface to images from cameras */
+  std::vector< Target > defined_target_set_;            /*!< TODO Not sure if I'll use this one */
+  CeresBlocks ceres_blocks_;                            /*!< This structure maintains the parameter sets for ceres */
   ceres::Problem problem_; /*!< This is the object which solves non-linear optimization problems */
-
 };
 
-} // end of namespace
+}  // end of namespace
 #endif

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/calibration_job_definition.h
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/calibration_job_definition.h
@@ -19,7 +19,6 @@
 #ifndef CALIBRATION_JOB_DEFINITION_H_
 #define CALIBRATION_JOB_DEFINITION_H_
 
-
 #include <industrial_extrinsic_cal/basic_types.h>
 #include <industrial_extrinsic_cal/camera_observer.hpp>
 #include <industrial_extrinsic_cal/camera_definition.h>
@@ -39,47 +38,49 @@
 #include <fstream>
 #include <iostream>
 
-
 namespace industrial_extrinsic_cal
 {
-  namespace covariance_requests{
-    enum CovarianceRequestType { 
-      DefaultInvalid=0,
-      StaticCameraIntrinsicParams,
-      StaticCameraExtrinsicParams,
-      MovingCameraIntrinsicParams,
-      MovingCameraExtrinsicParams,
-      StaticTargetPoseParams,
-      MovingTargetPoseParams
-    };
-  } // end of namespace covariance_requests
-  struct CovarianceVariableRequest{
-    covariance_requests::CovarianceRequestType request_type;
-    std::string object_name;
-    int scene_id;
-  };
+namespace covariance_requests
+{
+enum CovarianceRequestType
+{
+  DefaultInvalid = 0,
+  StaticCameraIntrinsicParams,
+  StaticCameraExtrinsicParams,
+  MovingCameraIntrinsicParams,
+  MovingCameraExtrinsicParams,
+  StaticTargetPoseParams,
+  MovingTargetPoseParams
+};
+}  // end of namespace covariance_requests
+struct CovarianceVariableRequest
+{
+  covariance_requests::CovarianceRequestType request_type;
+  std::string object_name;
+  int scene_id;
+};
 
-  /*! @brief converts an integer to a covariance request type
-   * @param request the integer request type
-   * @returns the covariance request type
-   */
-  covariance_requests::CovarianceRequestType intToCovRequest(int request);
+/*! @brief converts an integer to a covariance request type
+ * @param request the integer request type
+ * @returns the covariance request type
+ */
+covariance_requests::CovarianceRequestType intToCovRequest(int request);
 
 /*! @brief defines and executes the calibration script */
 class CalibrationJob
 {
 public:
   /** @brief constructor */
-  CalibrationJob(std::string camera_fn, std::string target_fn, std::string caljob_fn) :
-    camera_def_file_name_(camera_fn), 
-    target_def_file_name_(target_fn), 
-    caljob_def_file_name_(caljob_fn), 
-    solved_(false), problem_(NULL),
-    post_proc_on_(false)
-  {  } ;
+  CalibrationJob(std::string camera_fn, std::string target_fn, std::string caljob_fn)
+    : camera_def_file_name_(camera_fn)
+    , target_def_file_name_(target_fn)
+    , caljob_def_file_name_(caljob_fn)
+    , solved_(false)
+    , problem_(NULL)
+    , post_proc_on_(false){};
 
   /** @brief default destructor */
-  ~CalibrationJob() {  } ;
+  ~CalibrationJob(){};
 
   /** @brief reads input files to create a calibration job
    * @return true if successful
@@ -95,7 +96,7 @@ public:
   /** @brief shows the current poses of all cameras and targets
    * @return true if successful
    */
- void show();
+  void show();
 
   /** @brief runs both data collection and optimization
    * @return true if successful
@@ -117,7 +118,6 @@ public:
    */
   bool clearObservationData();
 
-
   const std::string& getReferenceFrame() const
   {
     return ceres_blocks_.reference_frame_;
@@ -137,7 +137,7 @@ public:
    *    @param variables a list of cameras and targets
    *    @param covariance_file_name name of file to store the resulting matrix in
    */
-  bool computeCovariance(std::vector<CovarianceVariableRequest> &variables, std::string &covariance_file_name);
+  bool computeCovariance(std::vector< CovarianceVariableRequest >& variables, std::string& covariance_file_name);
 
   /** @brief set the flag to save observation data to a file indicated for post processing
    *    @param post_proc_file_name the name of the file to put the post processing data
@@ -147,11 +147,17 @@ public:
   /** @brief clears the flag that saves observation data to a file for post processing */
   void postProcessingOff();
 
-/*@brief get pointer to the blocks moving and static cameras and targets */
-  CeresBlocks * getBlocks(){return &ceres_blocks_; }; 
+  /*@brief get pointer to the blocks moving and static cameras and targets */
+  CeresBlocks* getBlocks()
+  {
+    return &ceres_blocks_;
+  };
 
-/*@brief get pointer to list of scenes*/
-  std::vector<ObservationScene> * getScenes(){return &scene_list_;}; 
+  /*@brief get pointer to list of scenes*/
+  std::vector< ObservationScene >* getScenes()
+  {
+    return &scene_list_;
+  };
 
   //    ::std::ostream& operator<<(::std::ostream& os, const CalibrationJob& C){ return os<< "TODO";}
 protected:
@@ -205,8 +211,8 @@ protected:
    *  @param target a pointer to the target
    *  @return true if successful
    */
-  bool addObservationToCurrentScene(boost::shared_ptr<ROSCameraObserver> camera_observer,
-                                    boost::shared_ptr<Target> target);
+  bool addObservationToCurrentScene(boost::shared_ptr< ROSCameraObserver > camera_observer,
+                                    boost::shared_ptr< Target > target);
 
   /** @brief removes all cameras and targets from current scene
    *  @return true if successful
@@ -217,33 +223,32 @@ protected:
    *  @param trig the trigger type to use for this scene
    *  @return true if successful
    */
-  bool appendNewScene(boost::shared_ptr<Trigger> trig);
+  bool appendNewScene(boost::shared_ptr< Trigger > trig);
 
   /** @brief each camera and each target have a transform interface, push the current values to the interface */
   void pushTransforms();
 
-  /** @brief each camera and each target have a transform interface, pull the current values from the interface 
+  /** @brief each camera and each target have a transform interface, pull the current values from the interface
    *    @param scene_id the id for the scene, only pull transforms from targets and cameras of this scene
 */
   void pullTransforms(int scene_id);
 
-
 private:
-  std::vector<ObservationDataPointList> observation_data_point_list_; /*!< a list of observation data points */
-  std::vector<ObservationScene> scene_list_; /*!< contains list of scenes which define the job */
-  std::string camera_def_file_name_; /*!< this file describes all cameras in job */
-  std::string target_def_file_name_; /*!< this file describes all targets in job */
-  std::string caljob_def_file_name_; /*!< this file describes all observations in job */
-  int current_scene_; /*!< id of current scene under review or construction */
-  CeresBlocks ceres_blocks_; /*!< This structure maintains the parameter sets for ceres */
-  ceres::Problem  *problem_; /*!< this is the object used to define the optimization problem for ceres */
+  std::vector< ObservationDataPointList > observation_data_point_list_; /*!< a list of observation data points */
+  std::vector< ObservationScene > scene_list_; /*!< contains list of scenes which define the job */
+  std::string camera_def_file_name_;           /*!< this file describes all cameras in job */
+  std::string target_def_file_name_;           /*!< this file describes all targets in job */
+  std::string caljob_def_file_name_;           /*!< this file describes all observations in job */
+  int current_scene_;                          /*!< id of current scene under review or construction */
+  CeresBlocks ceres_blocks_;                   /*!< This structure maintains the parameter sets for ceres */
+  ceres::Problem* problem_;              /*!< this is the object used to define the optimization problem for ceres */
   ceres::Solver::Summary ceres_summary_; /*!< object for displaying solver results */
-  int total_observations_; /*< number of observations/cost elements in problem */
-  bool solved_; /*< set once the problem has been solved, allows covariance to be computed*/
-  bool post_proc_on_; /*< flag indicating to save the observation data for post processing */
-  std::string post_proc_data_file_; /*< file name for observation data for post processing */ 
-};//end class
+  int total_observations_;               /*< number of observations/cost elements in problem */
+  bool solved_;                          /*< set once the problem has been solved, allows covariance to be computed*/
+  bool post_proc_on_;                    /*< flag indicating to save the observation data for post processing */
+  std::string post_proc_data_file_;      /*< file name for observation data for post processing */
+};                                       // end class
 
-}//end namespace industrial_extrinsic_cal
+}  // end namespace industrial_extrinsic_cal
 
 #endif /* CALIBRATION_JOB_DEFINITION_H_ */

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/caljob_yaml_parser.h
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/caljob_yaml_parser.h
@@ -12,29 +12,25 @@
 #include <industrial_extrinsic_cal/observation_scene.h>
 #include <industrial_extrinsic_cal/ceres_blocks.h>
 
-namespace industrial_extrinsic_cal {
+namespace industrial_extrinsic_cal
+{
+// prototypes
+/** @brief parses the calibration job definition yaml file
+ *   @param caljob_input_file a stream pointing at the file
+ *   @param scene_list the returned list of scenes
+ *   @param reference_frame the retured reference frame
+ *   @param blocks the blocks containing pointers to all the camera and target parameters for ceres
+ **/
+bool parseCaljob(std::string& caljob_input_file, std::vector< ObservationScene >& scene_list,
+                 std::string& reference_frame, CeresBlocks& blocks);
 
-
-
-  // prototypes
-  /** @brief parses the calibration job definition yaml file
-   *   @param caljob_input_file a stream pointing at the file
-   *   @param scene_list the returned list of scenes
-   *   @param reference_frame the retured reference frame
-   *   @param blocks the blocks containing pointers to all the camera and target parameters for ceres
-   **/
-  bool parseCaljob(std::string &caljob_input_file, 
-		   std::vector<ObservationScene>  &scene_list, 
-		   std::string &reference_frame, 
-		   CeresBlocks &blocks);
-
-  /** @brief parses a single scene
-   *   @param node, the yaml node 
-   *   @param scene_id the current scenes' id
-   *   @param blocks the blocks containing pointers to all the camera and target parameters for ceres
-   *   @return an observation scene
-   **/
-  ObservationScene parseSingleScene(const YAML::Node &node, int scene_id, CeresBlocks & blocks);
-}// end industrial_extrinsic_cal namespace
+/** @brief parses a single scene
+ *   @param node, the yaml node
+ *   @param scene_id the current scenes' id
+ *   @param blocks the blocks containing pointers to all the camera and target parameters for ceres
+ *   @return an observation scene
+ **/
+ObservationScene parseSingleScene(const YAML::Node& node, int scene_id, CeresBlocks& blocks);
+}  // end industrial_extrinsic_cal namespace
 
 #endif

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/camera_definition.h
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/camera_definition.h
@@ -19,7 +19,6 @@
 #ifndef CAMERA_CLASS_H_
 #define CAMERA_CLASS_H_
 
-
 #include <ros/console.h>
 #include <industrial_extrinsic_cal/camera_observer.hpp>
 #include <industrial_extrinsic_cal/basic_types.h>
@@ -31,7 +30,6 @@
 
 namespace industrial_extrinsic_cal
 {
-
 /*! \brief a high level camera wrapper including its parameters, and its observer */
 class Camera
 {
@@ -55,12 +53,12 @@ public:
    */
   bool isMoving();
 
-  /*! \brief send the camera parameters to the transform interface 
+  /*! \brief send the camera parameters to the transform interface
    *  Note: some interfaces do nothing on the operation
    */
   void pushTransform();
 
-  /*! \brief get the camera parameters from the transform interface 
+  /*! \brief get the camera parameters from the transform interface
    *  Note: some interfaces do nothing on this operaton
    */
   void pullTransform();
@@ -69,42 +67,41 @@ public:
    *  Transform interfaces allow hardware or simulation to provide or accept pose information
    *  depending on whether they are a broadcaster or a listener
    */
-  void setTransformInterface(boost::shared_ptr<TransformInterface> tranform_interface);
+  void setTransformInterface(boost::shared_ptr< TransformInterface > tranform_interface);
 
   /*! \brief set the reference frame for the tranform interface.
    *  Because transform interfaces need to get created when the camera or target is created, we often don't know
    *  what the reference frame is for the interface until later, so we need to set it
    */
-  void setTIReferenceFrame(std::string & ref_frame);
+  void setTIReferenceFrame(std::string& ref_frame);
 
   /*! \brief get the observations from the observer
    *  @param camera_observations a vector of observations
      * @return 0 if failed to get observations, 1 if successful
    */
-  int getObservations(CameraObservations &camera_observations);
+  int getObservations(CameraObservations& camera_observations);
 
-
-  /*! \brief get the transform interface, 
+  /*! \brief get the transform interface,
    *  Because transform interfaces need to get created when the camera or target is created, we often don't know
    *  what the reference frame is for the interface until later, so we need to set it
    * TODO since we have a get and set, why is it public?
    */
-  boost::shared_ptr<TransformInterface> getTransformInterface();
-  boost::shared_ptr<CameraObserver> camera_observer_;/*!< processes images, does CameraObservations */
-  boost::shared_ptr<Trigger>  trigger_; /*!< pointer to the trigger mechanism for this camera*/
-  CameraParameters camera_parameters_;/*!< The intrinsic and extrinsic parameters */
-  std::string camera_name_; /*!< string camera_name_ unique name of a camera */
-  boost::shared_ptr<TransformInterface>  transform_interface_; /**< interface to transform, tf for example  */
+  boost::shared_ptr< TransformInterface > getTransformInterface();
+  boost::shared_ptr< CameraObserver > camera_observer_;         /*!< processes images, does CameraObservations */
+  boost::shared_ptr< Trigger > trigger_;                        /*!< pointer to the trigger mechanism for this camera*/
+  CameraParameters camera_parameters_;                          /*!< The intrinsic and extrinsic parameters */
+  std::string camera_name_;                                     /*!< string camera_name_ unique name of a camera */
+  boost::shared_ptr< TransformInterface > transform_interface_; /**< interface to transform, tf for example  */
   Pose6d intermediate_frame_; /**< Sometimes there is an intermediate transform from ref to origin of intrinsics */
-  bool is_moving_; /*!< bool is_moving_  false for static cameras */
+  bool is_moving_;            /*!< bool is_moving_  false for static cameras */
 };
 // end of class Camera
 
 /*! @brief unique observation command */
 typedef struct
 {
-  boost::shared_ptr<Camera> camera;
-  boost::shared_ptr<Target> target;
+  boost::shared_ptr< Camera > camera;
+  boost::shared_ptr< Target > target;
   Roi roi;
   Cost_function cost_type;
 } ObservationCmd;
@@ -113,11 +110,10 @@ typedef struct
 /*! \brief moving cameras need a new pose with each scene in which they are used */
 typedef struct MovingCamera
 {
-  boost::shared_ptr<Camera> cam; // must hold a copy of the camera extrinsic parameters
-  int scene_id; // but copy of intrinsics may be and unused duplicate
+  boost::shared_ptr< Camera > cam;  // must hold a copy of the camera extrinsic parameters
+  int scene_id;                     // but copy of intrinsics may be and unused duplicate
 } MovingCamera;
 
-}//end namespace industrial_extrinsic_cal
-
+}  // end namespace industrial_extrinsic_cal
 
 #endif /* CAMERA_CLASS_H_ */

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/camera_observer.hpp
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/camera_observer.hpp
@@ -20,58 +20,57 @@
 #define CAMERA_OBSERVER_HPP_
 
 #include <industrial_extrinsic_cal/basic_types.h> /* Target,Roi,Observation,CameraObservations */
-#include <industrial_extrinsic_cal/target.h> /* Roi,Observation,CameraObservations */
+#include <industrial_extrinsic_cal/target.h>      /* Roi,Observation,CameraObservations */
 #include <industrial_extrinsic_cal/ceres_costs_utils.h>
 
 namespace industrial_extrinsic_cal
 {
-  /*! \brief An observation is the x,y image location of a target's point in an image*/
-  typedef struct
-  {
-    boost::shared_ptr<Target> target; /**< pointer to target who's point is observed */
-    int point_id; /**< point's id in target's point array */
-    double image_loc_x; /**< target point was found at image location x */
-    double image_loc_y; /**< target point image location y */
-    Cost_function cost_type;  /**< type of cost associated with this observation */
-    Pose6d intermediate_frame; /**< sometimes one needs the transform from ref_frame to the frame of extrinics for camera */
-  } Observation;
+/*! \brief An observation is the x,y image location of a target's point in an image*/
+typedef struct
+{
+  boost::shared_ptr< Target > target; /**< pointer to target who's point is observed */
+  int point_id;                       /**< point's id in target's point array */
+  double image_loc_x;                 /**< target point was found at image location x */
+  double image_loc_y;                 /**< target point image location y */
+  Cost_function cost_type;            /**< type of cost associated with this observation */
+  Pose6d
+      intermediate_frame; /**< sometimes one needs the transform from ref_frame to the frame of extrinics for camera */
+} Observation;
 
-  /*! \brief A vector of observations made by a single camera of posibly multiple targets */
-  typedef     std::vector<Observation> CameraObservations;
+/*! \brief A vector of observations made by a single camera of posibly multiple targets */
+typedef std::vector< Observation > CameraObservations;
 
-  /** @brief A camera observer is an object which given a set of targets and regions of interest, it provides observations 
-   *              of those targets. A camera obsever is configured with targets, then triggered, once observations are done, they
-   *              may be collected with the getter function.
-   */
+/** @brief A camera observer is an object which given a set of targets and regions of interest, it provides observations
+ *              of those targets. A camera obsever is configured with targets, then triggered, once observations are
+ * done, they
+ *              may be collected with the getter function.
+ */
 class CameraObserver
 {
 public:
   /** @brief Default destructor */
-  virtual ~CameraObserver()
-  {
-  }
-  ;
+  virtual ~CameraObserver(){};
 
   /** @brief add a target to look for */
   /** @param targ a target to look for */
   /** @param roi Region of interest for target */
-  virtual bool addTarget(boost::shared_ptr<Target> targ, Roi &roi, Cost_function cost_type)=0;
+  virtual bool addTarget(boost::shared_ptr< Target > targ, Roi& roi, Cost_function cost_type) = 0;
 
   /** @brief remove all targets */
-  virtual void clearTargets()=0;
+  virtual void clearTargets() = 0;
 
   /** @brief clear all previous observations */
-  virtual void clearObservations()=0;
+  virtual void clearObservations() = 0;
 
   /** @brief return observations */
   /** @param output all observations of targets defined */
-  virtual int getObservations(CameraObservations &camera_observations)=0;
+  virtual int getObservations(CameraObservations& camera_observations) = 0;
 
   /** @brief print this object TODO */
-  virtual void triggerCamera()=0;
+  virtual void triggerCamera() = 0;
 
   /** @brief tells when camera has completed its observations */
-  virtual bool observationsDone()=0;
+  virtual bool observationsDone() = 0;
 
   /** @brief pushes the camera_info out to the camera driver */
   /** @param fx the focal length in x*/
@@ -84,7 +83,8 @@ public:
   /** @param p1 distortion decentering */
   /** @param p2 distortion decentering */
   /** @returns true if successful */
-  virtual bool pushCameraInfo(double &fx, double &fy, double &cx, double &cy, double &k1,  double &k2,  double &k3,  double &p1,  double &p2)=0;
+  virtual bool pushCameraInfo(double& fx, double& fy, double& cx, double& cy, double& k1, double& k2, double& k3,
+                              double& p1, double& p2) = 0;
 
   /** @brief pulls the camera_info in from the camera driver */
   /** @param fx the focal length in x*/
@@ -97,7 +97,8 @@ public:
   /** @param p1 distortion decentering */
   /** @param p2 distortion decentering */
   /** @returns true if successful */
-  virtual bool pullCameraInfo(double &fx, double &fy, double &cx, double &cy, double &k1,  double &k2,  double &k3,  double &p1,  double &p2)=0;
+  virtual bool pullCameraInfo(double& fx, double& fy, double& cx, double& cy, double& k1, double& k2, double& k3,
+                              double& p1, double& p2) = 0;
 
   /** @brief pulls the camera_info in from the camera driver */
   /** @param fx the focal length in x*/
@@ -112,7 +113,8 @@ public:
   /** @param width image width */
   /** @param height image height */
   /** @returns true if successful */
-  virtual bool pullCameraInfo(double &fx, double &fy, double &cx, double &cy, double &k1,  double &k2,  double &k3,  double &p1,  double &p2, int &width, int &height)=0;
+  virtual bool pullCameraInfo(double& fx, double& fy, double& cx, double& cy, double& k1, double& k2, double& k3,
+                              double& p1, double& p2, int& width, int& height) = 0;
 
   std::string camera_name_; /*!< string camera_name_ unique name of a camera */
 
@@ -120,5 +122,5 @@ public:
   //    virtual ::std::ostream& operator<<(::std::ostream& os, const CameraObserver& camera);
 };
 
-} // end of namespace
+}  // end of namespace
 #endif

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/camera_yaml_parser.h
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/camera_yaml_parser.h
@@ -10,40 +10,41 @@
 #include <industrial_extrinsic_cal/trigger.h>
 #include <industrial_extrinsic_cal/yaml_utils.h>
 
-namespace industrial_extrinsic_cal {
+namespace industrial_extrinsic_cal
+{
+// prototypes
+/** @brief parses a single camera, either moving or static
+ *   @param node, the yaml node
+ *   @return a shared pointer to camera parsed
+ **/
+boost::shared_ptr< Camera > parseSingleCamera(const YAML::Node& node);
+/** @brief parses a transform interface
+ *   @param node, the yaml node
+ *   @param frame, the frame that the transform interface refers to
+ *   @param pose, the initial value of the pose
+ *   @return a shared pointer to transform interface parsed
+ **/
+boost::shared_ptr< TransformInterface > parseTransformInterface(const YAML::Node& node, std::string& name,
+                                                                std::string& frame, Pose6d& pose);
+/** @brief parses a trigger
+ *   @param node, the yaml node
+ *   @param name name of trigger
+ *   @return shared pointer to the trigger parsed
+ **/
+boost::shared_ptr< Trigger > parseTrigger(const YAML::Node& node, std::string& name);
+/** @brief parses a Pose6d
+ *   @param node, the yaml node
+ *   @param pose as 6dof pose from parsed position and angle axis parameters xyz,wx,wy,wz
+ *   @return true if sucessful
+ **/
+bool parsePose(const YAML::Node& node, Pose6d& pose);
+/** @brief parse all the cameras, the main function of this module
+ *   @param camera_input_file path/file from which to parse a vector of cameras
+ *   @param returned vector of shared pointers to cameras
+ *   @return true if successful
+ **/
+bool parseCameras(std::string& cameras_input_file, std::vector< boost::shared_ptr< Camera > >& cameras);
 
-  // prototypes
-  /** @brief parses a single camera, either moving or static 
-   *   @param node, the yaml node 
-   *   @return a shared pointer to camera parsed
-   **/
-  boost::shared_ptr<Camera> parseSingleCamera(const YAML::Node &node);
-  /** @brief parses a transform interface
-   *   @param node, the yaml node 
-   *   @param frame, the frame that the transform interface refers to
-   *   @param pose, the initial value of the pose
-   *   @return a shared pointer to transform interface parsed
-   **/
-  boost::shared_ptr<TransformInterface> parseTransformInterface(const YAML::Node &node, std::string &name, std::string &frame, Pose6d &pose);
-  /** @brief parses a trigger
-   *   @param node, the yaml node 
-   *   @param name name of trigger
-   *   @return shared pointer to the trigger parsed
-   **/
-  boost::shared_ptr<Trigger> parseTrigger(const YAML::Node &node, std::string &name);
-  /** @brief parses a Pose6d
-   *   @param node, the yaml node 
-   *   @param pose as 6dof pose from parsed position and angle axis parameters xyz,wx,wy,wz
-   *   @return true if sucessful
-   **/
-  bool parsePose(const YAML::Node &node, Pose6d &pose);
-  /** @brief parse all the cameras, the main function of this module
-   *   @param camera_input_file path/file from which to parse a vector of cameras
-   *   @param returned vector of shared pointers to cameras
-   *   @return true if successful
-   **/
-  bool parseCameras(std::string &cameras_input_file, std::vector<boost::shared_ptr<Camera> >& cameras);
-
-}// end industrial_extrinsic_cal namespace
+}  // end industrial_extrinsic_cal namespace
 
 #endif

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/ceres_blocks.h
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/ceres_blocks.h
@@ -30,7 +30,6 @@
 
 namespace industrial_extrinsic_cal
 {
-
 /** \brief These blocks of data hold the ceres parameters upon which the optimizaition proceeds
  *   Static cameras have a block of parameters for their 6Dof Pose
  *                  they have a block of 4 parameters for pinhole projection model intrinsics
@@ -52,34 +51,34 @@ public:
    *  \param camera_to_add this is the camera added to the list
    *  \return true on success
    */
-  bool addStaticCamera(boost::shared_ptr<Camera> camera_to_add);
+  bool addStaticCamera(boost::shared_ptr< Camera > camera_to_add);
 
   /*! \brief adds a static target to job's list of static targets
    *  \param target_to_add this is the target added to the list
    *  \return true on success
    */
-  bool addStaticTarget(boost::shared_ptr<Target> target_to_add);
+  bool addStaticTarget(boost::shared_ptr< Target > target_to_add);
 
   /*! \brief adds a moving camera to job's list of cameras
    *  \param camera_to_add this is the camera added to the list
    *  \param scene_id the scene's id, only one camera of given name exist in each scene
    *  \return true on success
    */
-  bool addMovingCamera(boost::shared_ptr<Camera> camera_to_add, int scene_id);
+  bool addMovingCamera(boost::shared_ptr< Camera > camera_to_add, int scene_id);
 
   /*! \brief adds a static target to job's list of static targets
    *  \param target_to_add this is the target added to the list
    *  \param scene_id the scene's id, only one target of given name exist in each scene
    *  \return true on success
    */
-  bool addMovingTarget(boost::shared_ptr<Target> target_to_add, int scene_id);
+  bool addMovingTarget(boost::shared_ptr< Target > target_to_add, int scene_id);
 
   /*! \brief grabs a camera from the camera list given the camera name
    *  \param camera_name is the name of the camera
    *  \param camera this is the camera from the list, either moving or static
    *  \return true on success
    */
-  const boost::shared_ptr<Camera> getCameraByName(const std::string &camera_name);
+  const boost::shared_ptr< Camera > getCameraByName(const std::string& camera_name);
 
   /*!
    * \brief grabs a target from the target list given the target name
@@ -88,9 +87,9 @@ public:
    * @param scene_id, when a target is moving, it has a separate object for each scene
    * @return shared pointer to target
    */
-  const boost::shared_ptr<Target>  getTargetByName(const std::string &target_name, int scene_id=0);
+  const boost::shared_ptr< Target > getTargetByName(const std::string& target_name, int scene_id = 0);
 
-  /*! @brief gets a pointer to the intrinsic parameters of a static camera 
+  /*! @brief gets a pointer to the intrinsic parameters of a static camera
    *  @param camera_name the camera's name
    */
   P_BLOCK getStaticCameraParameterBlockIntrinsics(std::string camera_name);
@@ -156,7 +155,7 @@ public:
    */
   P_BLOCK getMovingTargetPointParameterBlock(std::string target_name, int pnt_id);
 
-  /*! @brief writes a single launch file with all the static tranforms 
+  /*! @brief writes a single launch file with all the static tranforms
    *  @param filepath  the full path to the launch file being created
    */
   bool writeAllStaticTransforms(std::string filepath);
@@ -185,7 +184,7 @@ public:
   /*! @brief sends transform to the interface*/
   void pushTransforms();
 
-  /*! @brief gets transform from interface 
+  /*! @brief gets transform from interface
    *    @param scene_id the current scene's id. Pulls from all static cameras, static targets, and those from this scene
    */
   void pullTransforms(int scene_id);
@@ -194,33 +193,36 @@ public:
   void setReferenceFrame(std::string ref_frame);
 
   /*! @brief get reference frame name from the interface */
-  std::string getReferenceFrame(){ return(reference_frame_);};
+  std::string getReferenceFrame()
+  {
+    return (reference_frame_);
+  };
 
-  std::vector<boost::shared_ptr<Camera> > static_cameras_; /*!< all non-moving cameras in job */
-  std::vector<boost::shared_ptr<MovingCamera> > moving_cameras_; /*! only one camera of a given name per scene */
-  std::vector<boost::shared_ptr<Target> > static_targets_; /*!< all non-moving targets in job */
-  std::vector<boost::shared_ptr<MovingTarget> > moving_targets_; /*! only one target of a given name per scene */
+  std::vector< boost::shared_ptr< Camera > > static_cameras_;       /*!< all non-moving cameras in job */
+  std::vector< boost::shared_ptr< MovingCamera > > moving_cameras_; /*! only one camera of a given name per scene */
+  std::vector< boost::shared_ptr< Target > > static_targets_;       /*!< all non-moving targets in job */
+  std::vector< boost::shared_ptr< MovingTarget > > moving_targets_; /*! only one target of a given name per scene */
   std::string reference_frame_; /*! name of reference frame, typically a ROS tf frame */
 
-};//end class
+};  // end class
 
- // dangling debugging functions
-/*! @brief displays a pose from the extrinsic parameters 
+// dangling debugging functions
+/*! @brief displays a pose from the extrinsic parameters
  *   @param extrinsics an array of parameters representing the 6D pose
- *   @param message a string that describes the pose to be shown 
+ *   @param message a string that describes the pose to be shown
  */
- void  showPose(P_BLOCK extrinsics, std::string message);
-/*! @brief displays a pose 
+void showPose(P_BLOCK extrinsics, std::string message);
+/*! @brief displays a pose
  *   @param pose the 6D pose to be shown
- *   @param message a string that describes the pose to be shown 
+ *   @param message a string that describes the pose to be shown
  */
- void  showPose(Pose6d pose, std::string message);
+void showPose(Pose6d pose, std::string message);
 /*! @brief displays the intrinsic parameters
  *   @param intrinsics an array of parameters representing the focal length, optical center, and distortion parameters
  *   @param num_param, sometimes there is no distortion, so this is either 4 or 9 depending
  */
- void  showIntrinsics(P_BLOCK intrinsics, int num_param);
+void showIntrinsics(P_BLOCK intrinsics, int num_param);
 
-}// end namespace industrial_extrinsic_cal
+}  // end namespace industrial_extrinsic_cal
 
 #endif /* CERES_BLOCKS_H_ */

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/ceres_costs_utils.h
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/ceres_costs_utils.h
@@ -22,53 +22,55 @@
 #include <string>
 namespace industrial_extrinsic_cal
 {
-  // create an enumeration of all the cost functions
-  namespace cost_functions{
-    enum Cost_function{
-      CameraReprjErrorWithDistortion,
-      CameraReprjErrorWithDistortionPK,
-      CameraReprjError,
-      CameraReprjErrorPK,
-      TriangulationError,
-      TargetCameraReprjError,
-      TargetCameraReprjErrorPK,
-      LinkTargetCameraReprjError,
-      LinkTargetCameraReprjErrorPK,
-      PosedTargetCameraReprjErrorPK,
-      LinkCameraTargetReprjError,
-      LinkCameraTargetReprjErrorPK,
-      CircleCameraReprjErrorWithDistortion,
-      CircleCameraReprjErrorWithDistortionPK,
-      CircleCameraReprjError,
-      CircleCameraReprjErrorPK,
-      CircleTargetCameraReprjErrorWithDistortion,
-      CircleTargetCameraReprjErrorWithDistortionPK,
-      FixedCircleTargetCameraReprjErrorWithDistortionPK,
-      SimpleCircleTargetCameraReprjErrorWithDistortionPK,
-      CircleTargetCameraReprjError,
-      CircleTargetCameraReprjErrorPK,
-      LinkCircleTargetCameraReprjError,
-      LinkCircleTargetCameraReprjErrorPK,
-      LinkCameraCircleTargetReprjError,
-      LinkCameraCircleTargetReprjErrorPK,
-      FixedCircleTargetCameraReprjErrorPK,
-      NullCostType
-    };
-  }// end of namespace cost_functions
-  typedef cost_functions::Cost_function Cost_function;
+// create an enumeration of all the cost functions
+namespace cost_functions
+{
+enum Cost_function
+{
+  CameraReprjErrorWithDistortion,
+  CameraReprjErrorWithDistortionPK,
+  CameraReprjError,
+  CameraReprjErrorPK,
+  TriangulationError,
+  TargetCameraReprjError,
+  TargetCameraReprjErrorPK,
+  LinkTargetCameraReprjError,
+  LinkTargetCameraReprjErrorPK,
+  PosedTargetCameraReprjErrorPK,
+  LinkCameraTargetReprjError,
+  LinkCameraTargetReprjErrorPK,
+  CircleCameraReprjErrorWithDistortion,
+  CircleCameraReprjErrorWithDistortionPK,
+  CircleCameraReprjError,
+  CircleCameraReprjErrorPK,
+  CircleTargetCameraReprjErrorWithDistortion,
+  CircleTargetCameraReprjErrorWithDistortionPK,
+  FixedCircleTargetCameraReprjErrorWithDistortionPK,
+  SimpleCircleTargetCameraReprjErrorWithDistortionPK,
+  CircleTargetCameraReprjError,
+  CircleTargetCameraReprjErrorPK,
+  LinkCircleTargetCameraReprjError,
+  LinkCircleTargetCameraReprjErrorPK,
+  LinkCameraCircleTargetReprjError,
+  LinkCameraCircleTargetReprjErrorPK,
+  FixedCircleTargetCameraReprjErrorPK,
+  NullCostType
+};
+}  // end of namespace cost_functions
+typedef cost_functions::Cost_function Cost_function;
 
-  // prototypes of functions 
+// prototypes of functions
 
-  /*! @brief converts a string to a cost type 
-   *   @param cost_type_str The cost type string 
-   *   @returns The cost function type from the enumeration
-   */
-  Cost_function string2CostType(std::string &cost_type_str);
-  /*! @brief converts a cost type to a string
-   *   @param cost_type The cost type 
-   *   @returns The cost function type as a string
-   */
-  std::string costType2String(Cost_function cost_type);
+/*! @brief converts a string to a cost type
+ *   @param cost_type_str The cost type string
+ *   @returns The cost function type from the enumeration
+ */
+Cost_function string2CostType(std::string& cost_type_str);
+/*! @brief converts a cost type to a string
+ *   @param cost_type The cost type
+ *   @returns The cost function type as a string
+ */
+std::string costType2String(Cost_function cost_type);
 
-} // end of namespace industrial_extrinsic_cal
+}  // end of namespace industrial_extrinsic_cal
 #endif

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/ceres_costs_utils.hpp
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/ceres_costs_utils.hpp
@@ -26,2329 +26,2388 @@
 
 namespace industrial_extrinsic_cal
 {
+// HELPER TEMPLATES
 
+/*! \brief ceres compliant template to compute product of two rotations
+ *   @param R1 first rotation matrix in column major order
+ *   @param R1 second rotation matrix in column major order
+ *   @param R3 matrix product of R1*R2
+ */
+template < typename T >
+void rotationProduct(const T R1[9], const T R2[9], T R3[9]);
+template < typename T >
+inline void rotationProduct(const T R1[9], const T R2[9], T R3[9])
+{
+  // We assume that the rotation matrices are in column major order
+  // x column
+  R3[0] = R1[0] * R2[0] + R1[3] * R2[1] + R1[6] * R2[2];
+  R3[1] = R1[1] * R2[0] + R1[4] * R2[1] + R1[7] * R2[2];
+  R3[2] = R1[2] * R2[0] + R1[5] * R2[1] + R1[8] * R2[2];
+  // y column
+  R3[3] = R1[0] * R2[3] + R1[3] * R2[4] + R1[6] * R2[5];
+  R3[4] = R1[1] * R2[3] + R1[4] * R2[4] + R1[7] * R2[5];
+  R3[5] = R1[2] * R2[3] + R1[5] * R2[4] + R1[8] * R2[5];
+  // z column
+  R3[6] = R1[0] * R2[6] + R1[3] * R2[7] + R1[6] * R2[8];
+  R3[7] = R1[1] * R2[6] + R1[4] * R2[7] + R1[7] * R2[8];
+  R3[8] = R1[2] * R2[6] + R1[5] * R2[7] + R1[8] * R2[8];
+}
 
-  // HELPER TEMPLATES  
+/*! \brief ceres compliant template to extract the camera parameters from an ambigious vector of parameters
+ *   @param intrinsics[9] vector of parameters
+ *   @param fx focal length in x
+ *   @param fy focal length in y
+ *   @param cx optical center in x
+ *   @param cy optical center in y
+ *   @param k1 radial distortion coefficient k1
+ *   @param k2 radial distortion coefficient k2
+ *   @param k3 radial distortion coefficient k3
+ *   @param p1 tangential distortion coefficient p1
+ *   @param p2 tangential distortion coefficient p2
+ */
 
-  /*! \brief ceres compliant template to compute product of two rotations
-   *   @param R1 first rotation matrix in column major order
-   *   @param R1 second rotation matrix in column major order
-   *   @param R3 matrix product of R1*R2
-   */
-  template<typename T>  void rotationProduct(const T R1[9], const T R2[9], T R3[9]);
-  template<typename T> inline void rotationProduct(const T R1[9], const T R2[9], T R3[9])
+template < typename T >
+void extractCameraIntrinsics(const T intrinsics[9], T& fx, T& fy, T& cx, T& cy, T& k1, T& k2, T& k3, T& p1, T& p2);
+template < typename T >
+inline void extractCameraIntrinsics(const T intrinsics[9], T& fx, T& fy, T& cx, T& cy, T& k1, T& k2, T& k3, T& p1,
+                                    T& p2)
+{
+  fx = intrinsics[0]; /** focal length x */
+  fy = intrinsics[1]; /** focal length y */
+  cx = intrinsics[2]; /** central point x */
+  cy = intrinsics[3]; /** central point y */
+  k1 = intrinsics[4]; /** distortion k1  */
+  k2 = intrinsics[5]; /** distortion k2  */
+  k3 = intrinsics[6]; /** distortion k3  */
+  p1 = intrinsics[7]; /** distortion p1  */
+  p2 = intrinsics[8]; /** distortion p2  */
+}
+
+/*! \brief ceres compliant template to extract the camera parameters from an ambigious vector of parameters without
+ * distortion
+ *   @param intrinsics[9] vector of parameters
+ *   @param fx focal length in x
+ *   @param fy focal length in y
+ *   @param cx optical center in x
+ *   @param cy optical center in y
+ */
+
+template < typename T >
+void extractCameraIntrinsics(const T intrinsics[4], T& fx, T& fy, T& cx, T& cy);
+template < typename T >
+inline void extractCameraIntrinsics(const T intrinsics[4], T& fx, T& fy, T& cx, T& cy)
+{
+  fx = intrinsics[0]; /** focal length x */
+  fy = intrinsics[1]; /** focal length y */
+  cx = intrinsics[2]; /** central point x */
+  cy = intrinsics[3]; /** central point y */
+}
+
+/*! \brief ceres compliant template to extract the camera pose from an ambigious vector of parameters
+ *   @param extrinsics[9] vector of parameters
+ *   @param tx, position x
+ *   @param ty, position y
+ *   @param tz, position z
+ *   @param ax, angle axis x
+ *   @param ay, angle axis y
+ *   @param az, angle axis z
+ */
+template < typename T >
+void extractCameraExtrinsics(const T extrinsics[6], T& x, T& y, T& z, T& ax, T& ay, T& az);
+template < typename T >
+inline void extractCameraExtrinsics(const T extrinsics[6], T& x, T& y, T& z, T& ax, T& ay, T& az)
+{
+  ax = extrinsics[0]; /** angle axis x */
+  ay = extrinsics[1]; /** angle axis y */
+  az = extrinsics[2]; /** angle axis z */
+  x = extrinsics[3];  /** position x */
+  y = extrinsics[4];  /** position y */
+  z = extrinsics[5];  /** position z */
+}
+
+/*! \brief ceres compliant to compute inverse of a rotation matrix
+ *  @param R the input rotation
+ *  @param RI the output inverse rotation
+ */
+
+template < typename T >
+void rotationInverse(const T R[9], const T RI[9]);
+template < typename T >
+inline void rotationInverse(const T R[9], T RI[9])
+{
+  RI[0] = R[0];
+  RI[3] = R[1];
+  RI[6] = R[2];
+  RI[1] = R[3];
+  RI[4] = R[4];
+  RI[7] = R[5];
+  RI[2] = R[6];
+  RI[5] = R[7];
+  RI[8] = R[8];
+}
+
+/*! \brief ceres compliant function to apply an angle-axis and translation to transform a point
+ *  @param angle_axis, ax, ay, and az
+ *  @param tx translation tx, ty and tz
+ *  @param point the original point
+ *  @param t_point the transformed point
+ */
+
+template < typename T >
+inline void transformPoint(const T angle_axis[3], const T tx[3], const T point[3], T t_point[3]);
+template < typename T >
+inline void transformPoint(const T angle_axis[3], const T tx[3], const T point[3], T t_point[3])
+{
+  ceres::AngleAxisRotatePoint(angle_axis, point, t_point);
+  t_point[0] = t_point[0] + tx[0];
+  t_point[1] = t_point[1] + tx[1];
+  t_point[2] = t_point[2] + tx[2];
+}
+
+/*! \brief ceres compliant function to apply a pose to transform a point
+ *  @param pose, contains both rotation and translation in a structure
+ *  @param point the original point
+ *  @param t_point the transformed point
+ */
+
+template < typename T >
+inline void poseTransformPoint(const Pose6d& pose, const T point[3], T t_point[3]);
+template < typename T >
+inline void poseTransformPoint(const Pose6d& pose, const T point[3], T t_point[3])
+{
+  T angle_axis[3];
+  angle_axis[0] = T(pose.ax);
+  angle_axis[1] = T(pose.ay);
+  angle_axis[2] = T(pose.az);
+  ceres::AngleAxisRotatePoint(angle_axis, point, t_point);
+  t_point[0] = t_point[0] + T(pose.x);
+  t_point[1] = t_point[1] + T(pose.y);
+  t_point[2] = t_point[2] + T(pose.z);
+}
+
+/*! \brief ceres compliant function to apply an angle-axis and translation to transform a point in Point3d form
+ *  @param angle_axis, ax, ay, and az
+ *  @param tx translation tx, ty and tz
+ *  @param point the original point in a Point3d form
+ *  @param t_point the transformed point
+ */
+template < typename T >
+void transformPoint3d(const T angle_axis[3], const T tx[3], const Point3d& point, T t_point[3]);
+template < typename T >
+inline void transformPoint3d(const T angle_axis[3], const T tx[3], const Point3d& point, T t_point[3])
+{
+  T point_[3];
+  point_[0] = T(point.x);
+  point_[1] = T(point.y);
+  point_[2] = T(point.z);
+  ceres::AngleAxisRotatePoint(angle_axis, point_, t_point);
+  t_point[0] = t_point[0] + tx[0];
+  t_point[1] = t_point[1] + tx[1];
+  t_point[2] = t_point[2] + tx[2];
+}
+
+/*! \brief ceres compliant function get a templated rotation from a Pose6d structure
+ *  @param pose the input pose
+ *  @param pose the output rotatation matrix
+ */
+template < typename T >
+void poseRotationMatrix(const Pose6d& pose, T R[9]);
+template < typename T >
+inline void poseRotationMatrix(const Pose6d& pose, T R[9])
+{
+  T angle_axis[3];
+  angle_axis[0] = T(pose.ax);
+  angle_axis[1] = T(pose.ay);
+  angle_axis[2] = T(pose.az);
+  ceres::AngleAxisToRotationMatrix(angle_axis, R);
+}
+
+/*! \brief ceres compliant function to compute the residual from a distorted pinhole camera model
+ *  @param point[3] the input point
+ *  @param k1 radial distortion parameter k1
+ *  @param k2 radial distortion parameter k2
+ *  @param k3 radial distortion parameter k3
+ *  @param p1 tangential distortion parameter p1
+ *  @param p2 tangential distortion parameter p2
+ *  @param fx focal length in x
+ *  @param fy focal length in y
+ *  @param cx optical center in x
+ *  @param cy optical center in y
+ *  @param ox observation in x
+ *  @param oy observation in y
+ *  @param residual the output or difference between where the point should appear given the parameters, and where it
+ * was observed
+ */
+template < typename T >
+void cameraPntResidualDist(T point[3], T& k1, T& k2, T& k3, T& p1, T& p2, T& fx, T& fy, T& cx, T& cy, T& ox, T& oy,
+                           T residual[2]);
+template < typename T >
+inline void cameraPntResidualDist(T point[3], T& k1, T& k2, T& k3, T& p1, T& p2, T& fx, T& fy, T& cx, T& cy, T& ox,
+                                  T& oy, T residual[2])
+{
+  T xp1 = point[0];
+  T yp1 = point[1];
+  T zp1 = point[2];
+
+  /** scale into the image plane by distance away from camera */
+  T xp;
+  T yp;
+  if (zp1 == T(0))
+  {  // avoid divide by zero
+    xp = xp1;
+    yp = yp1;
+  }
+  else
   {
-    // We assume that the rotation matrices are in column major order
-    // x column
-    R3[0] = R1[0]*R2[0] +  R1[3]*R2[1] +  R1[6]*R2[2];
-    R3[1] = R1[1]*R2[0] +  R1[4]*R2[1] +  R1[7]*R2[2];
-    R3[2] = R1[2]*R2[0] +  R1[5]*R2[1] +  R1[8]*R2[2];
-    // y column
-    R3[3] = R1[0]*R2[3] +  R1[3]*R2[4] +  R1[6]*R2[5];
-    R3[4] = R1[1]*R2[3] +  R1[4]*R2[4] +  R1[7]*R2[5];
-    R3[5] = R1[2]*R2[3] +  R1[5]*R2[4] +  R1[8]*R2[5];
-    // z column
-    R3[6] = R1[0]*R2[6] +  R1[3]*R2[7] +  R1[6]*R2[8];
-    R3[7] = R1[1]*R2[6] +  R1[4]*R2[7] +  R1[7]*R2[8];
-    R3[8] = R1[2]*R2[6] +  R1[5]*R2[7] +  R1[8]*R2[8];
+    xp = xp1 / zp1;
+    yp = yp1 / zp1;
   }
 
+  /* temporary variables for distortion model */
+  T xp2 = xp * xp;  /* x^2 */
+  T yp2 = yp * yp;  /* y^2 */
+  T r2 = xp2 + yp2; /* r^2 radius squared */
+  T r4 = r2 * r2;   /* r^4 */
+  T r6 = r2 * r4;   /* r^6 */
 
-  /*! \brief ceres compliant template to extract the camera parameters from an ambigious vector of parameters
-   *   @param intrinsics[9] vector of parameters
-   *   @param fx focal length in x
-   *   @param fy focal length in y
-   *   @param cx optical center in x
-   *   @param cy optical center in y
-   *   @param k1 radial distortion coefficient k1
-   *   @param k2 radial distortion coefficient k2
-   *   @param k3 radial distortion coefficient k3
-   *   @param p1 tangential distortion coefficient p1
-   *   @param p2 tangential distortion coefficient p2
-   */
+  /* apply the distortion coefficients to refine pixel location */
+  T xpp = xp + k1 * r2 * xp           // 2nd order term
+          + k2 * r4 * xp              // 4th order term
+          + k3 * r6 * xp              // 6th order term
+          + p2 * (r2 + T(2.0) * xp2)  // tangential
+          + p1 * xp * yp * T(2.0);    // other tangential term
+  T ypp = yp + k1 * r2 * yp           // 2nd order term
+          + k2 * r4 * yp              // 4th order term
+          + k3 * r6 * yp              // 6th order term
+          + p1 * (r2 + T(2.0) * yp2)  // tangential term
+          + p2 * xp * yp * T(2.0);    // other tangential term
 
-  template<typename T>  void extractCameraIntrinsics(const T intrinsics[9], T &fx, T &fy, T &cx, T &cy, T &k1, T &k2, T &k3, T &p1, T &p2);
-  template<typename T> inline void extractCameraIntrinsics(const T intrinsics[9], T &fx, T &fy, T &cx, T &cy, T &k1, T &k2, T &k3, T &p1, T &p2)
+  /** perform projection using focal length and camera center into image plane */
+  residual[0] = fx * xpp + cx - ox;
+  residual[1] = fy * ypp + cy - oy;
+}
+
+/*! \brief ceres compliant function to compute projection of a point into the image plane of a pinhole camera without
+ * distortion
+ *  @param point[3] the input point
+ *  @param fx focal length in x
+ *  @param fy focal length in y
+ *  @param cx optical center in x
+ *  @param cy optical center in y
+ *  @param ox observation in x
+ *  @param oy observation in y
+ */
+template < typename T >
+void projectPntNoDistortion(T point[3], T& fx, T& fy, T& cx, T& cy, T& ox, T& oy);
+template < typename T >
+inline void projectPntNoDistortion(T point[3], T& fx, T& fy, T& cx, T& cy, T& ox, T& oy)
+{
+  T xp1 = point[0];
+  T yp1 = point[1];
+  T zp1 = point[2];
+
+  /** scale into the image plane by distance away from camera */
+  T xp;
+  T yp;
+  if (zp1 == T(0))
+  {  // avoid divide by zero
+    xp = xp1;
+    yp = yp1;
+  }
+  else
   {
-    fx  = intrinsics[0]; /** focal length x */
-    fy  = intrinsics[1]; /** focal length y */
-    cx  = intrinsics[2]; /** central point x */
-    cy  = intrinsics[3]; /** central point y */
-    k1  = intrinsics[4]; /** distortion k1  */
-    k2  = intrinsics[5]; /** distortion k2  */
-    k3  = intrinsics[6]; /** distortion k3  */
-    p1  = intrinsics[7]; /** distortion p1  */
-    p2  = intrinsics[8]; /** distortion p2  */
+    xp = xp1 / zp1;
+    yp = yp1 / zp1;
   }
 
-  /*! \brief ceres compliant template to extract the camera parameters from an ambigious vector of parameters without distortion
-   *   @param intrinsics[9] vector of parameters
-   *   @param fx focal length in x
-   *   @param fy focal length in y
-   *   @param cx optical center in x
-   *   @param cy optical center in y
-   */
+  /** perform projection using focal length and camera center into image plane */
+  ox = fx * xp + cx;
+  oy = fy * yp + cy;
+}
 
-  template<typename T>  void extractCameraIntrinsics(const T intrinsics[4], T &fx, T &fy, T &cx, T &cy);
-  template<typename T> inline void extractCameraIntrinsics(const T intrinsics[4], T &fx, T &fy, T &cx, T &cy)
+/*! \brief ceres compliant function to compute the residual from a distorted pinhole camera model, in this case,
+ *   the point is actually a planar circle with some diameter. There observation is not the projected center,
+ *   but is offset due to the angle between the plane and the imaging plane
+ *  @param point[3] the input point
+ *  @param circle_diameter the diameter of the circle being observed
+ *  @param k1 radial distortion parameter k1
+ *  @param k2 radial distortion parameter k2
+ *  @param k3 radial distortion parameter k3
+ *  @param p1 tangential distortion parameter p1
+ *  @param p2 tangential distortion parameter p2
+ *  @param fx focal length in x
+ *  @param fy focal length in y
+ *  @param cx optical center in x
+ *  @param cy optical center in y
+ *  @param ox observation in x
+ *  @param oy observation in y
+ *  @param residual the output or difference between where the point should appear given the parameters, and where it
+ * was observed
+ */
+template < typename T >
+void cameraCircResidualDist(T point[3], T& circle_diameter, T R_TtoC[9], T& k1, T& k2, T& k3, T& p1, T& p2, T& fx,
+                            T& fy, T& cx, T& cy, T& ox, T& oy, T residual[2]);
+template < typename T >
+inline void cameraCircResidualDist(T point[3], T& circle_diameter, T R_TtoC[9], T& k1, T& k2, T& k3, T& p1, T& p2,
+                                   T& fx, T& fy, T& cx, T& cy, T& ox, T& oy, T residual[2])
+{
+  T xp1 = point[0];
+  T yp1 = point[1];
+  T zp1 = point[2];
+
+  // Circle Delta is the difference between the projection of the center of the circle
+  // and the center of the projected ellipse
+
+  // The 3 columns of R_TtoC represent:
+  // 1. the x-axis of the target in camera coordinates
+  // 2. the y-axis of the target in camera coordinates
+  // 3. the z-axis (normal of the target plane) in camera coordinates
+  // NOTE: we assume target is an XY planar target (all points on target have nominal z=0)
+
+  // Find projection of distance vector D = [xp1 yp1 zp1] on to plane of target
+  T D_targetx = xp1 * R_TtoC[0] + yp1 * R_TtoC[1] + zp1 * R_TtoC[2];
+  T D_targety = xp1 * R_TtoC[3] + yp1 * R_TtoC[4] + zp1 * R_TtoC[5];
+
+  // projection of D onto target xy plane expressed in camera frame is given by
+  // D_targetx * R_TtoC(1stcol) + D_targety * R_TtoC(2ndcol)
+
+  // The vector of interest "Vperp" is orthogonal to this in the target xy plane
+  // Vperp = -D_targety * R_TtoC(1stcol) + D_targetx * R_TtoC(2ndcol)
+  // However we want Vperp to be in the direction with a negative z component
+
+  T Vperp[3];
+  Vperp[0] = -D_targety * R_TtoC[0] + D_targetx * R_TtoC[3];
+  Vperp[1] = -D_targety * R_TtoC[1] + D_targetx * R_TtoC[4];
+  Vperp[2] = -D_targety * R_TtoC[2] + D_targetx * R_TtoC[5];
+
+  // Vector direction of Vperp is arbitrary, but need to specify direction closer to camera
+  T mysign;
+  if (Vperp[2] * Vperp[2] > T(0.0))
   {
-    fx  = intrinsics[0]; /** focal length x */
-    fy  = intrinsics[1]; /** focal length y */
-    cx  = intrinsics[2]; /** central point x */
-    cy  = intrinsics[3]; /** central point y */
+    mysign = -abs(Vperp[2]) / Vperp[2];
   }
-
-
-  /*! \brief ceres compliant template to extract the camera pose from an ambigious vector of parameters
-   *   @param extrinsics[9] vector of parameters
-   *   @param tx, position x
-   *   @param ty, position y
-   *   @param tz, position z
-   *   @param ax, angle axis x
-   *   @param ay, angle axis y
-   *   @param az, angle axis z
-   */
-  template<typename T>  void extractCameraExtrinsics(const T extrinsics[6], T &x, T &y, T &z, T &ax, T &ay, T &az);
-  template<typename T> inline void extractCameraExtrinsics(const T extrinsics[6], T &x, T &y, T &z, T &ax, T &ay, T &az)
+  else
   {
-    ax  = extrinsics[0]; /** angle axis x */
-    ay  = extrinsics[1]; /** angle axis y */
-    az  = extrinsics[2]; /** angle axis z */
-    x  = extrinsics[3]; /** position x */
-    y  = extrinsics[4]; /** position y */
-    z  = extrinsics[5]; /** position z */
+    mysign = T(1);
   }
+  Vperp[0] = mysign * Vperp[0];
+  Vperp[1] = mysign * Vperp[1];
+  Vperp[2] = mysign * Vperp[2];
 
-  /*! \brief ceres compliant to compute inverse of a rotation matrix
-   *  @param R the input rotation
-   *  @param RI the output inverse rotation
-   */
+  /** scale into the image plane by distance away from camera */
+  T xp = xp1 / zp1;
+  T yp = yp1 / zp1;
 
-  template<typename T>  void rotationInverse(const T R[9], const T RI[9]);
-  template<typename T> inline void rotationInverse(const T R[9], T RI[9])
-  {
-    RI[0] = R[0]; RI[3] = R[1];  RI[6] = R[2];
-    RI[1] = R[3]; RI[4] = R[4];  RI[7] = R[5];
-    RI[2] = R[6]; RI[5] = R[7];  RI[8] = R[8];
-  }
-
-  /*! \brief ceres compliant function to apply an angle-axis and translation to transform a point
-   *  @param angle_axis, ax, ay, and az
-   *  @param tx translation tx, ty and tz
-   *  @param point the original point
-   *  @param t_point the transformed point
-   */
-
-  template<typename T> inline void transformPoint(const T angle_axis[3], const T tx[3], const T point[3], T t_point[3]);
-  template<typename T> inline void transformPoint(const T angle_axis[3], const T tx[3], const T point[3], T t_point[3])
-  {
-    ceres::AngleAxisRotatePoint(angle_axis, point, t_point);
-    t_point[0] = t_point[0] + tx[0];
-    t_point[1] = t_point[1] + tx[1];
-    t_point[2] = t_point[2] + tx[2];
-  }
-
-  /*! \brief ceres compliant function to apply a pose to transform a point
-   *  @param pose, contains both rotation and translation in a structure
-   *  @param point the original point
-   *  @param t_point the transformed point
-   */
-
-  template<typename T> inline void poseTransformPoint(const Pose6d &pose, const T point[3], T t_point[3]);
-  template<typename T> inline void poseTransformPoint(const Pose6d &pose, const T point[3], T t_point[3])
-  {
-    T angle_axis[3];
-    angle_axis[0]  = T(pose.ax);
-    angle_axis[1]  = T(pose.ay);
-    angle_axis[2]  = T(pose.az);
-    ceres::AngleAxisRotatePoint(angle_axis, point, t_point);
-    t_point[0] = t_point[0] + T(pose.x);
-    t_point[1] = t_point[1] + T(pose.y);
-    t_point[2] = t_point[2] + T(pose.z);
-  }
-
-
-  /*! \brief ceres compliant function to apply an angle-axis and translation to transform a point in Point3d form
-   *  @param angle_axis, ax, ay, and az
-   *  @param tx translation tx, ty and tz
-   *  @param point the original point in a Point3d form
-   *  @param t_point the transformed point
-   */
-  template<typename T>  void transformPoint3d(const T angle_axis[3], const T tx[3], const Point3d &point, T t_point[3]);
-  template<typename T> inline void transformPoint3d(const T angle_axis[3], const T tx[3], const Point3d &point, T t_point[3])
-  {
-    T point_[3];
-    point_[0] = T(point.x);
-    point_[1] = T(point.y);
-    point_[2] = T(point.z);
-    ceres::AngleAxisRotatePoint(angle_axis, point_, t_point);
-    t_point[0] = t_point[0] + tx[0];
-    t_point[1] = t_point[1] + tx[1];
-    t_point[2] = t_point[2] + tx[2];
-  }
-
-  /*! \brief ceres compliant function get a templated rotation from a Pose6d structure
-   *  @param pose the input pose
-   *  @param pose the output rotatation matrix
-   */
-  template<typename T>  void poseRotationMatrix(const Pose6d &pose, T R[9]);
-  template<typename T> inline void poseRotationMatrix(const Pose6d &pose, T R[9])
-  {
-    T angle_axis[3];
-    angle_axis[0] = T(pose.ax);
-    angle_axis[1] = T(pose.ay);
-    angle_axis[2] = T(pose.az);
-    ceres::AngleAxisToRotationMatrix(angle_axis, R);
-  }
-  
-  /*! \brief ceres compliant function to compute the residual from a distorted pinhole camera model
-   *  @param point[3] the input point
-   *  @param k1 radial distortion parameter k1
-   *  @param k2 radial distortion parameter k2
-   *  @param k3 radial distortion parameter k3
-   *  @param p1 tangential distortion parameter p1
-   *  @param p2 tangential distortion parameter p2
-   *  @param fx focal length in x
-   *  @param fy focal length in y
-   *  @param cx optical center in x
-   *  @param cy optical center in y
-   *  @param ox observation in x
-   *  @param oy observation in y
-   *  @param residual the output or difference between where the point should appear given the parameters, and where it was observed
-   */
-  template<typename T>  void cameraPntResidualDist(T point[3], T &k1, T &k2, T &k3, T &p1, T &p2, T &fx, T &fy, T &cx, T &cy, T &ox, T &oy, T residual[2]);
-  template<typename T> inline void cameraPntResidualDist(T point[3], T &k1, T &k2, T &k3, T &p1, T &p2, T &fx, T &fy, T &cx, T &cy, T &ox, T &oy, T residual[2])
-  {
-    T xp1 = point[0];
-    T yp1 = point[1];
-    T zp1 = point[2];
-
-    /** scale into the image plane by distance away from camera */
-    T xp;
-    T yp;
-    if(zp1==T(0)){ // avoid divide by zero
-      xp =xp1;
-      yp =yp1;
+  if (zp1 + Vperp[2] != 0.0)
+  {  // adjust only focal plan not parallel to target's xy plane
+    T Vpx = (xp1 + Vperp[0]) / (zp1 + Vperp[2]);
+    T Vpy = (yp1 + Vperp[1]) / (zp1 + Vperp[2]);
+    T Vnorm = sqrt(Vpx * Vpx + Vpy * Vpy);
+    if (Vnorm != 0.0)
+    {
+      // find scale of motion
+      // Delta = (r*sin(theta)/(D-rcos(theta)) - r*sin(theta)/(D+rcos(theta)))/2
+      // where r is the radius of the circle being projected
+      //       D is the distance between camera and circle center
+      //       theta is the angle between D vector an target xy plane
+      Vpx = Vpx / Vnorm;
+      Vpy = Vpy / Vnorm;
+      T D = sqrt(xp1 * xp1 + yp1 * yp1 + zp1 * zp1);
+      T s_theta = (R_TtoC[6] * xp1 + R_TtoC[7] * yp1 + R_TtoC[8] * zp1) / D;
+      T c_theta = sqrt(T(1.0) - s_theta * s_theta);
+      T r = T(circle_diameter / 2.0);
+      T Delta = r * s_theta * (T(1.0) / (D - r * c_theta) - T(1.0) / (D + r * c_theta)) / T(2.0);
+      xp = xp + Delta * Vpx;
+      yp = yp + Delta * Vpy;
     }
-    else{
-      xp = xp1 / zp1;
-      yp = yp1 / zp1;
-    }
-
-    /* temporary variables for distortion model */
-    T xp2 = xp * xp;		/* x^2 */
-    T yp2 = yp * yp;		/* y^2 */
-    T r2  = xp2 + yp2;	/* r^2 radius squared */
-    T r4  = r2 * r2;		/* r^4 */
-    T r6  = r2 * r4;		/* r^6 */
-    
-    /* apply the distortion coefficients to refine pixel location */
-    T xpp = xp 
-      + k1 * r2 * xp		// 2nd order term
-      + k2 * r4 * xp		// 4th order term
-      + k3 * r6 * xp		// 6th order term
-      + p2 * (r2 + T(2.0) * xp2) // tangential
-      + p1 * xp * yp * T(2.0); // other tangential term
-    T ypp = yp 
-      + k1 * r2 * yp		// 2nd order term
-      + k2 * r4 * yp		// 4th order term
-      + k3 * r6 * yp		// 6th order term
-      + p1 * (r2 + T(2.0) * yp2) // tangential term
-      + p2 * xp * yp * T(2.0); // other tangential term
-    
-    /** perform projection using focal length and camera center into image plane */
-    residual[0] = fx * xpp + cx - ox;
-    residual[1] = fy * ypp + cy - oy;
-
   }
 
-  /*! \brief ceres compliant function to compute projection of a point into the image plane of a pinhole camera without distortion
-   *  @param point[3] the input point
-   *  @param fx focal length in x
-   *  @param fy focal length in y
-   *  @param cx optical center in x
-   *  @param cy optical center in y
-   *  @param ox observation in x
-   *  @param oy observation in y
-   */
-  template<typename T> void projectPntNoDistortion(T point[3], T &fx, T &fy, T &cx, T &cy, T &ox, T &oy);
-  template<typename T> inline void projectPntNoDistortion(T point[3], T &fx, T &fy, T &cx, T &cy, T &ox, T &oy)
+  /* temporary variables for distortion model */
+  T xp2 = xp * xp;  /* x^2 */
+  T yp2 = yp * yp;  /* y^2 */
+  T r2 = xp2 + yp2; /* r^2 radius squared */
+  T r4 = r2 * r2;   /* r^4 */
+  T r6 = r2 * r4;   /* r^6 */
+
+  /* apply the distortion coefficients to refine pixel location */
+  T xpp = xp + k1 * r2 * xp           // 2nd order term
+          + k2 * r4 * xp              // 4th order term
+          + k3 * r6 * xp              // 6th order term
+          + p2 * (r2 + T(2.0) * xp2)  // tangential
+          + p1 * xp * yp * T(2.0);    // other tangential term
+  T ypp = yp + k1 * r2 * yp           // 2nd order term
+          + k2 * r4 * yp              // 4th order term
+          + k3 * r6 * yp              // 6th order term
+          + p1 * (r2 + T(2.0) * yp2)  // tangential term
+          + p2 * xp * yp * T(2.0);    // other tangential term
+
+  /** perform projection using focal length and camera center into image plane */
+  residual[0] = fx * xpp + cx - ox;
+  residual[1] = fy * ypp + cy - oy;
+}
+
+/*! \brief ceres compliant function to compute the residual from a pinhole camera model without distortion, in this
+ * case,
+ *   the point is actually a planar circle with some diameter. There observation is not the projected center,
+ *   but is offset due to the angle between the plane and the imaging plane
+ *  @param point[3] the input point
+ *  @param circle_diameter the diameter of the circle being observed
+ *  @param fx focal length in x
+ *  @param fy focal length in y
+ *  @param cx optical center in x
+ *  @param cy optical center in y
+ *  @param ox observation in x
+ *  @param oy observation in y
+ *  @param residual the output or difference between where the point should appear given the parameters, and where it
+ * was observed
+ */
+template < typename T >
+void cameraCircResidual(T point[3], T& circle_diameter, T R_TtoC[9], T& fx, T& fy, T& cx, T& cy, T& ox, T& oy,
+                        T residual[2]);
+template < typename T >
+inline void cameraCircResidual(T point[3], T& circle_diameter, T R_TtoC[9], T& fx, T& fy, T& cx, T& cy, T& ox, T& oy,
+                               T residual[2])
+{
+  T xp1 = point[0];
+  T yp1 = point[1];
+  T zp1 = point[2];
+
+  // Circle Delta is the difference between the projection of the center of the circle
+  // and the center of the projected ellipse
+
+  // find rotation from target coordinates into camera coordinates
+  // The 3 columns represent:
+  // 1. the x-axis of the target in camera coordinates
+  // 2. the y-axis of the target in camera coordinates
+  // 3. the z-axis (normal of the target plane) in camera coordinates
+  // NOTE: we assume target is an XY planar target (all points on target have nominal z=0)
+
+  // Find projection of distance vector D = [xp1 yp1 zp1] on to plane of target
+  T D_targetx = xp1 * R_TtoC[0] + yp1 * R_TtoC[1] + zp1 * R_TtoC[2];
+  T D_targety = xp1 * R_TtoC[3] + yp1 * R_TtoC[4] + zp1 * R_TtoC[5];
+
+  // projection of D onto target xy plane expressed in camera frame is given by
+  // D_targetx * R_TtoC(1stcol) + D_targety * R_TtoC(2ndcol)
+
+  // The vector of interest "Vperp" is orthogonal to this in the target xy plane
+  // Vperp = -D_targety * R_TtoC(1stcol) + D_targetx * R_TtoC(2ndcol)
+  // However we want Vperp to be in the direction with a negative z component
+
+  T Vperp[3];
+  Vperp[0] = -D_targety * R_TtoC[0] + D_targetx * R_TtoC[3];
+  Vperp[1] = -D_targety * R_TtoC[1] + D_targetx * R_TtoC[4];
+  Vperp[2] = -D_targety * R_TtoC[2] + D_targetx * R_TtoC[5];
+
+  // Vector direction of Vperp is arbitrary, but need to specify direction closer to camera
+  T mysign;
+  if (Vperp[2] * Vperp[2] > T(0.0))
   {
-    T xp1 = point[0];
-    T yp1 = point[1];
-    T zp1 = point[2];
+    mysign = -abs(Vperp[2]) / Vperp[2];
+  }
+  else
+  {
+    mysign = T(1);
+  }
+  Vperp[0] = mysign * Vperp[0];
+  Vperp[1] = mysign * Vperp[1];
+  Vperp[2] = mysign * Vperp[2];
 
-    /** scale into the image plane by distance away from camera */
-    T xp;
-    T yp;
-    if(zp1==T(0)){ // avoid divide by zero
-      xp =xp1;
-      yp =yp1;
-    }
-    else{
-      xp = xp1 / zp1;
-      yp = yp1 / zp1;
-    }
+  /** scale into the image plane by distance away from camera */
+  T xp = xp1 / zp1;
+  T yp = yp1 / zp1;
 
-    /** perform projection using focal length and camera center into image plane */
-    ox = fx * xp + cx;
-    oy = fy * yp + cy;
+  if (zp1 + Vperp[2] != 0.0)
+  {  // adjust only focal plan not parallel to target's xy plane
+    T Vpx = (xp1 + Vperp[0]) / (zp1 + Vperp[2]);
+    T Vpy = (yp1 + Vperp[1]) / (zp1 + Vperp[2]);
+    T Vnorm = sqrt(Vpx * Vpx + Vpy * Vpy);
+    if (Vnorm != 0.0)
+    {
+      // find scale of motion
+      // Delta = (r*sin(theta)/(D-rcos(theta)) - r*sin(theta)/(D+rcos(theta)))/2
+      // where r is the radius of the circle being projected
+      //       D is the distance between camera and circle center
+      //       theta is the angle between D vector an target xy plane
+      Vpx = Vpx / Vnorm;
+      Vpy = Vpy / Vnorm;
+      T D = sqrt(xp1 * xp1 + yp1 * yp1 + zp1 * zp1);
+      T s_theta = (R_TtoC[6] * xp1 + R_TtoC[7] * yp1 + R_TtoC[8] * zp1) / D;
+      T c_theta = sqrt(T(1.0) - s_theta * s_theta);
+      T r = T(circle_diameter / 2.0);
+      T Delta = r * s_theta * (T(1.0) / (D - r * c_theta) - T(1.0) / (D + r * c_theta)) / T(2.0);
+      xp = xp + Delta * Vpx;
+      yp = yp + Delta * Vpy;
+    }
   }
 
-  /*! \brief ceres compliant function to compute the residual from a distorted pinhole camera model, in this case,
-   *   the point is actually a planar circle with some diameter. There observation is not the projected center,
-   *   but is offset due to the angle between the plane and the imaging plane
-   *  @param point[3] the input point
-   *  @param circle_diameter the diameter of the circle being observed
-   *  @param k1 radial distortion parameter k1
-   *  @param k2 radial distortion parameter k2
-   *  @param k3 radial distortion parameter k3
-   *  @param p1 tangential distortion parameter p1
-   *  @param p2 tangential distortion parameter p2
-   *  @param fx focal length in x
-   *  @param fy focal length in y
-   *  @param cx optical center in x
-   *  @param cy optical center in y
-   *  @param ox observation in x
-   *  @param oy observation in y
-   *  @param residual the output or difference between where the point should appear given the parameters, and where it was observed
-   */
-  template<typename T>  void cameraCircResidualDist(T point[3], T &circle_diameter, T R_TtoC[9], 
-							  T &k1, T &k2, T &k3, T &p1, T &p2, 
-							  T &fx, T &fy, T &cx, T &cy, T &ox, T &oy, T residual[2]);
-  template<typename T> inline void cameraCircResidualDist(T point[3], T &circle_diameter, T R_TtoC[9],
-							  T &k1, T &k2, T &k3, T &p1, T &p2, 
-							  T &fx, T &fy, T &cx, T &cy, T &ox, T &oy, T residual[2])
-  {
-    T xp1 = point[0];
-    T yp1 = point[1];
-    T zp1 = point[2];
-    
-    // Circle Delta is the difference between the projection of the center of the circle
-    // and the center of the projected ellipse 
+  /** perform projection using focal length and camera center into image plane */
+  residual[0] = fx * xp + cx - ox;
+  residual[1] = fy * yp + cy - oy;
+}
 
-    // The 3 columns of R_TtoC represent:
-    // 1. the x-axis of the target in camera coordinates
-    // 2. the y-axis of the target in camera coordinates
-    // 3. the z-axis (normal of the target plane) in camera coordinates
-    // NOTE: we assume target is an XY planar target (all points on target have nominal z=0)
-    
-    // Find projection of distance vector D = [xp1 yp1 zp1] on to plane of target
-    T D_targetx = xp1*R_TtoC[0] + yp1*R_TtoC[1] + zp1*R_TtoC[2];
-    T D_targety = xp1*R_TtoC[3] + yp1*R_TtoC[4] + zp1*R_TtoC[5];
-    
-    // projection of D onto target xy plane expressed in camera frame is given by 
-    // D_targetx * R_TtoC(1stcol) + D_targety * R_TtoC(2ndcol)
-    
-    // The vector of interest "Vperp" is orthogonal to this in the target xy plane
-    // Vperp = -D_targety * R_TtoC(1stcol) + D_targetx * R_TtoC(2ndcol)
-    // However we want Vperp to be in the direction with a negative z component
-    
-    T Vperp[3]; 
-    Vperp[0] = -D_targety*R_TtoC[0] + D_targetx*R_TtoC[3] ;
-    Vperp[1] = -D_targety*R_TtoC[1] + D_targetx*R_TtoC[4] ;
-    Vperp[2] = -D_targety*R_TtoC[2] + D_targetx*R_TtoC[5] ;
-    
-    // Vector direction of Vperp is arbitrary, but need to specify direction closer to camera
-    T mysign;
-    if(Vperp[2]*Vperp[2] > T(0.0)){
-      mysign = -abs(Vperp[2])/Vperp[2]; 
-    }
-    else{
-      mysign = T(1);
-    }
-    Vperp[0] = mysign*Vperp[0];
-    Vperp[1] = mysign*Vperp[1];
-    Vperp[2] = mysign*Vperp[2];
-        
-    /** scale into the image plane by distance away from camera */
-    T xp = xp1 / zp1;
-    T yp = yp1 / zp1;
-    
-    if(zp1+Vperp[2] !=0.0){	// adjust only focal plan not parallel to target's xy plane
-      T Vpx = (xp1+Vperp[0])/(zp1+Vperp[2]);
-      T Vpy = (yp1+Vperp[1])/(zp1+Vperp[2]);
-      T Vnorm = sqrt(Vpx*Vpx+Vpy*Vpy);
-      if(Vnorm!=0.0){
-	// find scale of motion
-	// Delta = (r*sin(theta)/(D-rcos(theta)) - r*sin(theta)/(D+rcos(theta)))/2
-	// where r is the radius of the circle being projected
-	//       D is the distance between camera and circle center
-	//       theta is the angle between D vector an target xy plane
-	Vpx = Vpx/Vnorm;
-	Vpy = Vpy/Vnorm;
-	T D = sqrt(xp1*xp1 + yp1*yp1 + zp1*zp1);
-	T s_theta = (R_TtoC[6]*xp1 + R_TtoC[7]*yp1 + R_TtoC[8]*zp1)/D;
-	T c_theta = sqrt( T(1.0) - s_theta*s_theta);
-	T r = T(circle_diameter/2.0);
-	T Delta = r*s_theta*(T(1.0)/(D-r*c_theta) - T(1.0)/(D+r*c_theta))/T(2.0);
-	xp = xp + Delta*Vpx;
-	yp = yp + Delta*Vpy;
+/*! \brief ceres compliant function to compute the residual from a pinhole camera model without distortion
+ *  @param point[3] the input point
+ *  @param fx focal length in x
+ *  @param fy focal length in y
+ *  @param cx optical center in x
+ *  @param cy optical center in y
+ *  @param ox observation in x
+ *  @param oy observation in y
+ *  @param residual the output or difference between where the point should appear given the parameters, and where it
+ * was observed
+ */
+
+template < typename T >
+void cameraPntResidual(T point[3], T& fx, T& fy, T& cx, T& cy, T& ox, T& oy, T residual[2]);
+template < typename T >
+inline void cameraPntResidual(T point[3], T& fx, T& fy, T& cx, T& cy, T& ox, T& oy, T residual[2])
+{
+  T xp1 = point[0];
+  T yp1 = point[1];
+  T zp1 = point[2];
+
+  /** scale into the image plane by distance away from camera */
+  T xp, yp;
+  if (zp1 == T(0))
+  {  // avoid divide by zero
+    xp = xp1;
+    yp = yp1;
+  }
+  else
+  {
+    xp = xp1 / zp1;
+    yp = yp1 / zp1;
+  }
+  /** perform projection using focal length and camera center into image plane */
+  residual[0] = fx * xp + cx - ox;
+  residual[1] = fy * yp + cy - oy;
+}
+
+class CameraReprjErrorWithDistortion
+{
+public:
+  CameraReprjErrorWithDistortion(double ob_x, double ob_y) : ox_(ob_x), oy_(ob_y)
+  {
+  }
+
+  template < typename T >
+  bool operator()(const T* const c_p1, /** extrinsic parameters */
+                  const T* c_p2,       /** intrinsic parameters */
+                  const T* point,      /** point being projected, has 3 parameters */
+                  T* residual) const
+  {
+    const T* camera_aa(&c_p1[0]);
+    const T* camera_tx(&c_p1[3]);
+    T fx, fy, cx, cy, k1, k2, k3, p1, p2;
+    extractCameraIntrinsics(c_p2, fx, fy, cx, cy, k1, k2, k3, p1, p2);
+    T camera_point[3]; /** point in camera coordinates*/
+
+    /** transform point into camera coordinates */
+    transformPoint(camera_aa, camera_tx, point, camera_point);
+
+    /** compute project point into image plane and compute residual */
+    T ox = T(ox_);
+    T oy = T(oy_);
+    cameraPntResidualDist(camera_point, k1, k2, k3, p1, p2, fx, fy, cx, cy, ox, oy, residual);
+
+    return true;
+  } /** end of operator() */
+
+  /** Factory to hide the construction of the CostFunction object from */
+  /** the client code. */
+  static ceres::CostFunction* Create(const double o_x, const double o_y)
+  {
+    return (new ceres::AutoDiffCostFunction< CameraReprjErrorWithDistortion, 2, 6, 9, 3 >(
+        new CameraReprjErrorWithDistortion(o_x, o_y)));
+  }
+  double ox_; /** observed x location of object in image */
+  double oy_; /** observed y location of object in image */
+};
+
+// reprojection error of a single simple point observed by a camera with lens distortion
+// typically used for intrinsic calibration
+// location of target is known, and fixed, point's location within target is also known
+// both extrinsic and intrinsic parameters of camera are being computed
+class CameraReprjErrorWithDistortionPK
+{
+public:
+  CameraReprjErrorWithDistortionPK(double ob_x, double ob_y, Point3d point) : ox_(ob_x), oy_(ob_y), point_(point)
+  {
+  }
+
+  template < typename T >
+  bool operator()(const T* const c_p1, /** extrinsic parameters */
+                  const T* c_p2,       /** intrinsic parameters */
+                  T* residual) const
+  {
+    const T* camera_aa(&c_p1[0]);
+    const T* camera_tx(&c_p1[3]);
+    T fx, fy, cx, cy, k1, k2, k3, p1, p2;
+    extractCameraIntrinsics(c_p2, fx, fy, cx, cy, k1, k2, k3, p1, p2);
+    T camera_point[3];
+
+    /** transform point into camera coordinates */
+    transformPoint3d(camera_aa, camera_tx, point_, camera_point);
+
+    /** compute project point into image plane and compute residual */
+    T ox = T(ox_);
+    T oy = T(oy_);
+    cameraPntResidualDist(camera_point, k1, k2, k3, p1, p2, fx, fy, cx, cy, ox, oy, residual);
+
+    return true;
+  } /** end of operator() */
+
+  /** Factory to hide the construction of the CostFunction object from */
+  /** the client code. */
+  static ceres::CostFunction* Create(const double o_x, const double o_y, Point3d point)
+  {
+    return (new ceres::AutoDiffCostFunction< CameraReprjErrorWithDistortionPK, 2, 6, 9 >(
+        new CameraReprjErrorWithDistortionPK(o_x, o_y, point)));
+  }
+  double ox_;     /** observed x location of object in image */
+  double oy_;     /** observed y location of object in image */
+  Point3d point_; /*! location of point in target coordinates */
+};
+
+// reprojection error of a single simple point observed by a camera with NO lens distortion
+// should subscribe to a rectified image when using the error function
+class CameraReprjError
+{
+public:
+  CameraReprjError(double ob_x, double ob_y, double fx, double fy, double cx, double cy)
+    : ox_(ob_x), oy_(ob_y), fx_(fx), fy_(fy), cx_(cx), cy_(cy)
+  {
+  }
+
+  template < typename T >
+  bool operator()(const T* const c_p1, /** extrinsic parameters */
+                  const T* point,      /** point being projected, yes this is has 3 parameters */
+                  T* residual) const
+  {
+    const T* camera_aa(&c_p1[0]);
+    const T* camera_tx(&c_p1[3]);
+    T camera_point[3]; /** point in camera coordinates */
+
+    /** transform point into camera coordinates */
+    transformPoint(camera_aa, camera_tx, point, camera_point);
+
+    /** compute project point into image plane and compute residual */
+    T fx = T(fx_);
+    T fy = T(fy_);
+    T cx = T(cx_);
+    T cy = T(cy_);
+    T ox = T(ox_);
+    T oy = T(oy_);
+    cameraPntResidual(camera_point, fx, fy, cx, cy, ox, oy, residual);
+
+    return true;
+  } /** end of operator() */
+
+  /** Factory to hide the construction of the CostFunction object from */
+  /** the client code. */
+  static ceres::CostFunction* Create(const double o_x, const double o_y, const double fx, const double fy,
+                                     const double cx, const double cy)
+  {
+    return (
+        new ceres::AutoDiffCostFunction< CameraReprjError, 2, 6, 3 >(new CameraReprjError(o_x, o_y, fx, fy, cx, cy)));
+  }
+  double ox_; /** observed x location of object in image */
+  double oy_; /** observed y location of object in image */
+  double fx_; /*!< known focal length of camera in x */
+  double fy_; /*!< known focal length of camera in y */
+  double cx_; /*!< known optical center of camera in x */
+  double cy_; /*!< known optical center of camera in y */
+};
+
+class TriangulationError
+{
+public:
+  TriangulationError(double ob_x, double ob_y, double fx, double fy, double cx, double cy, Pose6d camera_pose)
+    : ox_(ob_x), oy_(ob_y), fx_(fx), fy_(fy), cx_(cx), cy_(cy), camera_pose_(camera_pose)
+  {
+  }
+
+  template < typename T >
+  bool operator()(const T* point, /** point being projected, yes this is has 3 parameters */
+                  T* residual) const
+  {
+    T camera_point[3]; /** point in camera coordinates */
+
+    /** transform point into camera coordinates */
+    poseTransformPoint(camera_pose_, point, camera_point);
+
+    /** compute project point into image plane and compute residual */
+    T fx = T(fx_);
+    T fy = T(fy_);
+    T cx = T(cx_);
+    T cy = T(cy_);
+    T ox = T(ox_);
+    T oy = T(oy_);
+    cameraPntResidual(camera_point, fx, fy, cx, cy, ox, oy, residual);
+
+    return true;
+  } /** end of operator() */
+
+  /** Factory to hide the construction of the CostFunction object from */
+  /** the client code. */
+  static ceres::CostFunction* Create(const double o_x, const double o_y, const double fx, const double fy,
+                                     const double cx, const double cy, const Pose6d camera_pose)
+  {
+    return (new ceres::AutoDiffCostFunction< TriangulationError, 2, 3 >(
+        new TriangulationError(o_x, o_y, fx, fy, cx, cy, camera_pose)));
+  }
+  double ox_;          /** observed x location of object in image */
+  double oy_;          /** observed y location of object in image */
+  double fx_;          /*!< known focal length of camera in x */
+  double fy_;          /*!< known focal length of camera in y */
+  double cx_;          /*!< known optical center of camera in x */
+  double cy_;          /*!< known optical center of camera in y */
+  Pose6d camera_pose_; /*!< known camera pose */
+};
+
+// reprojection error of a single simple point observed by a camera with NO lens distortion
+// should subscribe to a rectified image when using the error function
+class CameraReprjErrorPK
+{
+public:
+  CameraReprjErrorPK(double ob_x, double ob_y, double fx, double fy, double cx, double cy, Point3d point)
+    : ox_(ob_x), oy_(ob_y), fx_(fx), fy_(fy), cx_(cx), cy_(cy), point_(point)
+  {
+  }
+
+  template < typename T >
+  bool operator()(const T* const c_p1, /** extrinsic parameters */
+                  T* residual) const
+  {
+    const T* camera_aa(&c_p1[0]);
+    const T* camera_tx(&c_p1[3]);
+    T camera_point[3]; /** point in camera coordinates */
+
+    /** transform point into camera coordinates */
+    transformPoint3d(camera_aa, camera_tx, point_, camera_point);
+
+    /** compute project point into image plane and compute residual */
+    T fx = T(fx_);
+    T fy = T(fy_);
+    T cx = T(cx_);
+    T cy = T(cy_);
+    T ox = T(ox_);
+    T oy = T(oy_);
+    cameraPntResidual(camera_point, fx, fy, cx, cy, ox, oy, residual);
+
+    return true;
+  } /** end of operator() */
+
+  /** Factory to hide the construction of the CostFunction object from */
+  /** the client code. */
+  static ceres::CostFunction* Create(const double o_x, const double o_y, const double fx, const double fy,
+                                     const double cx, const double cy, const Point3d point)
+  {
+    return (new ceres::AutoDiffCostFunction< CameraReprjErrorPK, 2, 6 >(
+        new CameraReprjErrorPK(o_x, o_y, fx, fy, cx, cy, point)));
+  }
+  double ox_;     /** observed x location of object in image */
+  double oy_;     /** observed y location of object in image */
+  double fx_;     /*!< known focal length of camera in x */
+  double fy_;     /*!< known focal length of camera in y */
+  double cx_;     /*!< known optical center of camera in x */
+  double cy_;     /*!< known optical center of camera in y */
+  Point3d point_; /*! location of point in target coordinates */
+};
+
+// reprojection error of a single point attatched to a target observed by a camera with NO lens distortion
+// should subscribe to a rectified image when using the error function
+//
+class TargetCameraReprjError
+{
+public:
+  TargetCameraReprjError(double ob_x, double ob_y, double fx, double fy, double cx, double cy)
+    : ox_(ob_x), oy_(ob_y), fx_(fx), fy_(fy), cx_(cx), cy_(cy)
+  {
+  }
+
+  template < typename T >
+  bool operator()(const T* const c_p1,  /** extrinsic parameters */
+                  const T* const c_p2,  /** 6Dof transform of target points into world frame */
+                  const T* const point, /** point described in target frame */
+                  T* residual) const
+  {
+    const T* camera_aa(&c_p1[0]);
+    const T* camera_tx(&c_p1[3]);
+    const T* target_aa(&c_p2[0]);
+    const T* target_tx(&c_p2[3]);
+
+    T world_point[3];  /** point in world coordinates */
+    T camera_point[3]; /** point in camera coordinates */
+
+    /** transform point into camera coordinates */
+    transformPoint(target_aa, target_tx, point, world_point);
+    transformPoint(camera_aa, camera_tx, world_point, camera_point);
+
+    /** compute project point into image plane and compute residual */
+    T fx = T(fx_);
+    T fy = T(fy_);
+    T cx = T(cx_);
+    T cy = T(cy_);
+    T ox = T(ox_);
+    T oy = T(oy_);
+    cameraPntResidual(camera_point, fx, fy, cx, cy, ox, oy, residual);
+
+    return true;
+  } /** end of operator() */
+
+  /** Factory to hide the construction of the CostFunction object from */
+  /** the client code. */
+  static ceres::CostFunction* Create(const double o_x, const double o_y, const double fx, const double fy,
+                                     const double cx, const double cy)
+
+  {
+    return (new ceres::AutoDiffCostFunction< TargetCameraReprjError, 2, 6, 6, 3 >(
+        new TargetCameraReprjError(o_x, o_y, fx, fy, cx, cy)));
+  }
+  double ox_; /** observed x location of object in image */
+  double oy_; /** observed y location of object in image */
+  double fx_; /*!< known focal length of camera in x */
+  double fy_; /*!< known focal length of camera in y */
+  double cx_; /*!< known optical center of camera in x */
+  double cy_; /*!< known optical center of camera in y */
+};
+
+// reprojection error of a single point attatched to a target observed by a camera with NO lens distortion
+// should subscribe to a rectified image when using the error function
+//
+class TargetCameraReprjErrorPK
+{
+public:
+  TargetCameraReprjErrorPK(double ob_x, double ob_y, double fx, double fy, double cx, double cy, Point3d point)
+    : ox_(ob_x), oy_(ob_y), fx_(fx), fy_(fy), cx_(cx), cy_(cy), point_(point)
+  {
+  }
+
+  template < typename T >
+  bool operator()(const T* const c_p1, /** extrinsic parameters */
+                  const T* const c_p2, /** 6Dof transform of target points into world frame */
+                  T* residual) const
+  {
+    const T* camera_aa(&c_p1[0]);
+    const T* camera_tx(&c_p1[3]);
+    const T* target_aa(&c_p2[0]);
+    const T* target_tx(&c_p2[3]);
+    T world_point[3];  /** point in world coordinates */
+    T camera_point[3]; /** point in camera coordinates */
+
+    /** transform point into camera coordinates */
+    transformPoint3d(target_aa, target_tx, point_, world_point);
+    transformPoint(camera_aa, camera_tx, world_point, camera_point);
+
+    /** compute project point into image plane and compute residual */
+    T fx = T(fx_);
+    T fy = T(fy_);
+    T cx = T(cx_);
+    T cy = T(cy_);
+    T ox = T(ox_);
+    T oy = T(oy_);
+    cameraPntResidual(camera_point, fx, fy, cx, cy, ox, oy, residual);
+
+    return true;
+  } /** end of operator() */
+
+  /** Factory to hide the construction of the CostFunction object from */
+  /** the client code. */
+  static ceres::CostFunction* Create(const double o_x, const double o_y, const double fx, const double fy,
+                                     const double cx, const double cy, const Point3d point)
+
+  {
+    return (new ceres::AutoDiffCostFunction< TargetCameraReprjErrorPK, 2, 6, 6 >(
+        new TargetCameraReprjErrorPK(o_x, o_y, fx, fy, cx, cy, point)));
+  }
+  double ox_;     /** observed x location of object in image */
+  double oy_;     /** observed y location of object in image */
+  double fx_;     /*!< known focal length of camera in x */
+  double fy_;     /*!< known focal length of camera in y */
+  double cx_;     /*!< known optical center of camera in x */
+  double cy_;     /*!< known optical center of camera in y */
+  Point3d point_; /*! location of point in target coordinates */
+};
+
+// reprojection error of a single point attatched to a target observed by a camera with NO lens distortion
+// should subscribe to a rectified image when using the error function
+//
+class LinkTargetCameraReprjError
+{
+public:
+  LinkTargetCameraReprjError(double ob_x, double ob_y, double fx, double fy, double cx, double cy, Pose6d link_pose)
+    : ox_(ob_x), oy_(ob_y), fx_(fx), fy_(fy), cx_(cx), cy_(cy), link_pose_(link_pose)
+  {
+  }
+
+  template < typename T >
+  bool operator()(const T* const c_p1,  /** extrinsic parameters */
+                  const T* const c_p2,  /** 6Dof transform of target points into world frame */
+                  const T* const point, /** point described in target frame that is being seen */
+                  T* residual) const
+  {
+    const T* camera_aa(&c_p1[0]);
+    const T* camera_tx(&c_p1[3]);
+    const T* target_aa(&c_p2[0]);
+    const T* target_tx(&c_p2[3]);
+    T link_point[3];   /** point in link coordinates */
+    T world_point[3];  /** point in world coordinates */
+    T camera_point[3]; /** point in camera coordinates */
+
+    /** transform point into camera coordinates */
+    transformPoint(target_aa, target_tx, point, link_point);
+    poseTransformPoint(link_pose_, link_point, world_point);
+    transformPoint(camera_aa, camera_tx, world_point, camera_point);
+
+    /** compute project point into image plane and compute residual */
+    T fx = T(fx_);
+    T fy = T(fy_);
+    T cx = T(cx_);
+    T cy = T(cy_);
+    T ox = T(ox_);
+    T oy = T(oy_);
+    cameraPntResidual(camera_point, fx, fy, cx, cy, ox, oy, residual);
+
+    return true;
+  } /** end of operator() */
+
+  /** Factory to hide the construction of the CostFunction object from */
+  /** the client code. */
+  static ceres::CostFunction* Create(const double ox, const double oy, const double fx, const double fy,
+                                     const double cx, const double cy, Pose6d pose)
+
+  {
+    return (new ceres::AutoDiffCostFunction< LinkTargetCameraReprjError, 2, 6, 6, 3 >(
+        new LinkTargetCameraReprjError(ox, oy, fx, fy, cx, cy, pose)));
+  }
+  double ox_;        /** observed x location of object in image */
+  double oy_;        /** observed y location of object in image */
+  double fx_;        /*!< known focal length of camera in x */
+  double fy_;        /*!< known focal length of camera in y */
+  double cx_;        /*!< known optical center of camera in x */
+  double cy_;        /*!< known optical center of camera in y */
+  Pose6d link_pose_; /*!< transform from world to link coordinates */
+};
+
+// reprojection error of a single point attatched to a target observed by a camera with NO lens distortion
+// should subscribe to a rectified image when using the error function
+//
+class LinkTargetCameraReprjErrorPK
+{
+public:
+  LinkTargetCameraReprjErrorPK(double ob_x, double ob_y, double fx, double fy, double cx, double cy, Pose6d link_pose,
+                               Point3d point)
+    : ox_(ob_x), oy_(ob_y), fx_(fx), fy_(fy), cx_(cx), cy_(cy), link_pose_(link_pose), point_(point)
+  {
+  }
+
+  template < typename T >
+  bool operator()(const T* const c_p1, /** extrinsic parameters */
+                  const T* const c_p2, /** 6Dof transform of target points into world frame */
+                  T* residual) const
+  {
+    const T* camera_aa(&c_p1[0]);
+    const T* camera_tx(&c_p1[3]);
+    const T* target_aa(&c_p2[0]);
+    const T* target_tx(&c_p2[3]);
+    T link_point[3];   /** point in link coordinates */
+    T world_point[3];  /** point in worls coordinates */
+    T camera_point[3]; /** point in camera coordinates */
+
+    /** transform point into camera coordinates */
+    transformPoint3d(target_aa, target_tx, point_, link_point);
+    poseTransformPoint(link_pose_, link_point, world_point);
+    transformPoint(camera_aa, camera_tx, world_point, camera_point);
+
+    /** compute project point into image plane and compute residual */
+    T fx = T(fx_);
+    T fy = T(fy_);
+    T cx = T(cx_);
+    T cy = T(cy_);
+    T ox = T(ox_);
+    T oy = T(oy_);
+    cameraPntResidual(camera_point, fx, fy, cx, cy, ox, oy, residual);
+
+    return true;
+  } /** end of operator() */
+
+  /** Factory to hide the construction of the CostFunction object from */
+  /** the client code. */
+  static ceres::CostFunction* Create(const double o_x, const double o_y, const double fx, const double fy,
+                                     const double cx, const double cy, Pose6d pose, Point3d point)
+
+  {
+    return (new ceres::AutoDiffCostFunction< LinkTargetCameraReprjErrorPK, 2, 6, 6 >(
+        new LinkTargetCameraReprjErrorPK(o_x, o_y, fx, fy, cx, cy, pose, point)));
+  }
+  double ox_;        /** observed x location of object in image */
+  double oy_;        /** observed y location of object in image */
+  double fx_;        /*!< known focal length of camera in x */
+  double fy_;        /*!< known focal length of camera in y */
+  double cx_;        /*!< known optical center of camera in x */
+  double cy_;        /*!< known optical center of camera in y */
+  Pose6d link_pose_; /*!< transform from world to link coordinates */
+  Point3d point_;    /*! location of point in target coordinates */
+};
+
+// reprojection error of a single point attatched to a target observed by a camera with NO lens distortion
+// should subscribe to a rectified image when using the error function
+//
+class PosedTargetCameraReprjErrorPK
+{
+public:
+  PosedTargetCameraReprjErrorPK(double ob_x, double ob_y, double fx, double fy, double cx, double cy,
+                                Pose6d target_pose, Point3d point)
+    : ox_(ob_x), oy_(ob_y), fx_(fx), fy_(fy), cx_(cx), cy_(cy), target_pose_(target_pose), point_(point)
+  {
+  }
+
+  template < typename T >
+  bool operator()(const T* const c_p1, /** extrinsic parameters */
+                  T* residual) const
+  {
+    const T* camera_aa(&c_p1[0]);
+    const T* camera_tx(&c_p1[3]);
+    T world_point[3];  /** point in worls coordinates */
+    T camera_point[3]; /** point in camera coordinates */
+    T point[3];
+    point[0] = T(point_.x);
+    point[1] = T(point_.y);
+    point[2] = T(point_.z);
+    /** transform point into camera coordinates */
+    poseTransformPoint(target_pose_, point, world_point);
+    transformPoint(camera_aa, camera_tx, world_point, camera_point);
+
+    /** compute project point into image plane and compute residual */
+    T fx = T(fx_);
+    T fy = T(fy_);
+    T cx = T(cx_);
+    T cy = T(cy_);
+    T ox = T(ox_);
+    T oy = T(oy_);
+    cameraPntResidual(camera_point, fx, fy, cx, cy, ox, oy, residual);
+
+    return true;
+  } /** end of operator() */
+
+  /** Factory to hide the construction of the CostFunction object from */
+  /** the client code. */
+  static ceres::CostFunction* Create(const double o_x, const double o_y, const double fx, const double fy,
+                                     const double cx, const double cy, Pose6d target_pose, Point3d point)
+
+  {
+    return (new ceres::AutoDiffCostFunction< PosedTargetCameraReprjErrorPK, 2, 6 >(
+        new PosedTargetCameraReprjErrorPK(o_x, o_y, fx, fy, cx, cy, target_pose, point)));
+  }
+  double ox_;          /** observed x location of object in image */
+  double oy_;          /** observed y location of object in image */
+  double fx_;          /*!< known focal length of camera in x */
+  double fy_;          /*!< known focal length of camera in y */
+  double cx_;          /*!< known optical center of camera in x */
+  double cy_;          /*!< known optical center of camera in y */
+  Pose6d target_pose_; /*!< transform from world to target coordinates */
+  Point3d point_;      /*! location of point in target coordinates */
+};
+
+// reprojection error of a single point attatched to a target observed by a camera with NO lens distortion
+// should subscribe to a rectified image when using the error function
+//
+class LinkCameraTargetReprjError
+{
+public:
+  LinkCameraTargetReprjError(double ob_x, double ob_y, double fx, double fy, double cx, double cy, Pose6d link_pose)
+    : ox_(ob_x), oy_(ob_y), fx_(fx), fy_(fy), cx_(cx), cy_(cy), link_pose_(link_pose)
+  {
+    link_posei_ = link_pose_.getInverse();
+  }
+
+  template < typename T >
+  bool operator()(const T* const c_p1,  /** extrinsic parameters */
+                  const T* const c_p2,  /** 6Dof transform of target points into world frame */
+                  const T* const point, /** point described in target frame that is being seen */
+                  T* residual) const
+  {
+    const T* camera_aa(&c_p1[0]);
+    const T* camera_tx(&c_p1[3]);
+    const T* target_aa(&c_p2[0]);
+    const T* target_tx(&c_p2[3]);
+    T world_point[3];  /** point in world coordinates */
+    T link_point[3];   /** point in link coordinates */
+    T camera_point[3]; /** point in camera coordinates */
+
+    /** transform point into camera coordinates */
+    transformPoint(target_aa, target_tx, point, world_point);
+    poseTransformPoint(link_posei_, world_point, link_point);
+    transformPoint(camera_aa, camera_tx, link_point, camera_point);
+
+    /** compute project point into image plane and compute residual */
+    T fx = T(fx_);
+    T fy = T(fy_);
+    T cx = T(cx_);
+    T cy = T(cy_);
+    T ox = T(ox_);
+    T oy = T(oy_);
+    cameraPntResidual(camera_point, fx, fy, cx, cy, ox, oy, residual);
+
+    return true;
+  } /** end of operator() */
+
+  /** Factory to hide the construction of the CostFunction object from */
+  /** the client code. */
+  static ceres::CostFunction* Create(const double ox, const double oy, const double fx, const double fy,
+                                     const double cx, const double cy, Pose6d pose)
+
+  {
+    return (new ceres::AutoDiffCostFunction< LinkCameraTargetReprjError, 2, 6, 6, 3 >(
+        new LinkCameraTargetReprjError(ox, oy, fx, fy, cx, cy, pose)));
+  }
+  double ox_;         /*!< observed x location of object in image */
+  double oy_;         /*!< observed y location of object in image */
+  double fx_;         /*!< known focal length of camera in x */
+  double fy_;         /*!< known focal length of camera in y */
+  double cx_;         /*!< known optical center of camera in x */
+  double cy_;         /*!< known optical center of camera in y */
+  Pose6d link_pose_;  /*!< transform from world to link coordinates */
+  Pose6d link_posei_; /*!< transform from link to world coordinates */
+};
+
+// reprojection error of a single point attatched to a target observed by a camera with NO lens distortion
+// should subscribe to a rectified image when using the error function
+//
+class LinkCameraTargetReprjErrorPK
+{
+public:
+  LinkCameraTargetReprjErrorPK(double ob_x, double ob_y, double fx, double fy, double cx, double cy, Pose6d link_pose,
+                               Point3d point)
+    : ox_(ob_x), oy_(ob_y), fx_(fx), fy_(fy), cx_(cx), cy_(cy), link_pose_(link_pose), point_(point)
+  {
+    link_posei_ = link_pose_.getInverse();
+  }
+
+  template < typename T >
+  bool operator()(const T* const c_p1, /** extrinsic parameters */
+                  const T* const c_p2, /** 6Dof transform of target points into world frame */
+                  T* residual) const
+  {
+    const T* camera_aa(&c_p1[0]);
+    const T* camera_tx(&c_p1[3]);
+    const T* target_aa(&c_p2[0]);
+    const T* target_tx(&c_p2[3]);
+    T world_point[3];  /** point in world coordinates */
+    T link_point[3];   /** point in link coordinates */
+    T camera_point[3]; /** point in camera coordinates */
+
+    /** transform point into camera coordinates */
+    transformPoint3d(target_aa, target_tx, point_, world_point);
+    poseTransformPoint(link_posei_, world_point, link_point);
+    transformPoint(camera_aa, camera_tx, link_point, camera_point);
+
+    /** compute project point into image plane and compute residual */
+    T fx = T(fx_);
+    T fy = T(fy_);
+    T cx = T(cx_);
+    T cy = T(cy_);
+    T ox = T(ox_);
+    T oy = T(oy_);
+    cameraPntResidual(camera_point, fx, fy, cx, cy, ox, oy, residual);
+
+    return true;
+  } /** end of operator() */
+
+  /** Factory to hide the construction of the CostFunction object from */
+  /** the client code. */
+  static ceres::CostFunction* Create(const double o_x, const double o_y, const double fx, const double fy,
+                                     const double cx, const double cy, Pose6d pose, Point3d pnt)
+
+  {
+    return (new ceres::AutoDiffCostFunction< LinkCameraTargetReprjErrorPK, 2, 6, 6 >(
+        new LinkCameraTargetReprjErrorPK(o_x, o_y, fx, fy, cx, cy, pose, pnt)));
+  }
+  double ox_;         /** observed x location of object in image */
+  double oy_;         /** observed y location of object in image */
+  double fx_;         /*!< known focal length of camera in x */
+  double fy_;         /*!< known focal length of camera in y */
+  double cx_;         /*!< known optical center of camera in x */
+  double cy_;         /*!< known optical center of camera in y */
+  Pose6d link_pose_;  /*!< transform from world to link coordinates */
+  Pose6d link_posei_; /*!< transform from link to world coordinates */
+  Point3d point_;     /*! location of point in target coordinates */
+};
+
+// WARNING, ASSUMES CIRCLE LIES IN XY PLANE OF WORLD
+class CircleCameraReprjErrorWithDistortion
+{
+public:
+  CircleCameraReprjErrorWithDistortion(double ob_x, double ob_y, double c_dia)
+    : ox_(ob_x), oy_(ob_y), circle_diameter_(c_dia)
+  {
+  }
+
+  template < typename T >
+  bool operator()(const T* const c_p1,  /** extrinsic parameters [6]*/
+                  const T* const c_p2,  /** intrinsic parameters of camera fx,fy,cx,cy,k1,k2,k2,p1,p2 [9]*/
+                  const T* const point, /** point described in target frame that is being seen [3]*/
+                  T* residual) const
+  {
+    const T* camera_aa(&c_p1[0]);
+    const T* camera_tx(&c_p1[3]);
+    T fx, fy, cx, cy, k1, k2, k3, p1, p2;
+    extractCameraIntrinsics(c_p2, fx, fy, cx, cy, k1, k2, k3, p1, p2);
+    T camera_point[3]; /** point in camera coordinates*/
+    T R_TtoC[9];
+
+    /** transform point into camera coordinates */
+    transformPoint(camera_aa, camera_tx, point, camera_point);
+
+    // find rotation from target to camera frame
+    ceres::AngleAxisToRotationMatrix(camera_aa, R_TtoC);
+
+    /** compute project point into image plane and compute residual */
+    T circle_diameter = T(circle_diameter_);
+    T ox = T(ox_);
+    T oy = T(oy_);
+    cameraCircResidualDist(camera_point, circle_diameter, R_TtoC, k1, k2, k3, p1, p2, fx, fy, cx, cy, ox, oy, residual);
+
+    return true;
+  } /** end of operator() */
+
+  /** Factory to hide the construction of the CostFunction object from */
+  /** the client code. */
+  static ceres::CostFunction* Create(const double o_x, const double o_y, const double c_dia)
+  {
+    return (new ceres::AutoDiffCostFunction< CircleCameraReprjErrorWithDistortion, 2, 6, 9, 3 >(
+        new CircleCameraReprjErrorWithDistortion(o_x, o_y, c_dia)));
+  }
+  double ox_;               /** observed x location of object in image */
+  double oy_;               /** observed y location of object in image */
+  double circle_diameter_;  //** diameter of circle being observed */
+};
+
+// WARNING, ASSUMES CIRCLE LIES IN XY PLANE OF WORLD
+class CircleCameraReprjErrorWithDistortionPK
+{
+public:
+  CircleCameraReprjErrorWithDistortionPK(double ob_x, double ob_y, double c_dia, Point3d point)
+    : ox_(ob_x), oy_(ob_y), circle_diameter_(c_dia), point_(point)
+  {
+  }
+
+  template < typename T >
+  bool operator()(const T* const c_p1, /** extrinsic parameters [6] */
+                  const T* const c_p2, /** intrinsic parameters of camera fx,fy,cx,cy,k1,k2,k2,p1,p2 [9] */
+                  T* residual) const
+  {
+    const T* camera_aa(&c_p1[0]);
+    const T* camera_tx(&c_p1[3]);
+    T fx, fy, cx, cy, k1, k2, k3, p1, p2;
+    extractCameraIntrinsics(c_p2, fx, fy, cx, cy, k1, k2, k3, p1, p2);
+    T camera_point[3]; /** point in camera coordinates */
+    T R_TtoC[9];       /** rotation from target to camera coordinates
+      
+          /** find point in camera coordinates */
+    transformPoint3d(camera_aa, camera_tx, point_, camera_point);
+
+    // find rotation from target to camera coordinates
+    T T2C_angle_axis[3];
+    T2C_angle_axis[0] = T(-camera_aa[0]);
+    T2C_angle_axis[1] = T(-camera_aa[1]);
+    T2C_angle_axis[2] = T(-camera_aa[2]);
+    ceres::AngleAxisToRotationMatrix(T2C_angle_axis, R_TtoC);
+
+    /** compute project point into image plane and compute residual */
+    T circle_diameter = T(circle_diameter_);
+    T ox = T(ox_);
+    T oy = T(oy_);
+    cameraCircResidualDist(camera_point, circle_diameter, R_TtoC, k1, k2, k3, p1, p2, fx, fy, cx, cy, ox, oy, residual);
+
+    return true;
+  } /** end of operator() */
+
+  /** Factory to hide the construction of the CostFunction object from */
+  /** the client code. */
+  static ceres::CostFunction* Create(const double o_x, const double o_y, const double c_dia, Point3d point)
+  {
+    return (new ceres::AutoDiffCostFunction< CircleCameraReprjErrorWithDistortionPK, 2, 6, 9 >(
+        new CircleCameraReprjErrorWithDistortionPK(o_x, o_y, c_dia, point)));
+  }
+  double ox_;               /** observed x location of object in image */
+  double oy_;               /** observed y location of object in image */
+  double circle_diameter_;  //** diameter of circle being observed */
+  Point3d point_;
+};
+
+class CircleCameraReprjError
+{
+public:
+  CircleCameraReprjError(double ob_x, double ob_y, double c_dia, double fx, double fy, double cx, double cy)
+    : ox_(ob_x), oy_(ob_y), circle_diameter_(c_dia), fx_(fx), fy_(fy), cx_(cx), cy_(cy)
+  {
+  }
+
+  template < typename T >
+  bool operator()(const T* const c_p1,  /** extrinsic parameters [6]*/
+                  const T* const point, /** point described in target frame that is being seen [3]*/
+                  T* residual) const
+  {
+    const T* camera_aa(&c_p1[0]);
+    const T* camera_tx(&c_p1[3]);
+    T camera_point[3]; /** point in camera coordinates */
+    T R_TtoC[9];       /** rotation from target to camera coordinates */
+
+    /** transform point into camera coordinates */
+    transformPoint(camera_aa, camera_tx, point, camera_point);
+
+    // find rotation from target to camera coordinates
+    ceres::AngleAxisToRotationMatrix(camera_aa, R_TtoC);
+
+    /** compute project point into image plane and compute residual */
+    T circle_diameter = T(circle_diameter_);
+    T fx = T(fx_);
+    T fy = T(fy_);
+    T cx = T(cx_);
+    T cy = T(cy_);
+    T ox = T(ox_);
+    T oy = T(oy_);
+    cameraCircResidual(camera_point, circle_diameter, R_TtoC, fx, fy, cx, cy, ox, oy, residual);
+
+    return true;
+  } /** end of operator() */
+
+  /** Factory to hide the construction of the CostFunction object from */
+  /** the client code. */
+  static ceres::CostFunction* Create(const double o_x, const double o_y, const double c_dia, const double fx,
+                                     const double fy, const double cx, const double cy)
+  {
+    return (new ceres::AutoDiffCostFunction< CircleCameraReprjError, 2, 6, 3 >(
+        new CircleCameraReprjError(o_x, o_y, c_dia, fx, fy, cx, cy)));
+  }
+  double ox_;              /** observed x location of object in image */
+  double oy_;              /** observed y location of object in image */
+  double circle_diameter_; /** diameter of circle being observed */
+  double fx_;              /** focal length of camera in x (pixels) */
+  double fy_;              /** focal length of camera in y (pixels) */
+  double cx_;              /** focal center of camera in x (pixels) */
+  double cy_;              /** focal center of camera in y (pixels) */
+};
+
+class CircleCameraReprjErrorPK
+{
+public:
+  CircleCameraReprjErrorPK(double ob_x, double ob_y, double c_dia, double fx, double fy, double cx, double cy,
+                           Point3d point)
+    : ox_(ob_x), oy_(ob_y), circle_diameter_(c_dia), fx_(fx), fy_(fy), cx_(cx), cy_(cy), point_(point)
+  {
+  }
+
+  template < typename T >
+  bool operator()(const T* const c_p1, /** extrinsic parameters [6] */
+                  T* residual) const
+  {
+    const T* camera_aa(&c_p1[0]);
+    const T* camera_tx(&c_p1[3]);
+    T camera_point[3]; /* point in camera coordinates */
+    T R_TtoC[9];       /** rotation from target to camera coordinates */
+
+    /** rotate and translate point into camera coordinates*/
+    transformPoint3d(camera_aa, camera_tx, point_, camera_point);
+
+    // find rotation from target to camera coordinates
+    ceres::AngleAxisToRotationMatrix(camera_aa, R_TtoC);
+
+    /** compute project point into image plane and compute residual */
+    T circle_diameter = T(circle_diameter_);
+    T fx = T(fx_);
+    T fy = T(fy_);
+    T cx = T(cx_);
+    T cy = T(cy_);
+    T ox = T(ox_);
+    T oy = T(oy_);
+    cameraCircResidual(camera_point, circle_diameter, R_TtoC, fx, fy, cx, cy, ox, oy, residual);
+
+    return true;
+  } /** end of operator() */
+
+  /** Factory to hide the construction of the CostFunction object from */
+  /** the client code. */
+  static ceres::CostFunction* Create(const double o_x, const double o_y, const double c_dia, const double fx,
+                                     const double fy, const double cx, const double cy, Point3d point)
+  {
+    return (new ceres::AutoDiffCostFunction< CircleCameraReprjErrorPK, 2, 6 >(
+        new CircleCameraReprjErrorPK(o_x, o_y, c_dia, fx, fy, cx, cy, point)));
+  }
+  double ox_;               /** observed x location of object in image */
+  double oy_;               /** observed y location of object in image */
+  double circle_diameter_;  //** diameter of circle being observed */
+  double fx_;               /** focal length of camera in x (pixels) */
+  double fy_;               /** focal length of camera in y (pixels) */
+  double cx_;               /** focal center of camera in x (pixels) */
+  double cy_;               /** focal center of camera in y (pixels) */
+  Point3d point_;           /** location of point in target coordinates */
+};
+
+class FixedCircleTargetCameraReprjErrorWithDistortion
+{
+public:
+  FixedCircleTargetCameraReprjErrorWithDistortion(double ob_x, double ob_y, double c_dia)
+    : ox_(ob_x), oy_(ob_y), circle_diameter_(c_dia)
+  {
+  }
+
+  template < typename T >
+  bool operator()(const T* const c_p1,  /** extrinsic parameters [6]*/
+                  const T* const c_p2,  /** intrinsic parameters of camera fx,fy,cx,cy,k1,k2,k2,p1,p2 [9]*/
+                  const T* const c_p3,  /** 6Dof transform of target into world frame [6]*/
+                  const T* const point, /** point described in target frame that is being seen [3]*/
+                  T* residual) const
+  {
+    const T* camera_aa(&c_p1[0]);
+    const T* camera_tx(&c_p1[3]);
+    const T* target_aa(&c_p3[0]);
+    const T* target_tx(&c_p3[3]);
+    T fx, fy, cx, cy, k1, k2, k3, p1, p2;
+    extractCameraIntrinsics(c_p2, fx, fy, cx, cy, k1, k2, k3, p1, p2);
+    T world_point[3];  /** point in world coordinates */
+    T camera_point[3]; /** point in camera coordinates*/
+    T R_WtoC[9];       // rotation from world to camera coordinates
+    T R_TtoW[9];       // rotation from target to world coordinates
+    T R_TtoC[9];  // rotation from target to camera coordinates (assume circle lies in x-y plane of target coordinates)
+
+    /** compute necessary rotation matrices */
+    ceres::AngleAxisToRotationMatrix(camera_aa, R_WtoC);
+    ceres::AngleAxisToRotationMatrix(target_aa, R_TtoW);
+
+    /** transform point into camera coordinates */
+    transformPoint(target_aa, target_tx, point, world_point);
+    transformPoint(camera_aa, camera_tx, world_point, camera_point);
+
+    // find rotation from target to camera coordinates
+    rotationProduct(R_WtoC, R_TtoW, R_TtoC);  // R_WtoC*R_TtoW = R_TtoC
+
+    /** compute project point into image plane and compute residual */
+    T circle_diameter = T(circle_diameter_);
+    T ox = T(ox_);
+    T oy = T(oy_);
+    cameraCircResidualDist(camera_point, circle_diameter, R_TtoC, k1, k2, k3, p1, p2, fx, fy, cx, cy, ox, oy, residual);
+
+    return true;
+  } /** end of operator() */
+
+  /** Factory to hide the construction of the CostFunction object from */
+  /** the client code. */
+  static ceres::CostFunction* Create(const double o_x, const double o_y, const double c_dia)
+  {
+    return (new ceres::AutoDiffCostFunction< FixedCircleTargetCameraReprjErrorWithDistortion, 2, 6, 6, 9, 3 >(
+        new FixedCircleTargetCameraReprjErrorWithDistortion(o_x, o_y, c_dia)));
+  }
+  double ox_;               /** observed x location of object in image */
+  double oy_;               /** observed y location of object in image */
+  double circle_diameter_;  //** diameter of circle being observed */
+};
+
+class FixedCircleTargetCameraReprjErrorWithDistortionPK
+{
+public:
+  FixedCircleTargetCameraReprjErrorWithDistortionPK(double ob_x, double ob_y, double c_dia, Point3d point)
+    : ox_(ob_x), oy_(ob_y), circle_diameter_(c_dia), point_(point)
+  {
+  }
+
+  template < typename T >
+  bool operator()(const T* const c_p1, /** extrinsic parameters [6]*/
+                  const T* const c_p2, /** intrinsic parameters of camera fx,fy,cx,cy,k1,k2,k2,p1,p2 [9]*/
+                  const T* const c_p3, /** 6Dof transform of target into world frame [6]*/
+                  T* residual) const
+  {
+    const T* camera_aa(&c_p1[0]);
+    const T* camera_tx(&c_p1[3]);
+    const T* target_aa(&c_p3[0]);
+    const T* target_tx(&c_p3[3]);
+    T fx, fy, cx, cy, k1, k2, k3, p1, p2;
+    extractCameraIntrinsics(c_p2, fx, fy, cx, cy, k1, k2, k3, p1, p2);
+    T world_point[3];  /** point in world coordinates */
+    T camera_point[3]; /** point in camera coordinates*/
+    T R_WtoC[9];       // rotation from world to camera coordinates
+    T R_TtoW[9];       // rotation from target to world coordinates
+    T R_TtoC[9];  // rotation from target to camera coordinates (assume circle lies in x-y plane of target coordinates)
+
+    /** compute necessary rotation matrices */
+    ceres::AngleAxisToRotationMatrix(camera_aa, R_WtoC);
+    ceres::AngleAxisToRotationMatrix(target_aa, R_TtoW);
+
+    /** transform point into camera coordinates */
+    transformPoint3d(target_aa, target_tx, point_, world_point);
+    transformPoint(camera_aa, camera_tx, world_point, camera_point);
+
+    // find rotation from target to camera coordinates
+    rotationProduct(R_WtoC, R_TtoW, R_TtoC);  // R_WtoC*R_TtoW = R_TtoC
+
+    /** compute project point into image plane and compute residual */
+    T circle_diameter = T(circle_diameter_);
+    T ox = T(ox_);
+    T oy = T(oy_);
+    cameraCircResidualDist(camera_point, circle_diameter, R_TtoC, k1, k2, k3, p1, p2, fx, fy, cx, cy, ox, oy, residual);
+
+    return true;
+  } /** end of operator() */
+
+  /** Factory to hide the construction of the CostFunction object from */
+  /** the client code. */
+  static ceres::CostFunction* Create(const double o_x, const double o_y, const double c_dia, Point3d point)
+  {
+    return (new ceres::AutoDiffCostFunction< FixedCircleTargetCameraReprjErrorWithDistortionPK, 2, 6, 9, 3 >(
+        new FixedCircleTargetCameraReprjErrorWithDistortionPK(o_x, o_y, c_dia, point)));
+  }
+  double ox_;              /** observed x location of object in image */
+  double oy_;              /** observed y location of object in image */
+  double circle_diameter_; /** diameter of circle being observed */
+  Point3d point_;          /** location of point in target coordinates */
+};
+
+class CircleTargetCameraReprjErrorWithDistortion
+{
+public:
+  CircleTargetCameraReprjErrorWithDistortion(double ob_x, double ob_y, double c_dia)
+    : ox_(ob_x), oy_(ob_y), circle_diameter_(c_dia)
+  {
+  }
+
+  template < typename T >
+  bool operator()(const T* const c_p1,  /** extrinsic parameters [6]*/
+                  const T* const c_p2,  /** intrinsic parameters of camera fx,fy,cx,cy,k1,k2,k2,p1,p2 [9]*/
+                  const T* const point, /** point described in target frame that is being seen [3]*/
+                  T* residual) const
+  {
+    const T* camera_aa(&c_p1[0]);
+    const T* camera_tx(&c_p1[3]);
+    T fx, fy, cx, cy, k1, k2, k3, p1, p2;
+    extractCameraIntrinsics(c_p2, fx, fy, cx, cy, k1, k2, k3, p1, p2);
+    T world_point[3];  /** point in world coordinates */
+    T camera_point[3]; /** point in camera coordinates*/
+    T R_TtoC[9];  // rotation from target to camera coordinates (assume circle lies in x-y plane of target coordinates)
+
+    /** compute necessary rotation matrices */
+    ceres::AngleAxisToRotationMatrix(camera_aa, R_TtoC);
+
+    /** transform point into camera coordinates */
+    transformPoint(camera_aa, camera_tx, point, camera_point);
+
+    /** compute project point into image plane and compute residual */
+    T circle_diameter = T(circle_diameter_);
+    T ox = T(ox_);
+    T oy = T(oy_);
+    cameraCircResidualDist(camera_point, circle_diameter, R_TtoC, k1, k2, k3, p1, p2, fx, fy, cx, cy, ox, oy, residual);
+
+    return true;
+  } /** end of operator() */
+
+  /** Factory to hide the construction of the CostFunction object from */
+  /** the client code. */
+  static ceres::CostFunction* Create(const double o_x, const double o_y, const double c_dia)
+  {
+    return (new ceres::AutoDiffCostFunction< CircleTargetCameraReprjErrorWithDistortion, 2, 6, 9, 3 >(
+        new CircleTargetCameraReprjErrorWithDistortion(o_x, o_y, c_dia)));
+  }
+  double ox_;               /** observed x location of object in image */
+  double oy_;               /** observed y location of object in image */
+  double circle_diameter_;  //** diameter of circle being observed */
+};
+
+// circle target is the origin, camera's location not known, distortion also unknown
+class SimpleCircleTargetCameraReprjErrorWithDistortionPK
+{
+public:
+  SimpleCircleTargetCameraReprjErrorWithDistortionPK(const double& ob_x, const double& ob_y, const double& c_dia,
+                                                     const Point3d& point)
+    : ox_(ob_x), oy_(ob_y), circle_diameter_(c_dia), point_(point)
+  {
+  }
+
+  template < typename T >
+  bool operator()(const T* const c_p1, /** extrinsic parameters [6] */
+                  const T* const c_p2, /** intrinsic parameters[9] */
+                  T* residual) const
+  {
+    const T* camera_aa(&c_p1[0]);
+    const T* camera_tx(&c_p1[3]);
+    T fx, fy, cx, cy, k1, k2, k3, p1, p2;
+    extractCameraIntrinsics(c_p2, fx, fy, cx, cy, k1, k2, k3, p1, p2);
+    T camera_point[3];        /** point in camera coordinates */
+    T R_optical_to_target[9]; /** rotation from optical frame to target frame */
+    T circle_diameter = T(circle_diameter_);
+    T ox = T(ox_);
+    T oy = T(oy_);
+    T point[3];
+    point[0] = T(point_.x);
+    point[1] = T(point_.y);
+    point[2] = T(point_.z);
+
+    /** get necessary rotation matrices */
+    ceres::AngleAxisToRotationMatrix(camera_aa, R_optical_to_target);
+
+    /** transform point into camera coordinates */
+    transformPoint(camera_aa, camera_tx, point, camera_point);
+
+    /** compute project point into image plane and compute residual */
+    cameraCircResidualDist(camera_point, circle_diameter, R_optical_to_target, k1, k2, k3, p1, p2, fx, fy, cx, cy, ox,
+                           oy, residual);
+
+    return true;
+  } /** end of operator() */
+
+  /** Factory to hide the construction of the CostFunction object from */
+  /** the client code. */
+  static ceres::CostFunction* Create(const double& o_x, const double& o_y, const double& c_dia, Point3d& point)
+  {
+    return (new ceres::AutoDiffCostFunction< SimpleCircleTargetCameraReprjErrorWithDistortionPK, 2, 6, 9 >(
+        new SimpleCircleTargetCameraReprjErrorWithDistortionPK(o_x, o_y, c_dia, point)));
+  }
+  double ox_;               /** observed x location of object in image */
+  double oy_;               /** observed y location of object in image */
+  double circle_diameter_;  //** diameter of circle being observed */
+  Point3d point_;           /** point expressed in target coordinates */
+};
+
+class CircleTargetCameraReprjErrorWithDistortionPK
+{
+public:
+  CircleTargetCameraReprjErrorWithDistortionPK(const double ob_x, const double ob_y, const double c_dia,
+                                               const Point3d point)
+    : ox_(ob_x), oy_(ob_y), circle_diameter_(c_dia), point_(point)
+  {
+  }
+
+  template < typename T >
+  bool operator()(const T* const c_p1, /** extrinsic parameters [6] */
+                  const T* const c_p2, /** 6Dof transform of target into world frame [6] */
+                  const T* const c_p3, /** intrinsic parameters of camera fx,fy,cx,cy,k1,k2,k2,p1,p2 [9] */
+                  T* residual) const
+  {
+    const T* camera_aa(&c_p1[0]);
+    const T* camera_tx(&c_p1[3]);
+    const T* target_aa(&c_p3[0]);
+    const T* target_tx(&c_p3[3]);
+    T fx, fy, cx, cy, k1, k2, k3, p1, p2;
+    extractCameraIntrinsics(c_p2, fx, fy, cx, cy, k1, k2, k3, p1, p2);
+    T world_point[3];  /** point in world coordinates */
+    T camera_point[3]; /** point in world coordinates */
+    T R_WtoC[9];       // rotation from world to camera coordinates
+    T R_TtoW[9];       // rotation from target to world coordinates
+    T R_TtoC[9];  // rotation from target to camera coordinates (assume circle lies in x-y plane of target coordinates)
+
+    /** compute necessary rotation matrices */
+    ceres::AngleAxisToRotationMatrix(camera_aa, R_WtoC);
+    ceres::AngleAxisToRotationMatrix(target_aa, R_TtoW);
+
+    /** transform point into camera coordinates */
+    transformPoint3d(target_aa, target_tx, point_, world_point);
+    transformPoint(camera_aa, camera_tx, world_point, camera_point);
+
+    // find rotation from target to camera coordinates
+    rotationProduct(R_WtoC, R_TtoW, R_TtoC);  // R_WtoC*R_TtoW = R_TtoC
+
+    /** compute project point into image plane and compute residual */
+    T circle_diameter = T(circle_diameter_);
+    T ox = T(ox_);
+    T oy = T(oy_);
+    cameraCircResidualDist(camera_point, circle_diameter, R_TtoC, k1, k2, k3, p1, p2, fx, fy, cx, cy, ox, oy, residual);
+
+    return true;
+  } /** end of operator() */
+
+  /** Factory to hide the construction of the CostFunction object from */
+  /** the client code. */
+  static ceres::CostFunction* Create(const double o_x, const double o_y, const double c_dia, Point3d point)
+  {
+    return (new ceres::AutoDiffCostFunction< CircleTargetCameraReprjErrorWithDistortionPK, 2, 6, 6, 9 >(
+        new CircleTargetCameraReprjErrorWithDistortionPK(o_x, o_y, c_dia, point)));
+  }
+  double ox_;               /** observed x location of object in image */
+  double oy_;               /** observed y location of object in image */
+  double circle_diameter_;  //** diameter of circle being observed */
+  Point3d point_;
+};
+
+class CircleTargetCameraReprjError
+{
+public:
+  CircleTargetCameraReprjError(double ob_x, double ob_y, double c_dia, double fx, double fy, double cx, double cy)
+    : ox_(ob_x), oy_(ob_y), circle_diameter_(c_dia), fx_(fx), fy_(fy)
+  {
+  }
+
+  template < typename T >
+  bool operator()(const T* const c_p1,  /** extrinsic parameters [6]*/
+                  const T* const c_p2,  /** 6Dof transform of target into world frame [6]*/
+                  const T* const point, /** point described in target frame that is being seen [3]*/
+                  T* residual) const
+  {
+    const T* camera_aa(&c_p1[0]);
+    const T* camera_tx(&c_p1[3]);
+    const T* target_aa(&c_p2[0]);
+    const T* target_tx(&c_p2[3]);
+    T world_point[3];  /** point in world coordinates */
+    T camera_point[3]; /** point in camera coordinates*/
+    T R_WtoC[9];       // rotation from world to camera coordinates
+    T R_TtoW[9];       // rotation from target to world coordinates
+    T R_TtoC[9];  // rotation from target to camera coordinates (assume circle lies in x-y plane of target coordinates)
+
+    /** compute necessary rotation matrices */
+    ceres::AngleAxisToRotationMatrix(camera_aa, R_WtoC);
+    ceres::AngleAxisToRotationMatrix(target_aa, R_TtoW);
+
+    /** transform point into camera coordinates */
+    transformPoint(target_aa, target_tx, point, world_point);
+    transformPoint(camera_aa, camera_tx, world_point, camera_point);
+
+    /** find rotation from target to camera coordinates */
+    rotationProduct(R_WtoC, R_TtoW, R_TtoC);  // R_WtoC*R_TtoW = R_TtoC
+
+    /** compute project point into image plane and compute residual */
+    T circle_diameter = T(circle_diameter_);
+    T fx = T(fx_);
+    T fy = T(fy_);
+    T cx = T(cx_);
+    T cy = T(cy_);
+    T ox = T(ox_);
+    T oy = T(oy_);
+    cameraCircResidual(camera_point, circle_diameter, R_TtoC, fx, fy, cx, cy, ox, oy, residual);
+
+    return true;
+  } /** end of operator() */
+
+  /** Factory to hide the construction of the CostFunction object from */
+  /** the client code. */
+  static ceres::CostFunction* Create(const double o_x, const double o_y, const double c_dia, const double fx,
+                                     const double fy, const double cx, const double cy)
+  {
+    return (new ceres::AutoDiffCostFunction< CircleTargetCameraReprjError, 2, 6, 6, 3 >(
+        new CircleTargetCameraReprjError(o_x, o_y, c_dia, fx, fy, cx, cy)));
+  }
+  double ox_;               /** observed x location of object in image */
+  double oy_;               /** observed y location of object in image */
+  double circle_diameter_;  //** diameter of circle being observed */
+  double fx_;               /** focal length of camera in x (pixels) */
+  double fy_;               /** focal length of camera in y (pixels) */
+  double cx_;               /** focal center of camera in x (pixels) */
+  double cy_;               /** focal center of camera in y (pixels) */
+};
+
+class CircleTargetCameraReprjErrorPK
+{
+public:
+  CircleTargetCameraReprjErrorPK(double ob_x, double ob_y, double c_dia, double fx, double fy, double cx, double cy,
+                                 Point3d point)
+    : ox_(ob_x), oy_(ob_y), circle_diameter_(c_dia), fx_(fx), fy_(fy), cx_(cx), cy_(cy), point_(point)
+  {
+  }
+
+  template < typename T >
+  bool operator()(const T* const c_p1, /** extrinsic parameters [6] */
+                  const T* const c_p2, /** 6Dof transform of target into world frame [6] */
+                  T* residual) const
+  {
+    const T* camera_aa(&c_p1[0]);
+    const T* camera_tx(&c_p1[3]);
+    const T* target_aa(&c_p2[0]);
+    const T* target_tx(&c_p2[3]);
+    T world_point[3];  /** point in world coordinates */
+    T camera_point[3]; /** point in camera coordinates */
+    T R_WtoC[9];       // rotation from world to camera coordinates
+    T R_TtoW[9];       // rotation from target to world coordinates
+    T R_TtoC[9];  // rotation from target to camera coordinates (assume circle lies in x-y plane of target coordinates)
+
+    /** compute necessary rotation matrices */
+    ceres::AngleAxisToRotationMatrix(camera_aa, R_WtoC);
+    ceres::AngleAxisToRotationMatrix(target_aa, R_TtoW);
+
+    /** transform point into camera frame */
+    transformPoint3d(target_aa, target_tx, point_, world_point);
+    transformPoint(camera_aa, camera_tx, world_point, camera_point);
+
+    /** find rotation from target to camera coordinates */
+    rotationProduct(R_WtoC, R_TtoW, R_TtoC);  // R_WtoC*R_TtoW = R_TtoC
+
+    /** compute project point into image plane and compute residual */
+    T circle_diameter = T(circle_diameter_);
+    T fx = T(fx_);
+    T fy = T(fy_);
+    T cx = T(cx_);
+    T cy = T(cy_);
+    T ox = T(ox_);
+    T oy = T(oy_);
+    cameraCircResidual(camera_point, circle_diameter, R_TtoC, fx, fy, cx, cy, ox, oy, residual);
+
+    return true;
+  } /** end of operator() */
+
+  /** Factory to hide the construction of the CostFunction object from */
+  /** the client code. */
+  static ceres::CostFunction* Create(const double o_x, const double o_y, const double c_dia, const double fx,
+                                     const double fy, const double cx, const double cy, Point3d point)
+  {
+    return (new ceres::AutoDiffCostFunction< CircleTargetCameraReprjErrorPK, 2, 6, 6 >(
+        new CircleTargetCameraReprjErrorPK(o_x, o_y, c_dia, fx, fy, cx, cy, point)));
+  }
+  double ox_;               /** observed x location of object in image */
+  double oy_;               /** observed y location of object in image */
+  double circle_diameter_;  //** diameter of circle being observed */
+  double fx_;               /** focal length of camera in x (pixels) */
+  double fy_;               /** focal length of camera in y (pixels) */
+  double cx_;               /** focal center of camera in x (pixels) */
+  double cy_;               /** focal center of camera in y (pixels) */
+  Point3d point_;
+};
+
+class LinkCircleTargetCameraReprjError
+{
+public:
+  LinkCircleTargetCameraReprjError(double ob_x, double ob_y, double c_dia, double fx, double fy, double cx, double cy,
+                                   Pose6d link_pose)
+    : ox_(ob_x), oy_(ob_y), circle_diameter_(c_dia), fx_(fx), fy_(fy), cx_(cx), cy_(cy), link_pose_(link_pose)
+  {
+  }
+
+  template < typename T >
+  bool operator()(const T* const c_p1,  /** extrinsic parameters [6]*/
+                  const T* const c_p2,  /** 6Dof transform of target into world frame [6]*/
+                  const T* const point, /** point described in target frame that is being seen [3]*/
+                  T* residual) const
+  {
+    const T* camera_aa(&c_p1[0]);
+    const T* camera_tx(&c_p1[3]);
+    const T* target_aa(&c_p2[0]);
+    const T* target_tx(&c_p2[3]);
+    T link_point[3];   /** point in link coordinates */
+    T world_point[3];  /** point in world coordinates */
+    T camera_point[3]; /** point in camera coordinates*/
+    T R_WtoC[9];       // rotation from world to camera coordinates
+    T R_TtoL[9];       // rotation from target to linkcoordinates
+    T R_LtoW[9];       // rotation from link to world coordinates
+    T R_TtoC[9];  // rotation from target to camera coordinates (assume circle lies in x-y plane of target coordinates)
+    T R_LtoC[9];  // rotation from link to camera coordinates
+
+    /** get necessary rotation matrices */
+    ceres::AngleAxisToRotationMatrix(camera_aa, R_WtoC);
+    ceres::AngleAxisToRotationMatrix(target_aa, R_TtoL);
+    poseRotationMatrix(link_pose_, R_LtoW);
+
+    /** transform point into camera coordinates */
+    transformPoint(target_aa, target_tx, point, link_point);
+    poseTransformPoint(link_pose_, link_point, world_point);
+    transformPoint(camera_aa, camera_tx, world_point, camera_point);
+
+    /** find rotation from target to camera coordinates */
+    rotationProduct(R_WtoC, R_LtoW, R_LtoC);
+    rotationProduct(R_LtoC, R_TtoL, R_TtoC);  // R_WtoC*R_LtoW*R_TtoL = R_TtoC
+
+    /** compute project point into image plane and compute residual */
+    T circle_diameter = T(circle_diameter_);
+    T fx = T(fx_);
+    T fy = T(fy_);
+    T cx = T(cx_);
+    T cy = T(cy_);
+    T ox = T(ox_);
+    T oy = T(oy_);
+    cameraCircResidual(camera_point, circle_diameter, R_TtoC, fx, fy, cx, cy, ox, oy, residual);
+
+    return true;
+  } /** end of operator() */
+
+  /** Factory to hide the construction of the CostFunction object from */
+  /** the client code. */
+  static ceres::CostFunction* Create(const double o_x, const double o_y, const double c_dia, const double fx,
+                                     const double fy, const double cx, const double cy, const Pose6d pose)
+  {
+    return (new ceres::AutoDiffCostFunction< LinkCircleTargetCameraReprjError, 2, 6, 6, 3 >(
+        new LinkCircleTargetCameraReprjError(o_x, o_y, c_dia, fx, fy, cx, cy, pose)));
+  }
+  double ox_;              /** observed x location of object in image */
+  double oy_;              /** observed y location of object in image */
+  double circle_diameter_; /** diameter of circle being observed */
+  Pose6d link_pose_;       /** transform from link to world coordinates*/
+  double fx_;              /** focal length of camera in x (pixels) */
+  double fy_;              /** focal length of camera in y (pixels) */
+  double cx_;              /** focal center of camera in x (pixels) */
+  double cy_;              /** focal center of camera in y (pixels) */
+};
+
+class LinkCircleTargetCameraReprjErrorPK
+{
+public:
+  LinkCircleTargetCameraReprjErrorPK(double ob_x, double ob_y, double c_dia, double fx, double fy, double cx, double cy,
+                                     Pose6d link_pose, Point3d point)
+    : ox_(ob_x)
+    , oy_(ob_y)
+    , circle_diameter_(c_dia)
+    , fx_(fx)
+    , fy_(fy)
+    , cx_(cx)
+    , cy_(cy)
+    , link_pose_(link_pose)
+    , point_(point)
+  {
+  }
+
+  template < typename T >
+  bool operator()(const T* const c_p1, /** extrinsic parameters [6] */
+                  const T* const c_p2, /** 6Dof transform of target into world frame [6] */
+                  T* residual) const
+  {
+    const T* camera_aa(&c_p1[0]);
+    const T* camera_tx(&c_p1[3]);
+    const T* target_aa(&c_p2[0]);
+    const T* target_tx(&c_p2[3]);
+    T link_point[3];   /** point in link coordinates */
+    T world_point[3];  /** point in world coordinates */
+    T camera_point[3]; /** point in camera coordinates */
+    T R_WtoC[9];       // rotation from world to camera coordinates
+    T R_TtoL[9];       // rotation from target to linkcoordinates
+    T R_LtoW[9];       // rotation from link to world coordinates
+    T R_LtoC[9];       // rotation from link to camera coordinataes
+    T R_TtoC[9];  // rotation from target to camera coordinates (assume circle lies in x-y plane of target coordinates)
+
+    /** compute necessary rotation matrices */
+    ceres::AngleAxisToRotationMatrix(camera_aa, R_WtoC);
+    ceres::AngleAxisToRotationMatrix(target_aa, R_TtoL);
+    poseRotationMatrix(link_pose_, R_LtoW);
+
+    /** transform point into camera frame */
+    transformPoint3d(target_aa, target_tx, point_, link_point);
+    poseTransformPoint(link_pose_, link_point, world_point);
+    transformPoint(camera_aa, camera_tx, world_point, camera_point);
+
+    /** find rotation from target to camera coordinates */
+    rotationProduct(R_WtoC, R_LtoW, R_LtoC);
+    rotationProduct(R_LtoC, R_TtoL, R_TtoC);  // R_WtoC*R_LtoW*R_TtoL = R_TtoC
+
+    /** compute project point into image plane and compute residual */
+    T circle_diameter = T(circle_diameter_);
+    T fx = T(fx_);
+    T fy = T(fy_);
+    T cx = T(cx_);
+    T cy = T(cy_);
+    T ox = T(ox_);
+    T oy = T(oy_);
+    cameraCircResidual(camera_point, circle_diameter, R_TtoC, fx, fy, cx, cy, ox, oy, residual);
+
+    return true;
+  } /** end of operator() */
+
+  /** Factory to hide the construction of the CostFunction object from */
+  /** the client code. */
+  static ceres::CostFunction* Create(const double o_x, const double o_y, const double c_dia, const double fx,
+                                     const double fy, const double cx, const double cy, const Pose6d pose,
+                                     Point3d point)
+  {
+    return (new ceres::AutoDiffCostFunction< LinkCircleTargetCameraReprjErrorPK, 2, 6, 6 >(
+        new LinkCircleTargetCameraReprjErrorPK(o_x, o_y, c_dia, fx, fy, cx, cy, pose, point)));
+  }
+  double ox_;               /** observed x location of object in image */
+  double oy_;               /** observed y location of object in image */
+  double circle_diameter_;  //** diameter of circle being observed */
+  Pose6d link_pose_;        /** transform from link to world coordinates*/
+  double fx_;               /** focal length of camera in x (pixels) */
+  double fy_;               /** focal length of camera in y (pixels) */
+  double cx_;               /** focal center of camera in x (pixels) */
+  double cy_;               /** focal center of camera in y (pixels) */
+  Point3d point_;           /** point expressed in target coordinates */
+};
+
+class LinkCameraCircleTargetReprjError
+{
+public:
+  LinkCameraCircleTargetReprjError(double ob_x, double ob_y, double c_dia, double fx, double fy, double cx, double cy,
+                                   Pose6d link_pose)
+    : ox_(ob_x), oy_(ob_y), circle_diameter_(c_dia), fx_(fx), fy_(fy), cx_(cx), cy_(cy), link_pose_(link_pose)
+  {
+    link_posei_ = link_pose_.getInverse();
+  }
+
+  template < typename T >
+  bool operator()(const T* const c_p1,  /** extrinsic parameters [6]*/
+                  const T* const c_p2,  /** 6Dof transform of target into world frame [6]*/
+                  const T* const point, /** point described in target frame that is being seen [3]*/
+                  T* residual) const
+  {
+    const T* camera_aa(&c_p1[0]);
+    const T* camera_tx(&c_p1[3]);
+    const T* target_aa(&c_p2[0]);
+    const T* target_tx(&c_p2[3]);
+    T world_point[3];  /** point in world coordinates */
+    T link_point[3];   /** point in link coordinates */
+    T camera_point[3]; /** point in camera coordinates*/
+    T R_LtoC[9];       // rotation from link to camera coordinates
+    T R_WtoL[9];       // rotation from world to link coordinates
+    T R_WtoC[9];       // rotation from world to camera coordinates, and intermediate transform
+    T R_TtoW[9];       // rotation from target to world coordinates
+    T R_TtoC[9];  // rotation from target to camera coordinates (assume circle lies in x-y plane of target coordinates)
+
+    /** compute necessary rotation matrices */
+    ceres::AngleAxisToRotationMatrix(camera_aa, R_LtoC);
+    poseRotationMatrix(link_pose_, R_WtoL);
+    ceres::AngleAxisToRotationMatrix(target_aa, R_TtoW);
+
+    /** transform point into camera coordinates */
+    transformPoint(target_aa, target_tx, point, world_point);
+    poseTransformPoint(link_posei_, world_point, link_point);
+    transformPoint(camera_aa, camera_tx, link_point, camera_point);
+
+    /** find rotation from target to camera coordinates */
+    rotationProduct(R_LtoC, R_WtoL, R_WtoC);
+    rotationProduct(R_WtoC, R_TtoW, R_TtoC);
+
+    /** compute project point into image plane and compute residual */
+    T circle_diameter = T(circle_diameter_);
+    T fx = T(fx_);
+    T fy = T(fy_);
+    T cx = T(cx_);
+    T cy = T(cy_);
+    T ox = T(ox_);
+    T oy = T(oy_);
+    cameraCircResidual(camera_point, circle_diameter, R_TtoC, fx, fy, cx, cy, ox, oy, residual);
+
+    return true;
+  } /** end of operator() */
+
+  /** Factory to hide the construction of the CostFunction object from */
+  /** the client code. */
+  static ceres::CostFunction* Create(const double o_x, const double o_y, const double c_dia, double fx, double fy,
+                                     double cx, double cy, const Pose6d pose)
+  {
+    return (new ceres::AutoDiffCostFunction< LinkCameraCircleTargetReprjError, 2, 6, 6, 3 >(
+        new LinkCameraCircleTargetReprjError(o_x, o_y, c_dia, fx, fy, cx, cy, pose)));
+  }
+  double ox_;              /** observed x location of object in image */
+  double oy_;              /** observed y location of object in image */
+  double circle_diameter_; /** diameter of circle being observed */
+  Pose6d link_pose_;       /** transform from link to world coordinates*/
+  Pose6d link_posei_;      /** transform from world to link coordinates*/
+  double fx_;              /** focal length of camera in x (pixels) */
+  double fy_;              /** focal length of camera in y (pixels) */
+  double cx_;              /** focal center of camera in x (pixels) */
+  double cy_;              /** focal center of camera in y (pixels) */
+};
+
+class LinkCameraCircleTargetReprjErrorPK
+{
+public:
+  LinkCameraCircleTargetReprjErrorPK(const double& ob_x, const double& ob_y, const double& c_dia, const double& fx,
+                                     const double& fy, const double& cx, const double& cy, const Pose6d& link_pose,
+                                     const Point3d& point)
+    : ox_(ob_x)
+    , oy_(ob_y)
+    , circle_diameter_(c_dia)
+    , fx_(fx)
+    , fy_(fy)
+    , cx_(cx)
+    , cy_(cy)
+    , link_pose_(link_pose)
+    , point_(point)
+  {
+    link_posei_ = link_pose_.getInverse();
+  }
+
+  void test_residual(const double* c_p1, const double* c_p2, double* residual)
+  {
+    const double* camera_aa(&c_p1[0]);
+    const double* camera_tx(&c_p1[3]);
+    const double* target_aa(&c_p2[0]);
+    const double* target_tx(&c_p2[3]);
+    double point[3];        /** point in target coordinates */
+    double world_point[3];  /** point in world coordinates */
+    double link_point[3];   /** point in link coordinates */
+    double camera_point[3]; /** point in camera coordinates*/
+    double R_LtoC[9];       // rotation from link to camera coordinates
+    double R_WtoL[9];       // rotation from world to link coordinates
+    double R_WtoC[9];       // rotation from world to camera coordinates, and intermediate transform
+    double R_TtoW[9];       // rotation from target to world coordinates
+    double R_TtoC[9];       // rotation from target to camera coordinates (assume circle lies in x-y plane of target
+                            // coordinates)
+    /** get necessary rotation matrices */
+    ceres::AngleAxisToRotationMatrix(camera_aa, R_LtoC);
+    printf("camera_aa = %6.3lf %6.3lf %6.3lf\n", camera_aa[0], camera_aa[1], camera_aa[2]);
+    printf("R_camera \n");
+    for (int i = 0; i < 3; i++)
+    {
+      for (int j = 0; j < 3; j++)
+      {
+        printf("%6.3lf", R_LtoC[i + j * 3]);
       }
+      printf("\n");
     }
-    
-    /* temporary variables for distortion model */
-    T xp2 = xp * xp;		/* x^2 */
-    T yp2 = yp * yp;		/* y^2 */
-    T r2  = xp2 + yp2;	/* r^2 radius squared */
-    T r4  = r2 * r2;		/* r^4 */
-    T r6  = r2 * r4;		/* r^6 */
-    
-    /* apply the distortion coefficients to refine pixel location */
-    T xpp = xp 
-      + k1 * r2 * xp		// 2nd order term
-      + k2 * r4 * xp		// 4th order term
-      + k3 * r6 * xp		// 6th order term
-      + p2 * (r2 + T(2.0) * xp2) // tangential
-      + p1 * xp * yp * T(2.0); // other tangential term
-    T ypp = yp 
-      + k1 * r2 * yp		// 2nd order term
-      + k2 * r4 * yp		// 4th order term
-      + k3 * r6 * yp		// 6th order term
-      + p1 * (r2 + T(2.0) * yp2) // tangential term
-      + p2 * xp * yp * T(2.0); // other tangential term
-    
-    /** perform projection using focal length and camera center into image plane */
-    residual[0] = fx * xpp + cx - ox;
-    residual[1] = fy * ypp + cy - oy;
+    poseRotationMatrix(link_posei_, R_WtoL);
+    printf("R_inverse link\n");
+    for (int i = 0; i < 3; i++)
+    {
+      for (int j = 0; j < 3; j++)
+      {
+        printf("%6.3lf", R_WtoL[i + j * 3]);
+      }
+      printf("\n");
+    }
+
+    ceres::AngleAxisToRotationMatrix(target_aa, R_TtoW);
+    printf("R_target\n");
+    for (int i = 0; i < 3; i++)
+    {
+      for (int j = 0; j < 3; j++)
+      {
+        printf("%6.3lf", R_TtoW[i + j * 3]);
+      }
+      printf("\n");
+    }
+
+    printf("point_ = %6.3lf  %6.3lf %6.3lf\n", point_.x, point_.y, point_.z);
+    /** transform point into camera coordinates */
+    transformPoint3d(target_aa, target_tx, point_, world_point);
+    printf("world_point = %6.3lf  %6.3lf %6.3lf\n", world_point[0], world_point[1], world_point[2]);
+    poseTransformPoint(link_posei_, world_point, link_point);
+    printf("link_point = %6.3lf  %6.3lf %6.3lf\n", link_point[0], link_point[1], link_point[2]);
+    transformPoint(camera_aa, camera_tx, link_point, camera_point);
+    printf("camera_point = %6.3lf  %6.3lf %6.3lf\n", camera_point[0], camera_point[1], camera_point[2]);
+
+    /** find rotation from target to camera coordinates */
+    rotationProduct(R_LtoC, R_WtoL, R_WtoC);
+    rotationProduct(R_WtoC, R_TtoW, R_TtoC);
+
+    /** compute project point into image plane and compute residual */
+    double circle_diameter = circle_diameter_;
+    double fx = fx_;
+    double fy = fy_;
+    double cx = cx_;
+    double cy = cy_;
+    double ox = ox_;
+    double oy = oy_;
+    //      cameraCircResidual(camera_point, circle_diameter, R_TtoC, fx, fy,cx,cy, ox, oy, residual);
+    cameraPntResidual(camera_point, fx, fy, cx, cy, ox, oy, residual);
+  }
+  template < typename T >
+  bool operator()(const T* const c_p1, /** extrinsic parameters [6] */
+                  const T* const c_p2, /** 6Dof transform of target into world frame [6] */
+                  T* residual) const
+  {
+    const T* camera_aa(&c_p1[0]);
+    const T* camera_tx(&c_p1[3]);
+    const T* target_aa(&c_p2[0]);
+    const T* target_tx(&c_p2[3]);
+    T point[3];        /** point in target coordinates */
+    T world_point[3];  /** point in world coordinates */
+    T link_point[3];   /** point in link coordinates */
+    T camera_point[3]; /** point in camera coordinates*/
+    T R_LtoC[9];       // rotation from link to camera coordinates
+    T R_WtoL[9];       // rotation from world to link coordinates
+    T R_WtoC[9];       // rotation from world to camera coordinates, and intermediate transform
+    T R_TtoW[9];       // rotation from target to world coordinates
+    T R_TtoC[9];  // rotation from target to camera coordinates (assume circle lies in x-y plane of target coordinates)
+
+    /** get necessary rotation matrices */
+    ceres::AngleAxisToRotationMatrix(camera_aa, R_LtoC);
+    poseRotationMatrix(link_posei_, R_WtoL);
+    ceres::AngleAxisToRotationMatrix(target_aa, R_TtoW);
+
+    /** transform point into camera coordinates */
+    transformPoint3d(target_aa, target_tx, point_, world_point);
+    poseTransformPoint(link_posei_, world_point, link_point);
+    transformPoint(camera_aa, camera_tx, link_point, camera_point);
+
+    /** find rotation from target to camera coordinates */
+    rotationProduct(R_LtoC, R_WtoL, R_WtoC);
+    rotationProduct(R_WtoC, R_TtoW, R_TtoC);
+
+    /** compute project point into image plane and compute residual */
+    T circle_diameter = T(circle_diameter_);
+    T fx = T(fx_);
+    T fy = T(fy_);
+    T cx = T(cx_);
+    T cy = T(cy_);
+    T ox = T(ox_);
+    T oy = T(oy_);
+    cameraCircResidual(camera_point, circle_diameter, R_TtoC, fx, fy, cx, cy, ox, oy, residual);
+
+    return true;
+  } /** end of operator() */
+
+  /** Factory to hide the construction of the CostFunction object from */
+  /** the client code. */
+  static ceres::CostFunction* Create(const double& o_x, const double& o_y, const double& c_dia, const double& fx,
+                                     const double& fy, const double& cx, const double& cy, const Pose6d& pose,
+                                     Point3d& point)
+  {
+    return (new ceres::AutoDiffCostFunction< LinkCameraCircleTargetReprjErrorPK, 2, 6, 6 >(
+        new LinkCameraCircleTargetReprjErrorPK(o_x, o_y, c_dia, fx, fy, cx, cy, pose, point)));
+  }
+  double ox_;               /** observed x location of object in image */
+  double oy_;               /** observed y location of object in image */
+  double circle_diameter_;  //** diameter of circle being observed */
+  Pose6d link_pose_;        /** transform from link to world coordinates*/
+  Pose6d link_posei_;       /** transform from world to link coordinates*/
+  double fx_;               /** focal length of camera in x (pixels) */
+  double fy_;               /** focal length of camera in y (pixels) */
+  double cx_;               /** focal center of camera in x (pixels) */
+  double cy_;               /** focal center of camera in y (pixels) */
+  Point3d point_;           /** point expressed in target coordinates */
+};
+
+class FixedCircleTargetCameraReprjErrorPK
+{
+public:
+  FixedCircleTargetCameraReprjErrorPK(const double& ob_x, const double& ob_y, const double& c_dia, const double& fx,
+                                      const double& fy, const double& cx, const double& cy, const Pose6d& target_pose,
+                                      const Pose6d& camera_mounting_pose, const Point3d& point)
+    : ox_(ob_x)
+    , oy_(ob_y)
+    , circle_diameter_(c_dia)
+    , fx_(fx)
+    , fy_(fy)
+    , cx_(cx)
+    , cy_(cy)
+    , target_pose_(target_pose)
+    , camera_mounting_pose_(camera_mounting_pose)
+    , point_(point)
+  {
+    // compute pose which transforms point in target frame to the mounting frame
+    mount_to_target_pose_ = camera_mounting_pose_.getInverse() * target_pose_;
   }
 
-  /*! \brief ceres compliant function to compute the residual from a pinhole camera model without distortion, in this case,
-   *   the point is actually a planar circle with some diameter. There observation is not the projected center,
-   *   but is offset due to the angle between the plane and the imaging plane
-   *  @param point[3] the input point
-   *  @param circle_diameter the diameter of the circle being observed
-   *  @param fx focal length in x
-   *  @param fy focal length in y
-   *  @param cx optical center in x
-   *  @param cy optical center in y
-   *  @param ox observation in x
-   *  @param oy observation in y
-   *  @param residual the output or difference between where the point should appear given the parameters, and where it was observed
-   */
-  template<typename T>  void cameraCircResidual(T point[3], T &circle_diameter, T R_TtoC[9],
-						      T &fx, T &fy, T &cx, T &cy, T &ox, T &oy, T residual[2]);
-  template<typename T> inline void cameraCircResidual(T point[3], T &circle_diameter, T R_TtoC[9],
-						      T &fx, T &fy, T &cx, T &cy, T &ox, T &oy, T residual[2])
+  void test_residual(const double* c_p1, double* resid)
   {
-    T xp1 = point[0];
-    T yp1 = point[1];
-    T zp1 = point[2];
-    
-    // Circle Delta is the difference between the projection of the center of the circle
-    // and the center of the projected ellipse 
-    
-    // find rotation from target coordinates into camera coordinates
-    // The 3 columns represent:
-    // 1. the x-axis of the target in camera coordinates
-    // 2. the y-axis of the target in camera coordinates
-    // 3. the z-axis (normal of the target plane) in camera coordinates
-    // NOTE: we assume target is an XY planar target (all points on target have nominal z=0)
-    
-    // Find projection of distance vector D = [xp1 yp1 zp1] on to plane of target
-    T D_targetx = xp1*R_TtoC[0] + yp1*R_TtoC[1] + zp1*R_TtoC[2];
-    T D_targety = xp1*R_TtoC[3] + yp1*R_TtoC[4] + zp1*R_TtoC[5];
-    
-    // projection of D onto target xy plane expressed in camera frame is given by 
-    // D_targetx * R_TtoC(1stcol) + D_targety * R_TtoC(2ndcol)
-    
-    // The vector of interest "Vperp" is orthogonal to this in the target xy plane
-    // Vperp = -D_targety * R_TtoC(1stcol) + D_targetx * R_TtoC(2ndcol)
-    // However we want Vperp to be in the direction with a negative z component
-    
-    T Vperp[3]; 
-    Vperp[0] = -D_targety*R_TtoC[0] + D_targetx*R_TtoC[3] ;
-    Vperp[1] = -D_targety*R_TtoC[1] + D_targetx*R_TtoC[4] ;
-    Vperp[2] = -D_targety*R_TtoC[2] + D_targetx*R_TtoC[5] ;
-    
-    // Vector direction of Vperp is arbitrary, but need to specify direction closer to camera
-    T mysign;
-    if(Vperp[2]*Vperp[2] > T(0.0)){
-      mysign = -abs(Vperp[2])/Vperp[2]; 
-    }
-    else{
-      mysign = T(1);
-    }
-    Vperp[0] = mysign*Vperp[0];
-    Vperp[1] = mysign*Vperp[1];
-    Vperp[2] = mysign*Vperp[2];
-    
-    /** scale into the image plane by distance away from camera */
-    T xp = xp1 / zp1;
-    T yp = yp1 / zp1;
-    
-    if(zp1+Vperp[2] !=0.0){	// adjust only focal plan not parallel to target's xy plane
-      T Vpx = (xp1+Vperp[0])/(zp1+Vperp[2]);
-      T Vpy = (yp1+Vperp[1])/(zp1+Vperp[2]);
-      T Vnorm = sqrt(Vpx*Vpx+Vpy*Vpy);
-      if(Vnorm!=0.0){
-	// find scale of motion
-	// Delta = (r*sin(theta)/(D-rcos(theta)) - r*sin(theta)/(D+rcos(theta)))/2
-	// where r is the radius of the circle being projected
-	//       D is the distance between camera and circle center
-	//       theta is the angle between D vector an target xy plane
-	Vpx = Vpx/Vnorm;
-	Vpy = Vpy/Vnorm;
-	T D = sqrt(xp1*xp1 + yp1*yp1 + zp1*zp1);
-	T s_theta = (R_TtoC[6]*xp1 + R_TtoC[7]*yp1 + R_TtoC[8]*zp1)/D;
-	T c_theta = sqrt( T(1.0) - s_theta*s_theta);
-	T r = T(circle_diameter/2.0);
-	T Delta = r*s_theta*(T(1.0)/(D-r*c_theta) - T(1.0)/(D+r*c_theta))/T(2.0);
-	xp = xp + Delta*Vpx;
-	yp = yp + Delta*Vpy;
-      }
-    }
-    
-    /** perform projection using focal length and camera center into image plane */
-    residual[0] = fx * xp + cx - ox;
-    residual[1] = fy * yp + cy - oy;
+    const double* camera_aa(&c_p1[0]);
+    const double* camera_tx(&c_p1[3]);
+    double mount_point[3];  /** point in world coordinates */
+    double camera_point[3]; /** point in camera coordinates */
+    double point[3];        /** point in world coordinates  */
+    point[0] = point_.x;
+    point[1] = point_.y;
+    point[2] = point_.z;
+    /** transform point into camera coordinates */
+    poseTransformPoint(mount_to_target_pose_, point, mount_point);
+    printf("mount_point = %6.3lf  %6.3lf %6.3lf\n", mount_point[0], mount_point[1], mount_point[2]);
+    transformPoint(camera_aa, camera_tx, mount_point, camera_point);
+    printf("camera_point = %6.3lf  %6.3lf %6.3lf\n", camera_point[0], camera_point[1], camera_point[2]);
+
+    double R_optical_to_mount[9]; /** rotation from optical to camera mounting frame */
+    double R_mount_to_target[9];  /** rotation from mounting frame to target frame */
+
+    /** get necessary rotation matrices */
+    ceres::AngleAxisToRotationMatrix(camera_aa, R_optical_to_mount);
+    poseRotationMatrix(mount_to_target_pose_, R_mount_to_target);
+
+    /** compute project point into image plane and compute residual */
+    double circle_diameter = circle_diameter_;
+    double fx = fx_;
+    double fy = fy_;
+    double cx = cx_;
+    double cy = cy_;
+    double ox = ox_;
+    double oy = oy_;
+    cameraCircResidual(camera_point, circle_diameter, R_mount_to_target, fx, fy, cx, cy, ox, oy, resid);
+  }
+  template < typename T >
+  bool operator()(const T* const c_p1, /** extrinsic parameters [6] */
+                  T* residual) const
+  {
+    const T* camera_aa(&c_p1[0]);
+    const T* camera_tx(&c_p1[3]);
+    T mount_point[3];         /** point in world coordinates */
+    T camera_point[3];        /** point in camera coordinates */
+    T R_optical_to_mount[9];  /** rotation from optical to camera mounting frame */
+    T R_mount_to_target[9];   /** rotation from mounting frame to target frame */
+    T R_optical_to_target[9]; /** rotation from optical frame to target frame */
+    T point[3];
+    point[0] = T(point_.x);
+    point[1] = T(point_.y);
+    point[2] = T(point_.z);
+
+    /** get necessary rotation matrices */
+    ceres::AngleAxisToRotationMatrix(camera_aa, R_optical_to_mount);
+    poseRotationMatrix(mount_to_target_pose_, R_mount_to_target);
+
+    /** transform point into camera coordinates */
+    poseTransformPoint(mount_to_target_pose_, point, mount_point);
+    transformPoint(camera_aa, camera_tx, mount_point, camera_point);
+
+    /** find rotation from target to camera coordinates */
+    rotationProduct(R_optical_to_mount, R_mount_to_target, R_optical_to_target);
+
+    /** compute project point into image plane and compute residual */
+    T circle_diameter = T(circle_diameter_);
+    T fx = T(fx_);
+    T fy = T(fy_);
+    T cx = T(cx_);
+    T cy = T(cy_);
+    T ox = T(ox_);
+    T oy = T(oy_);
+    cameraCircResidual(camera_point, circle_diameter, R_optical_to_target, fx, fy, cx, cy, ox, oy, residual);
+
+    return true;
+  } /** end of operator() */
+
+  /** Factory to hide the construction of the CostFunction object from */
+  /** the client code. */
+  static ceres::CostFunction* Create(const double& o_x, const double& o_y, const double& c_dia, const double& fx,
+                                     const double& fy, const double& cx, const double& cy, const Pose6d& target_pose,
+                                     const Pose6d& camera_mounting_pose, Point3d& point)
+  {
+    return (new ceres::AutoDiffCostFunction< FixedCircleTargetCameraReprjErrorPK, 2, 6 >(
+        new FixedCircleTargetCameraReprjErrorPK(o_x, o_y, c_dia, fx, fy, cx, cy, target_pose, camera_mounting_pose,
+                                                point)));
+  }
+  double ox_;                   /** observed x location of object in image */
+  double oy_;                   /** observed y location of object in image */
+  double circle_diameter_;      //** diameter of circle being observed */
+  Pose6d target_pose_;          /** pose of target relative to the reference coordinate frame */
+  Pose6d camera_mounting_pose_; /** pose camera mounting frame relative to the reference coordinate frame */
+  Pose6d mount_to_target_pose_; /** pose of target frame relative to camera's mounting frame */
+  double fx_;                   /** focal length of camera in x (pixels) */
+  double fy_;                   /** focal length of camera in y (pixels) */
+  double cx_;                   /** focal center of camera in x (pixels) */
+  double cy_;                   /** focal center of camera in y (pixels) */
+  Point3d point_;               /** point expressed in target coordinates */
+};
+
+class RailICal
+{
+public:
+  RailICal(double ob_x, double ob_y, double rail_position, Point3d point)
+    : ox_(ob_x), oy_(ob_y), rail_position_(rail_position), point_(point)
+  {
   }
 
-  /*! \brief ceres compliant function to compute the residual from a pinhole camera model without distortion
-   *  @param point[3] the input point
-   *  @param fx focal length in x
-   *  @param fy focal length in y
-   *  @param cx optical center in x
-   *  @param cy optical center in y
-   *  @param ox observation in x
-   *  @param oy observation in y
-   *  @param residual the output or difference between where the point should appear given the parameters, and where it was observed
-   */
-
-  template<typename T>  void cameraPntResidual(T point[3], T &fx, T &fy, T &cx, T &cy, T &ox, T &oy, T residual[2]);
-  template<typename T> inline void cameraPntResidual(T point[3], T &fx, T &fy, T &cx, T &cy, T &ox, T &oy, T residual[2])
+  template < typename T >
+  bool operator()(const T* const c_p1, /**intrinsics [9] */
+                  const T* const c_p2, /**target_pose [6] */
+                  T* residual) const
   {
-    T xp1 = point[0];
-    T yp1 = point[1];
-    T zp1 = point[2];
+    T fx, fy, cx, cy, k1, k2, k3, p1, p2;  // extract intrinsics
+    extractCameraIntrinsics(c_p1, fx, fy, cx, cy, k1, k2, k3, p1, p2);
+    const T* target_aa(&c_p2[0]);  // extract target's angle axis
+    const T* target_tx(&c_p2[3]);  // extract target's position
 
-    /** scale into the image plane by distance away from camera */
-    T xp,yp;
-    if(zp1==T(0)){ // avoid divide by zero
-      xp =xp1;
-      yp =yp1;
-    }
-    else{
-      xp = xp1 / zp1;
-      yp = yp1 / zp1;
-    }
-    /** perform projection using focal length and camera center into image plane */
-    residual[0] = fx * xp + cx - ox;
-    residual[1] = fy * yp + cy - oy;
+    /** transform point into camera frame */
+    T camera_point[3]; /** point in camera coordinates */
+    transformPoint3d(target_aa, target_tx, point_, camera_point);
+    camera_point[2] = camera_point[2] + T(rail_position_);  // transform to camera's location along rail
 
+    /** compute project point into image plane and compute residual */
+    T ox = T(ox_);
+    T oy = T(oy_);
+    cameraPntResidualDist(camera_point, k1, k2, k3, p1, p2, fx, fy, cx, cy, ox, oy, residual);
+
+    return true;
+  } /** end of operator() */
+
+  /** Factory to hide the construction of the CostFunction object from */
+  /** the client code. */
+  static ceres::CostFunction* Create(const double o_x, const double o_y, const double rail_position, Point3d point)
+  {
+    return (new ceres::AutoDiffCostFunction< RailICal, 2, 9, 6 >(new RailICal(o_x, o_y, rail_position, point)));
   }
-
-  class CameraReprjErrorWithDistortion
-  {
-  public:
-    CameraReprjErrorWithDistortion(double ob_x, double ob_y) :
-      ox_(ob_x), oy_(ob_y)
-    {
-    }
-
-    template<typename T>
-    bool operator()(const T* const c_p1, /** extrinsic parameters */
-                    const T* c_p2, /** intrinsic parameters */
-                    const T* point, /** point being projected, has 3 parameters */
-                    T* residual) const
-    {
-      const T *camera_aa(&c_p1[0]);
-      const T *camera_tx(&c_p1[3]);
-      T fx, fy, cx, cy, k1, k2, k3, p1, p2;
-      extractCameraIntrinsics(c_p2, fx, fy, cx, cy, k1, k2, k3, p1, p2);
-      T camera_point[3]; /** point in camera coordinates*/
-
-      /** transform point into camera coordinates */
-      transformPoint(camera_aa, camera_tx, point, camera_point);
-
-      /** compute project point into image plane and compute residual */
-      T ox = T(ox_);
-      T oy = T(oy_);
-      cameraPntResidualDist(camera_point, k1, k2, k3, p1, p2, fx, fy, cx, cy, ox, oy,  residual);
-
-      return true;
-    } /** end of operator() */
-
-    /** Factory to hide the construction of the CostFunction object from */
-    /** the client code. */
-    static ceres::CostFunction* Create(const double o_x, const double o_y)
-    {
-      return (new ceres::AutoDiffCostFunction<CameraReprjErrorWithDistortion, 2, 6, 9, 3>(new CameraReprjErrorWithDistortion(o_x, o_y)));
-    }
-    double ox_; /** observed x location of object in image */
-    double oy_; /** observed y location of object in image */
-  };
-
-  // reprojection error of a single simple point observed by a camera with lens distortion
-  // typically used for intrinsic calibration
-  // location of target is known, and fixed, point's location within target is also known
-  // both extrinsic and intrinsic parameters of camera are being computed
-  class CameraReprjErrorWithDistortionPK
-  {
-  public:
-    CameraReprjErrorWithDistortionPK(double ob_x, double ob_y, Point3d point) :
-      ox_(ob_x), oy_(ob_y), point_(point)
-    {
-    }
-
-    template<typename T>
-    bool operator()(const T* const c_p1, /** extrinsic parameters */
-                    const T* c_p2, /** intrinsic parameters */
-                    T* residual) const
-    {
-      const T *camera_aa(&c_p1[0]);
-      const T *camera_tx(&c_p1[3]);
-      T fx, fy, cx, cy, k1, k2, k3, p1, p2;
-      extractCameraIntrinsics(c_p2, fx, fy, cx, cy, k1, k2, k3, p1, p2);
-      T camera_point[3];
-
-      /** transform point into camera coordinates */
-      transformPoint3d(camera_aa, camera_tx, point_, camera_point);
-
-      /** compute project point into image plane and compute residual */
-      T ox = T(ox_);
-      T oy = T(oy_);
-      cameraPntResidualDist(camera_point, k1, k2, k3, p1, p2, fx, fy, cx, cy, ox, oy,  residual);
-      
-      return true;
-    } /** end of operator() */
-
-    /** Factory to hide the construction of the CostFunction object from */
-    /** the client code. */
-    static ceres::CostFunction* Create(const double o_x, const double o_y, Point3d point)
-    {
-      return (new ceres::AutoDiffCostFunction<CameraReprjErrorWithDistortionPK, 2, 6, 9>(new CameraReprjErrorWithDistortionPK(o_x, o_y, point)));
-    }
-    double ox_; /** observed x location of object in image */
-    double oy_; /** observed y location of object in image */
-    Point3d point_; /*! location of point in target coordinates */
-  };
-
-  // reprojection error of a single simple point observed by a camera with NO lens distortion
-  // should subscribe to a rectified image when using the error function
-  class CameraReprjError
-  {
-  public:
-    CameraReprjError(double ob_x, double ob_y, double fx, double fy, double cx, double cy) :
-      ox_(ob_x), oy_(ob_y), fx_(fx), fy_(fy), cx_(cx), cy_(cy)
-    {
-    }
-
-    template<typename T>
-    bool operator()(const T* const c_p1, /** extrinsic parameters */
-                    const T* point, /** point being projected, yes this is has 3 parameters */
-                    T* residual) const
-    {
-      const T *camera_aa(&c_p1[0]);
-      const T *camera_tx(&c_p1[3]);
-      T camera_point[3]; /** point in camera coordinates */
-
-      /** transform point into camera coordinates */
-      transformPoint(camera_aa, camera_tx, point, camera_point);
-
-      /** compute project point into image plane and compute residual */
-      T fx = T(fx_);
-      T fy = T(fy_);
-      T cx = T(cx_);
-      T cy = T(cy_);
-      T ox = T(ox_);
-      T oy = T(oy_);
-      cameraPntResidual(camera_point, fx, fy, cx, cy, ox, oy,  residual);
-
-      return true;
-    } /** end of operator() */
-
-    /** Factory to hide the construction of the CostFunction object from */
-    /** the client code. */
-    static ceres::CostFunction* Create(const double o_x, const double o_y, 
-				       const double fx, const double fy, 
-				       const double cx, const double cy)
-    {
-      return (new ceres::AutoDiffCostFunction<CameraReprjError, 2, 6, 3>(new CameraReprjError(o_x, o_y, fx, fy, cx, cy)));
-    }
-    double ox_; /** observed x location of object in image */
-    double oy_; /** observed y location of object in image */
-    double fx_; /*!< known focal length of camera in x */
-    double fy_; /*!< known focal length of camera in y */
-    double cx_; /*!< known optical center of camera in x */
-    double cy_; /*!< known optical center of camera in y */
-  };
-
-  class TriangulationError
-  {
-  public:
-    TriangulationError(double ob_x, double ob_y, double fx, double fy, double cx, double cy, Pose6d camera_pose) :
-      ox_(ob_x), oy_(ob_y), fx_(fx), fy_(fy), cx_(cx), cy_(cy), camera_pose_(camera_pose)
-    {
-    }
-
-    template<typename T>
-    bool operator()( const T* point, /** point being projected, yes this is has 3 parameters */
-                    T* residual) const
-    {
-      T camera_point[3]; /** point in camera coordinates */
-
-      /** transform point into camera coordinates */
-      poseTransformPoint(camera_pose_, point, camera_point);
-
-      /** compute project point into image plane and compute residual */
-      T fx = T(fx_);
-      T fy = T(fy_);
-      T cx = T(cx_);
-      T cy = T(cy_);
-      T ox = T(ox_);
-      T oy = T(oy_);
-      cameraPntResidual(camera_point, fx, fy, cx, cy, ox, oy,  residual);
-
-      return true;
-    } /** end of operator() */
-
-    /** Factory to hide the construction of the CostFunction object from */
-    /** the client code. */
-    static ceres::CostFunction* Create(const double o_x, const double o_y, 
-				       const double fx, const double fy, 
-				       const double cx, const double cy,
-				       const Pose6d camera_pose)
-    {
-      return (new ceres::AutoDiffCostFunction<TriangulationError, 2, 3>(new TriangulationError(o_x, o_y, fx, fy, cx, cy, camera_pose)));
-    }
-    double ox_; /** observed x location of object in image */
-    double oy_; /** observed y location of object in image */
-    double fx_; /*!< known focal length of camera in x */
-    double fy_; /*!< known focal length of camera in y */
-    double cx_; /*!< known optical center of camera in x */
-    double cy_; /*!< known optical center of camera in y */
-    Pose6d camera_pose_;/*!< known camera pose */
-  };
-
-  // reprojection error of a single simple point observed by a camera with NO lens distortion
-  // should subscribe to a rectified image when using the error function
-  class CameraReprjErrorPK
-  {
-  public:
-    CameraReprjErrorPK(double ob_x, double ob_y, double fx, double fy, double cx, double cy, Point3d point) :
-      ox_(ob_x), oy_(ob_y), fx_(fx), fy_(fy), cx_(cx), cy_(cy), point_(point)
-    {
-    }
-
-    template<typename T>
-    bool operator()(const T* const c_p1, /** extrinsic parameters */
-                    T* residual) const
-    {
-      const T *camera_aa(&c_p1[0]);
-      const T *camera_tx(&c_p1[3]);
-      T camera_point[3]; /** point in camera coordinates */
-
-      /** transform point into camera coordinates */
-      transformPoint3d(camera_aa, camera_tx, point_, camera_point);
-
-      /** compute project point into image plane and compute residual */
-      T fx = T(fx_);
-      T fy = T(fy_);
-      T cx = T(cx_);
-      T cy = T(cy_);
-      T ox = T(ox_);
-      T oy = T(oy_);
-      cameraPntResidual(camera_point, fx, fy, cx, cy, ox, oy,  residual);
-
-      return true;
-    } /** end of operator() */
-
-    /** Factory to hide the construction of the CostFunction object from */
-    /** the client code. */
-    static ceres::CostFunction* Create(const double o_x, const double o_y, 
-				       const double fx, const double fy, 
-				       const double cx, const double cy,
-				       const Point3d point)
-    {
-      return (new ceres::AutoDiffCostFunction<CameraReprjErrorPK, 2, 6>(new CameraReprjErrorPK(o_x, o_y, fx, fy, cx, cy, point)));
-    }
-    double ox_; /** observed x location of object in image */
-    double oy_; /** observed y location of object in image */
-    double fx_; /*!< known focal length of camera in x */
-    double fy_; /*!< known focal length of camera in y */
-    double cx_; /*!< known optical center of camera in x */
-    double cy_; /*!< known optical center of camera in y */
-    Point3d point_; /*! location of point in target coordinates */
-
-  };
-
-  // reprojection error of a single point attatched to a target observed by a camera with NO lens distortion
-  // should subscribe to a rectified image when using the error function
-  //
-  class TargetCameraReprjError
-  {
-  public:
-    TargetCameraReprjError(double ob_x, double ob_y, double fx, double fy, double cx, double cy) :
-      ox_(ob_x), oy_(ob_y), fx_(fx), fy_(fy), cx_(cx), cy_(cy)
-    {
-    }
-
-    template<typename T>
-    bool operator()(const T* const c_p1, /** extrinsic parameters */
-                    const T* const c_p2, /** 6Dof transform of target points into world frame */
-                    const T* const point, /** point described in target frame */
-                    T* residual) const
-    {
-
-      const T *camera_aa(&c_p1[0]);
-      const T *camera_tx(&c_p1[3]);
-      const T *target_aa(& c_p2[0]);
-      const T *target_tx(& c_p2[3]);
-
-      T world_point[3]; /** point in world coordinates */
-      T camera_point[3]; /** point in camera coordinates */
-
-      /** transform point into camera coordinates */
-      transformPoint(target_aa, target_tx, point, world_point);
-      transformPoint(camera_aa, camera_tx, world_point, camera_point);
-
-      /** compute project point into image plane and compute residual */
-      T fx = T(fx_);
-      T fy = T(fy_);
-      T cx = T(cx_);
-      T cy = T(cy_);
-      T ox = T(ox_);
-      T oy = T(oy_);
-      cameraPntResidual(camera_point, fx, fy, cx, cy, ox, oy,  residual);
-
-      return true;
-    } /** end of operator() */
-
-    /** Factory to hide the construction of the CostFunction object from */
-    /** the client code. */
-    static ceres::CostFunction* Create(const double o_x, const double o_y,
-				       const double fx, const double fy, 
-				       const double cx, const double cy)
-
-    {
-      return (new ceres::AutoDiffCostFunction<TargetCameraReprjError, 2, 6, 6, 3>(new TargetCameraReprjError(o_x, o_y, fx, fy, cx, cy)));
-    }
-    double ox_; /** observed x location of object in image */
-    double oy_; /** observed y location of object in image */
-    double fx_; /*!< known focal length of camera in x */
-    double fy_; /*!< known focal length of camera in y */
-    double cx_; /*!< known optical center of camera in x */
-    double cy_; /*!< known optical center of camera in y */
-  };
-
-  // reprojection error of a single point attatched to a target observed by a camera with NO lens distortion
-  // should subscribe to a rectified image when using the error function
-  //
-  class TargetCameraReprjErrorPK
-  {
-  public:
-    TargetCameraReprjErrorPK(double ob_x, double ob_y, double fx, double fy, double cx, double cy, Point3d point) :
-      ox_(ob_x), oy_(ob_y), fx_(fx), fy_(fy), cx_(cx), cy_(cy), point_(point)
-    {
-    }
-
-    template<typename T>
-    bool operator()(const T* const c_p1, /** extrinsic parameters */
-                    const T* const c_p2, /** 6Dof transform of target points into world frame */
-                    T* residual) const
-    {
-
-      const T *camera_aa(&c_p1[0]);
-      const T *camera_tx(&c_p1[3]);
-      const T *target_aa(& c_p2[0]);
-      const T *target_tx(& c_p2[3]);
-      T world_point[3]; /** point in world coordinates */
-      T camera_point[3]; /** point in camera coordinates */
-
-      /** transform point into camera coordinates */
-      transformPoint3d(target_aa, target_tx, point_, world_point);
-      transformPoint(camera_aa, camera_tx, world_point, camera_point);
-
-      /** compute project point into image plane and compute residual */
-      T fx = T(fx_);
-      T fy = T(fy_);
-      T cx = T(cx_);
-      T cy = T(cy_);
-      T ox = T(ox_);
-      T oy = T(oy_);
-      cameraPntResidual(camera_point, fx, fy, cx, cy, ox, oy,  residual);
-
-      return true;
-    } /** end of operator() */
-
-    /** Factory to hide the construction of the CostFunction object from */
-    /** the client code. */
-    static ceres::CostFunction* Create(const double o_x, const double o_y,
-				       const double fx, const double fy, 
-				       const double cx, const double cy,
-				       const Point3d point)
-
-    {
-      return (new ceres::AutoDiffCostFunction<TargetCameraReprjErrorPK, 2, 6, 6>(new TargetCameraReprjErrorPK(o_x, o_y, fx, fy, cx, cy, point)));
-    }
-    double ox_; /** observed x location of object in image */
-    double oy_; /** observed y location of object in image */
-    double fx_; /*!< known focal length of camera in x */
-    double fy_; /*!< known focal length of camera in y */
-    double cx_; /*!< known optical center of camera in x */
-    double cy_; /*!< known optical center of camera in y */
-    Point3d point_; /*! location of point in target coordinates */
-  };
-
-  // reprojection error of a single point attatched to a target observed by a camera with NO lens distortion
-  // should subscribe to a rectified image when using the error function
-  //
-  class LinkTargetCameraReprjError
-  {
-  public:
-    LinkTargetCameraReprjError(double ob_x, double ob_y, double fx, double fy, double cx, double cy, Pose6d link_pose) :
-      ox_(ob_x), oy_(ob_y), fx_(fx), fy_(fy), cx_(cx), cy_(cy), link_pose_(link_pose)
-    {
-    }
-
-    template<typename T>
-    bool operator()(const T* const c_p1, /** extrinsic parameters */
-                    const T* const c_p2, /** 6Dof transform of target points into world frame */
-                    const T* const point, /** point described in target frame that is being seen */
-                    T* residual) const
-    {
-      const T *camera_aa(&c_p1[0]);
-      const T *camera_tx(&c_p1[3]);
-      const T *target_aa(& c_p2[0]);
-      const T *target_tx(& c_p2[3]);
-      T link_point[3]; /** point in link coordinates */
-      T world_point[3]; /** point in world coordinates */
-      T camera_point[3]; /** point in camera coordinates */
-
-      /** transform point into camera coordinates */
-      transformPoint(target_aa, target_tx, point, link_point);
-      poseTransformPoint(link_pose_, link_point, world_point);
-      transformPoint(camera_aa, camera_tx, world_point, camera_point);
-
-      /** compute project point into image plane and compute residual */
-      T fx = T(fx_);
-      T fy = T(fy_);
-      T cx = T(cx_);
-      T cy = T(cy_);
-      T ox = T(ox_);
-      T oy = T(oy_);
-      cameraPntResidual(camera_point, fx, fy, cx, cy, ox, oy,  residual);
-
-      return true;
-    } /** end of operator() */
-
-    /** Factory to hide the construction of the CostFunction object from */
-    /** the client code. */
-    static ceres::CostFunction* Create(const double ox, const double oy,
-				       const double fx, const double fy, 
-				       const double cx, const double cy,
-				       Pose6d pose)
-
-    {
-      return (new ceres::AutoDiffCostFunction<LinkTargetCameraReprjError, 2, 6, 6, 3>(new LinkTargetCameraReprjError(ox, oy, fx, fy, cx, cy, pose)));
-    }
-    double ox_; /** observed x location of object in image */
-    double oy_; /** observed y location of object in image */
-    double fx_; /*!< known focal length of camera in x */
-    double fy_; /*!< known focal length of camera in y */
-    double cx_; /*!< known optical center of camera in x */
-    double cy_; /*!< known optical center of camera in y */
-    Pose6d link_pose_; /*!< transform from world to link coordinates */ 
-  };
-
-  // reprojection error of a single point attatched to a target observed by a camera with NO lens distortion
-  // should subscribe to a rectified image when using the error function
-  //
-  class LinkTargetCameraReprjErrorPK
-  {
-  public:
-    LinkTargetCameraReprjErrorPK(double ob_x, double ob_y, double fx, double fy, double cx, double cy, Pose6d link_pose, Point3d point) :
-      ox_(ob_x), oy_(ob_y), fx_(fx), fy_(fy), cx_(cx), cy_(cy), link_pose_(link_pose), point_(point)
-    {
-    }
-
-    template<typename T>
-    bool operator()(const T* const c_p1, /** extrinsic parameters */
-                    const T* const c_p2, /** 6Dof transform of target points into world frame */
-                    T* residual) const
-    {
-      const T *camera_aa(&c_p1[0]);
-      const T *camera_tx(&c_p1[3]);
-      const T *target_aa(& c_p2[0]);
-      const T *target_tx(& c_p2[3]);
-      T link_point[3]; /** point in link coordinates */
-      T world_point[3];/** point in worls coordinates */			   
-      T camera_point[3]; /** point in camera coordinates */
-
-      /** transform point into camera coordinates */
-      transformPoint3d(target_aa, target_tx, point_, link_point);
-      poseTransformPoint(link_pose_, link_point, world_point);
-      transformPoint(camera_aa, camera_tx, world_point, camera_point);
-
-      /** compute project point into image plane and compute residual */
-      T fx = T(fx_);
-      T fy = T(fy_);
-      T cx = T(cx_);
-      T cy = T(cy_);
-      T ox = T(ox_);
-      T oy = T(oy_);
-      cameraPntResidual(camera_point, fx, fy, cx, cy, ox, oy,  residual);
-
-      return true;
-    } /** end of operator() */
-
-    /** Factory to hide the construction of the CostFunction object from */
-    /** the client code. */
-    static ceres::CostFunction* Create(const double o_x, const double o_y,
-				       const double fx, const double fy, 
-				       const double cx, const double cy,
-				       Pose6d pose, Point3d point)
-
-    {
-      return (new ceres::AutoDiffCostFunction<LinkTargetCameraReprjErrorPK, 2, 6, 6>( new LinkTargetCameraReprjErrorPK(o_x, o_y, fx, fy, cx, cy, pose, point)));
-    }
-    double ox_; /** observed x location of object in image */
-    double oy_; /** observed y location of object in image */
-    double fx_; /*!< known focal length of camera in x */
-    double fy_; /*!< known focal length of camera in y */
-    double cx_; /*!< known optical center of camera in x */
-    double cy_; /*!< known optical center of camera in y */
-    Pose6d link_pose_; /*!< transform from world to link coordinates */ 
-    Point3d point_; /*! location of point in target coordinates */
-  };
-
-  // reprojection error of a single point attatched to a target observed by a camera with NO lens distortion
-  // should subscribe to a rectified image when using the error function
-  //
-  class PosedTargetCameraReprjErrorPK
-  {
-  public:
-    PosedTargetCameraReprjErrorPK(double ob_x, double ob_y, double fx, double fy, double cx, double cy, Pose6d target_pose, Point3d point) :
-      ox_(ob_x), oy_(ob_y), fx_(fx), fy_(fy), cx_(cx), cy_(cy), target_pose_(target_pose), point_(point)
-    {
-    }
-
-    template<typename T>
-    bool operator()(const T* const c_p1, /** extrinsic parameters */
-                    T* residual) const
-    {
-      const T *camera_aa(&c_p1[0]);
-      const T *camera_tx(&c_p1[3]);
-      T world_point[3];/** point in worls coordinates */			   
-      T camera_point[3]; /** point in camera coordinates */
-      T point[3];
-      point[0] = T(point_.x);
-      point[1] = T(point_.y);
-      point[2] = T(point_.z);
-      /** transform point into camera coordinates */
-      poseTransformPoint(target_pose_, point, world_point);
-      transformPoint(camera_aa, camera_tx, world_point, camera_point);
-
-      /** compute project point into image plane and compute residual */
-      T fx = T(fx_);
-      T fy = T(fy_);
-      T cx = T(cx_);
-      T cy = T(cy_);
-      T ox = T(ox_);
-      T oy = T(oy_);
-      cameraPntResidual(camera_point, fx, fy, cx, cy, ox, oy,  residual);
-
-      return true;
-    } /** end of operator() */
-
-    /** Factory to hide the construction of the CostFunction object from */
-    /** the client code. */
-    static ceres::CostFunction* Create(const double o_x, const double o_y,
-				       const double fx, const double fy, 
-				       const double cx, const double cy,
-				       Pose6d target_pose, Point3d point)
-
-    {
-      return (new ceres::AutoDiffCostFunction<PosedTargetCameraReprjErrorPK, 2, 6>( new PosedTargetCameraReprjErrorPK(o_x, o_y, fx, fy, cx, cy, target_pose, point)));
-    }
-    double ox_; /** observed x location of object in image */
-    double oy_; /** observed y location of object in image */
-    double fx_; /*!< known focal length of camera in x */
-    double fy_; /*!< known focal length of camera in y */
-    double cx_; /*!< known optical center of camera in x */
-    double cy_; /*!< known optical center of camera in y */
-    Pose6d target_pose_; /*!< transform from world to target coordinates */ 
-    Point3d point_; /*! location of point in target coordinates */
-  };
-
-  // reprojection error of a single point attatched to a target observed by a camera with NO lens distortion
-  // should subscribe to a rectified image when using the error function
-  //
-  class LinkCameraTargetReprjError
-  {
-  public:
-    LinkCameraTargetReprjError(double ob_x, double ob_y, double fx, double fy, double cx, double cy, Pose6d link_pose) :
-      ox_(ob_x), oy_(ob_y), fx_(fx), fy_(fy), cx_(cx), cy_(cy), link_pose_(link_pose)
-    {
-      link_posei_ = link_pose_.getInverse();
-    }
-
-    template<typename T>
-    bool operator()(const T* const c_p1, /** extrinsic parameters */
-                    const T* const c_p2, /** 6Dof transform of target points into world frame */
-                    const T* const point, /** point described in target frame that is being seen */
-                    T* residual) const
-    {
-      const T *camera_aa(&c_p1[0]);
-      const T *camera_tx(&c_p1[3]);
-      const T *target_aa(& c_p2[0]);
-      const T *target_tx(& c_p2[3]);
-      T world_point[3]; /** point in world coordinates */
-      T link_point[3]; /** point in link coordinates */
-      T camera_point[3];/** point in camera coordinates */
-
-      /** transform point into camera coordinates */
-      transformPoint(target_aa, target_tx, point, world_point);
-      poseTransformPoint(link_posei_, world_point, link_point);
-      transformPoint(camera_aa, camera_tx, link_point, camera_point);
-
-      /** compute project point into image plane and compute residual */
-      T fx = T(fx_);
-      T fy = T(fy_);
-      T cx = T(cx_);
-      T cy = T(cy_);
-      T ox = T(ox_);
-      T oy = T(oy_);
-      cameraPntResidual(camera_point, fx, fy, cx, cy, ox, oy,  residual);
-
-      return true;
-    } /** end of operator() */
-
-    /** Factory to hide the construction of the CostFunction object from */
-    /** the client code. */
-    static ceres::CostFunction* Create(const double ox, const double oy,
-				       const double fx, const double fy, 
-				       const double cx, const double cy,
-				       Pose6d pose)
-
-    {
-      return (new ceres::AutoDiffCostFunction<LinkCameraTargetReprjError, 2, 6, 6, 3>(new LinkCameraTargetReprjError(ox, oy, fx, fy, cx, cy, pose)));
-    }
-    double ox_; /*!< observed x location of object in image */
-    double oy_; /*!< observed y location of object in image */
-    double fx_; /*!< known focal length of camera in x */
-    double fy_; /*!< known focal length of camera in y */
-    double cx_; /*!< known optical center of camera in x */
-    double cy_; /*!< known optical center of camera in y */
-    Pose6d link_pose_; /*!< transform from world to link coordinates */ 
-    Pose6d link_posei_; /*!< transform from link to world coordinates */ 
-  };
-
-  // reprojection error of a single point attatched to a target observed by a camera with NO lens distortion
-  // should subscribe to a rectified image when using the error function
-  //
-  class LinkCameraTargetReprjErrorPK
-  {
-  public:
-    LinkCameraTargetReprjErrorPK(double ob_x, double ob_y, double fx, double fy, double cx, double cy, Pose6d link_pose, Point3d point) :
-      ox_(ob_x), oy_(ob_y), fx_(fx), fy_(fy), cx_(cx), cy_(cy), link_pose_(link_pose), point_(point)
-    {
-      link_posei_ = link_pose_.getInverse();
-    }
-
-    template<typename T>
-    bool operator()(const T* const c_p1, /** extrinsic parameters */
-                    const T* const c_p2, /** 6Dof transform of target points into world frame */
-                    T* residual) const
-    {
-      const T *camera_aa(&c_p1[0]);
-      const T *camera_tx(&c_p1[3]);
-      const T *target_aa(& c_p2[0]);
-      const T *target_tx(& c_p2[3]);
-      T world_point[3]; /** point in world coordinates */
-      T link_point[3]; /** point in link coordinates */
-      T camera_point[3]; /** point in camera coordinates */
-
-      /** transform point into camera coordinates */
-      transformPoint3d(target_aa, target_tx, point_, world_point);
-      poseTransformPoint(link_posei_, world_point, link_point);
-      transformPoint(camera_aa, camera_tx, link_point, camera_point);
-
-      /** compute project point into image plane and compute residual */
-      T fx = T(fx_);
-      T fy = T(fy_);
-      T cx = T(cx_);
-      T cy = T(cy_);
-      T ox = T(ox_);
-      T oy = T(oy_);
-      cameraPntResidual(camera_point, fx, fy, cx, cy, ox, oy,  residual);
-
-      return true;
-    } /** end of operator() */
-
-    /** Factory to hide the construction of the CostFunction object from */
-    /** the client code. */
-    static ceres::CostFunction* Create(const double o_x, const double o_y,
-				       const double fx, const double fy, 
-				       const double cx, const double cy,
-				       Pose6d pose, Point3d pnt)
-
-    {
-      return (new ceres::AutoDiffCostFunction<LinkCameraTargetReprjErrorPK, 2, 6, 6>( new LinkCameraTargetReprjErrorPK(o_x, o_y, fx, fy, cx, cy, pose, pnt)));
-    }
-    double ox_; /** observed x location of object in image */
-    double oy_; /** observed y location of object in image */
-    double fx_; /*!< known focal length of camera in x */
-    double fy_; /*!< known focal length of camera in y */
-    double cx_; /*!< known optical center of camera in x */
-    double cy_; /*!< known optical center of camera in y */
-    Pose6d link_pose_; /*!< transform from world to link coordinates */ 
-    Pose6d link_posei_; /*!< transform from link to world coordinates */ 
-    Point3d point_; /*! location of point in target coordinates */
-  };
-
-  // WARNING, ASSUMES CIRCLE LIES IN XY PLANE OF WORLD
-  class  CircleCameraReprjErrorWithDistortion
-  {
-  public:
-    CircleCameraReprjErrorWithDistortion(double ob_x, double ob_y, double c_dia) :
-      ox_(ob_x), oy_(ob_y), circle_diameter_(c_dia)
-    {
-    }
-
-    template<typename T>
-    bool operator()(const T* const c_p1, /** extrinsic parameters [6]*/
-		    const T* const c_p2, /** intrinsic parameters of camera fx,fy,cx,cy,k1,k2,k2,p1,p2 [9]*/
-		    const T* const point, /** point described in target frame that is being seen [3]*/
-		    T* residual) const
-    {
-      const T *camera_aa(&c_p1[0]);
-      const T *camera_tx(&c_p1[3]);
-      T fx, fy, cx, cy, k1, k2, k3, p1, p2;      
-      extractCameraIntrinsics(c_p2, fx, fy, cx, cy, k1, k2, k3, p1, p2);
-      T camera_point[3];  /** point in camera coordinates*/       
-      T R_TtoC[9];
-
-      /** transform point into camera coordinates */
-      transformPoint(camera_aa, camera_tx, point, camera_point);
-      
-      // find rotation from target to camera frame
-      ceres::AngleAxisToRotationMatrix(camera_aa,R_TtoC);
-
-      /** compute project point into image plane and compute residual */
-      T circle_diameter = T(circle_diameter_);
-      T ox = T(ox_);
-      T oy = T(oy_);
-      cameraCircResidualDist(camera_point, circle_diameter, R_TtoC, k1, k2, k3, p1,p2, fx, fy,cx,cy, ox, oy, residual);
-
-      return true;
-    } /** end of operator() */
-    
-    /** Factory to hide the construction of the CostFunction object from */
-    /** the client code. */
-    static ceres::CostFunction* Create(const double o_x, const double o_y, const double c_dia)
-    {
-      return (new ceres::AutoDiffCostFunction<CircleCameraReprjErrorWithDistortion, 2, 6, 9, 3>(new CircleCameraReprjErrorWithDistortion(o_x, o_y, c_dia)));
-    }
-    double ox_; /** observed x location of object in image */
-    double oy_; /** observed y location of object in image */
-    double circle_diameter_; //** diameter of circle being observed */
-  };
-
-  // WARNING, ASSUMES CIRCLE LIES IN XY PLANE OF WORLD
-  class  CircleCameraReprjErrorWithDistortionPK
-  {
-  public:
-    CircleCameraReprjErrorWithDistortionPK(double ob_x, double ob_y, double c_dia, Point3d point) :
-      ox_(ob_x), oy_(ob_y), circle_diameter_(c_dia), point_(point)
-    {
-    }
-
-    template<typename T>
-    bool operator()(const T* const c_p1, /** extrinsic parameters [6] */
-		    const T* const c_p2, /** intrinsic parameters of camera fx,fy,cx,cy,k1,k2,k2,p1,p2 [9] */
-		    T* residual) const
-    {
-      const T *camera_aa(&c_p1[0]);
-      const T *camera_tx(&c_p1[3]);
-      T fx, fy, cx, cy, k1, k2, k3, p1, p2;      
-      extractCameraIntrinsics(c_p2, fx, fy, cx, cy, k1, k2, k3, p1, p2);
-      T camera_point[3]; /** point in camera coordinates */
-      T R_TtoC[9]; /** rotation from target to camera coordinates 
-
-      /** find point in camera coordinates */
-      transformPoint3d(camera_aa, camera_tx, point_, camera_point);
-
-      // find rotation from target to camera coordinates
-      T T2C_angle_axis[3];
-      T2C_angle_axis[0] = T(-camera_aa[0]);
-      T2C_angle_axis[1] = T(-camera_aa[1]);
-      T2C_angle_axis[2] = T(-camera_aa[2]);
-      ceres::AngleAxisToRotationMatrix(T2C_angle_axis, R_TtoC);
-
-      /** compute project point into image plane and compute residual */
-      T circle_diameter = T(circle_diameter_);
-      T ox = T(ox_);
-      T oy = T(oy_);
-      cameraCircResidualDist(camera_point, circle_diameter, R_TtoC, k1, k2, k3, p1, p2, fx, fy,cx,cy, ox, oy, residual);
-
-      return true;
-    } /** end of operator() */
-
-    /** Factory to hide the construction of the CostFunction object from */
-    /** the client code. */
-    static ceres::CostFunction* Create(const double o_x, const double o_y, const double c_dia, Point3d point)
-    {
-      return (new ceres::AutoDiffCostFunction<CircleCameraReprjErrorWithDistortionPK, 2, 6, 9>(											       new CircleCameraReprjErrorWithDistortionPK(o_x, o_y, c_dia, point)));
-    }
-    double ox_; /** observed x location of object in image */
-    double oy_; /** observed y location of object in image */
-    double circle_diameter_; //** diameter of circle being observed */
-    Point3d point_;
-  };
-
-  class  CircleCameraReprjError
-  {
-  public:
-    CircleCameraReprjError(double ob_x, double ob_y, double c_dia, double fx, double fy, double cx, double cy) :
-      ox_(ob_x), oy_(ob_y), circle_diameter_(c_dia), fx_(fx), fy_(fy), cx_(cx), cy_(cy)
-    {
-    }
-
-    template<typename T>
-    bool operator()(const T* const c_p1, /** extrinsic parameters [6]*/
-		    const T* const point, /** point described in target frame that is being seen [3]*/
-		    T* residual) const
-    {
-      const T *camera_aa(&c_p1[0]);
-      const T *camera_tx(&c_p1[3]);
-      T camera_point[3];  /** point in camera coordinates */ 
-      T R_TtoC[9]; /** rotation from target to camera coordinates */
-
-      /** transform point into camera coordinates */
-      transformPoint(camera_aa, camera_tx, point, camera_point);
-      
-      // find rotation from target to camera coordinates
-      ceres::AngleAxisToRotationMatrix(camera_aa,R_TtoC);
-
-      /** compute project point into image plane and compute residual */
-      T circle_diameter = T(circle_diameter_);
-      T fx = T(fx_);
-      T fy = T(fy_);
-      T cx = T(cx_);
-      T cy = T(cy_);
-      T ox = T(ox_);
-      T oy = T(oy_);
-      cameraCircResidual(camera_point, circle_diameter, R_TtoC, fx, fy,cx,cy, ox, oy, residual);
-
-      return true;
-    } /** end of operator() */
-    
-    /** Factory to hide the construction of the CostFunction object from */
-    /** the client code. */
-    static ceres::CostFunction* Create(const double o_x, const double o_y, const double c_dia, 
-				       const double fx,  const double fy, const double cx, const double cy)
-    {
-      return (new ceres::AutoDiffCostFunction<CircleCameraReprjError, 2, 6, 3>(new CircleCameraReprjError(o_x, o_y, c_dia, fx, fy, cx, cy)));
-    }
-    double ox_; /** observed x location of object in image */
-    double oy_; /** observed y location of object in image */
-    double circle_diameter_; /** diameter of circle being observed */
-    double fx_; /** focal length of camera in x (pixels) */
-    double fy_; /** focal length of camera in y (pixels) */
-    double cx_; /** focal center of camera in x (pixels) */
-    double cy_; /** focal center of camera in y (pixels) */
-  };
-
-  class  CircleCameraReprjErrorPK
-  {
-  public:
-    CircleCameraReprjErrorPK(double ob_x, double ob_y, double c_dia, double fx, double fy, double cx, double cy,  Point3d point) :
-      ox_(ob_x), oy_(ob_y), circle_diameter_(c_dia), fx_(fx), fy_(fy), cx_(cx), cy_(cy), point_(point)
-    {
-    }
-
-    template<typename T>
-    bool operator()(const T* const c_p1, /** extrinsic parameters [6] */
-		    T* residual) const
-    {
-      const T *camera_aa(&c_p1[0]);
-      const T *camera_tx(&c_p1[3]);
-      T camera_point[3]; /* point in camera coordinates */
-      T R_TtoC[9]; /** rotation from target to camera coordinates */
-
-      /** rotate and translate point into camera coordinates*/
-      transformPoint3d(camera_aa, camera_tx, point_, camera_point);
-
-      // find rotation from target to camera coordinates
-      ceres::AngleAxisToRotationMatrix(camera_aa, R_TtoC);
-
-      /** compute project point into image plane and compute residual */
-      T circle_diameter = T(circle_diameter_);
-      T fx = T(fx_);
-      T fy = T(fy_);
-      T cx = T(cx_);
-      T cy = T(cy_);
-      T ox = T(ox_);
-      T oy = T(oy_);
-      cameraCircResidual(camera_point, circle_diameter, R_TtoC, fx, fy,cx,cy, ox, oy, residual);
-
-      return true;
-    } /** end of operator() */
-
-    /** Factory to hide the construction of the CostFunction object from */
-    /** the client code. */
-  static ceres::CostFunction* Create(const double o_x, const double o_y, const double c_dia, 
-				     const double fx, const double fy, const double cx, const double cy,
-				     Point3d point)
-    {
-      return (new ceres::AutoDiffCostFunction<CircleCameraReprjErrorPK, 2, 6>(new CircleCameraReprjErrorPK(o_x, o_y, c_dia, fx, fy, cx, cy, point)));
-    }
-    double ox_; /** observed x location of object in image */
-    double oy_; /** observed y location of object in image */
-    double circle_diameter_; //** diameter of circle being observed */
-    double fx_; /** focal length of camera in x (pixels) */
-    double fy_; /** focal length of camera in y (pixels) */
-    double cx_; /** focal center of camera in x (pixels) */
-    double cy_; /** focal center of camera in y (pixels) */
-    Point3d point_; /** location of point in target coordinates */
-  };
-
-  class  FixedCircleTargetCameraReprjErrorWithDistortion
-  {
-  public:
-    FixedCircleTargetCameraReprjErrorWithDistortion(double ob_x, double ob_y, double c_dia) :
-      ox_(ob_x), oy_(ob_y), circle_diameter_(c_dia)
-    {
-    }
-
-    template<typename T>
-    bool operator()(const T* const c_p1, /** extrinsic parameters [6]*/
-		    const T* const c_p2, /** intrinsic parameters of camera fx,fy,cx,cy,k1,k2,k2,p1,p2 [9]*/
-		    const T* const c_p3, /** 6Dof transform of target into world frame [6]*/
-		    const T* const point, /** point described in target frame that is being seen [3]*/
-		    T* residual) const
-    {
-      const T *camera_aa(&c_p1[0]);
-      const T *camera_tx(&c_p1[3]);
-      const T *target_aa(& c_p3[0]);
-      const T *target_tx(& c_p3[3]);
-      T fx, fy, cx, cy, k1, k2, k3, p1, p2;      
-      extractCameraIntrinsics(c_p2, fx, fy, cx, cy, k1, k2, k3, p1, p2);
-      T world_point[3]; /** point in world coordinates */
-      T camera_point[3];  /** point in camera coordinates*/ 
-      T R_WtoC[9]; // rotation from world to camera coordinates
-      T R_TtoW[9]; // rotation from target to world coordinates
-      T R_TtoC[9];  // rotation from target to camera coordinates (assume circle lies in x-y plane of target coordinates)
-
-      /** compute necessary rotation matrices */
-      ceres::AngleAxisToRotationMatrix(camera_aa, R_WtoC);  
-      ceres::AngleAxisToRotationMatrix(target_aa, R_TtoW);
-
-      /** transform point into camera coordinates */
-      transformPoint(target_aa, target_tx, point, world_point);
-      transformPoint(camera_aa, camera_tx, world_point, camera_point);
-
-      // find rotation from target to camera coordinates
-      rotationProduct(R_WtoC, R_TtoW, R_TtoC); // R_WtoC*R_TtoW = R_TtoC
-
-      /** compute project point into image plane and compute residual */
-      T circle_diameter = T(circle_diameter_);
-      T ox = T(ox_);
-      T oy = T(oy_);
-      cameraCircResidualDist(camera_point, circle_diameter, R_TtoC, k1, k2, k3, p1, p2, fx, fy,cx,cy, ox, oy, residual);
-
-      return true;
-    } /** end of operator() */
-    
-    /** Factory to hide the construction of the CostFunction object from */
-    /** the client code. */
-    static ceres::CostFunction* Create(const double o_x, const double o_y, const double c_dia)
-    {
-      return (new ceres::AutoDiffCostFunction<FixedCircleTargetCameraReprjErrorWithDistortion, 2, 6, 6, 9, 3>(new FixedCircleTargetCameraReprjErrorWithDistortion(o_x, o_y, c_dia)));
-    }
-    double ox_; /** observed x location of object in image */
-    double oy_; /** observed y location of object in image */
-    double circle_diameter_; //** diameter of circle being observed */
-  };
-
-  class  FixedCircleTargetCameraReprjErrorWithDistortionPK
-  {
-  public:
-    FixedCircleTargetCameraReprjErrorWithDistortionPK(double ob_x, double ob_y, double c_dia, Point3d point) :
-      ox_(ob_x), oy_(ob_y), circle_diameter_(c_dia), point_(point)
-    {
-    }
-
-    template<typename T>
-    bool operator()(const T* const c_p1, /** extrinsic parameters [6]*/
-		    const T* const c_p2, /** intrinsic parameters of camera fx,fy,cx,cy,k1,k2,k2,p1,p2 [9]*/
-		    const T* const c_p3, /** 6Dof transform of target into world frame [6]*/
-		    T* residual) const
-    {
-      const T *camera_aa(&c_p1[0]);
-      const T *camera_tx(&c_p1[3]);
-      const T *target_aa(& c_p3[0]);
-      const T *target_tx(& c_p3[3]);
-      T fx, fy, cx, cy, k1, k2, k3, p1, p2;      
-      extractCameraIntrinsics(c_p2, fx, fy, cx, cy, k1, k2, k3, p1, p2);
-      T world_point[3]; /** point in world coordinates */
-      T camera_point[3];  /** point in camera coordinates*/ 
-      T R_WtoC[9]; // rotation from world to camera coordinates
-      T R_TtoW[9]; // rotation from target to world coordinates
-      T R_TtoC[9];  // rotation from target to camera coordinates (assume circle lies in x-y plane of target coordinates)
-
-      /** compute necessary rotation matrices */
-      ceres::AngleAxisToRotationMatrix(camera_aa, R_WtoC);  
-      ceres::AngleAxisToRotationMatrix(target_aa, R_TtoW);
-
-      /** transform point into camera coordinates */
-      transformPoint3d(target_aa, target_tx, point_, world_point);
-      transformPoint(camera_aa, camera_tx, world_point, camera_point);
-
-      // find rotation from target to camera coordinates
-      rotationProduct(R_WtoC, R_TtoW, R_TtoC); // R_WtoC*R_TtoW = R_TtoC
-
-      /** compute project point into image plane and compute residual */
-      T circle_diameter = T(circle_diameter_);
-      T ox = T(ox_);
-      T oy = T(oy_);
-      cameraCircResidualDist(camera_point, circle_diameter, R_TtoC, k1, k2, k3, p1, p2, fx, fy,cx,cy, ox, oy, residual);
-
-      return true;
-    } /** end of operator() */
-    
-    /** Factory to hide the construction of the CostFunction object from */
-    /** the client code. */
-    static ceres::CostFunction* Create(const double o_x, const double o_y, const double c_dia, Point3d point)
-    {
-      return (new ceres::AutoDiffCostFunction<FixedCircleTargetCameraReprjErrorWithDistortionPK, 2, 6, 9, 3>(new FixedCircleTargetCameraReprjErrorWithDistortionPK(o_x, o_y, c_dia, point)));
-    }
-    double ox_; /** observed x location of object in image */
-    double oy_; /** observed y location of object in image */
-    double circle_diameter_; /** diameter of circle being observed */
-    Point3d point_; /** location of point in target coordinates */
-  };
-
-
-  class CircleTargetCameraReprjErrorWithDistortion
-  {
-  public:
-    CircleTargetCameraReprjErrorWithDistortion(double ob_x, double ob_y, double c_dia) :
-      ox_(ob_x), oy_(ob_y), circle_diameter_(c_dia)
-    {
-    }
-
-    template<typename T>
-    bool operator()(const T* const c_p1, /** extrinsic parameters [6]*/
-		    const T* const c_p2, /** intrinsic parameters of camera fx,fy,cx,cy,k1,k2,k2,p1,p2 [9]*/
-		    const T* const point, /** point described in target frame that is being seen [3]*/
-		    T* residual) const
-    {
-      const T *camera_aa(&c_p1[0]);
-      const T *camera_tx(&c_p1[3]);
-      T fx, fy, cx, cy, k1, k2, k3, p1, p2;      
-      extractCameraIntrinsics(c_p2, fx, fy, cx, cy, k1, k2, k3, p1, p2);
-      T world_point[3]; /** point in world coordinates */
-      T camera_point[3];  /** point in camera coordinates*/ 
-      T R_TtoC[9];  // rotation from target to camera coordinates (assume circle lies in x-y plane of target coordinates)
-
-      /** compute necessary rotation matrices */
-      ceres::AngleAxisToRotationMatrix(camera_aa, R_TtoC);  
-
-      /** transform point into camera coordinates */
-      transformPoint(camera_aa, camera_tx, point, camera_point);
-
-      /** compute project point into image plane and compute residual */
-      T circle_diameter = T(circle_diameter_);
-      T ox = T(ox_);
-      T oy = T(oy_);
-      cameraCircResidualDist(camera_point, circle_diameter, R_TtoC, k1, k2, k3, p1, p2, fx, fy,cx,cy, ox, oy, residual);
-
-      return true;
-    } /** end of operator() */
-    
-    /** Factory to hide the construction of the CostFunction object from */
-    /** the client code. */
-    static ceres::CostFunction* Create(const double o_x, const double o_y, const double c_dia)
-    {
-      return (new ceres::AutoDiffCostFunction<CircleTargetCameraReprjErrorWithDistortion, 2, 6, 9, 3>(new CircleTargetCameraReprjErrorWithDistortion(o_x, o_y, c_dia)));
-    }
-    double ox_; /** observed x location of object in image */
-    double oy_; /** observed y location of object in image */
-    double circle_diameter_; //** diameter of circle being observed */
-  };
-
-  // circle target is the origin, camera's location not known, distortion also unknown
-  class  SimpleCircleTargetCameraReprjErrorWithDistortionPK
-  {
-  public:
-    SimpleCircleTargetCameraReprjErrorWithDistortionPK(const double &ob_x, const double &ob_y, const double &c_dia,
-				   const Point3d &point) :
-      ox_(ob_x), oy_(ob_y), circle_diameter_(c_dia), point_(point)
-    {
-    }
-
-    template<typename T>
-    bool operator()(const T* const c_p1, /** extrinsic parameters [6] */
-		    const T* const c_p2, /** intrinsic parameters[9] */
-		    T* residual) const
-    {
-      const T *camera_aa(&c_p1[0]);
-      const T *camera_tx(&c_p1[3]);
-      T fx, fy, cx, cy, k1, k2, k3, p1, p2;      
-      extractCameraIntrinsics(c_p2, fx, fy, cx, cy, k1, k2, k3, p1, p2);
-      T camera_point[3];  /** point in camera coordinates */ 
-      T R_optical_to_target[9]; /** rotation from optical frame to target frame */
-      T circle_diameter = T(circle_diameter_);
-      T ox = T(ox_);
-      T oy = T(oy_);
-      T point[3];
-      point[0] = T(point_.x);
-      point[1] = T(point_.y);
-      point[2] = T(point_.z);
-      
-      /** get necessary rotation matrices */
-      ceres::AngleAxisToRotationMatrix(camera_aa, R_optical_to_target);  
-
-      /** transform point into camera coordinates */
-      transformPoint(camera_aa, camera_tx, point, camera_point);
-
-      /** compute project point into image plane and compute residual */
-      cameraCircResidualDist(camera_point, circle_diameter, R_optical_to_target, k1, k2, k3, p1, p2, fx, fy, cx, cy, ox, oy, residual);
-
-      return true;
-    } /** end of operator() */
-
-    /** Factory to hide the construction of the CostFunction object from */
-    /** the client code. */
-    static ceres::CostFunction* Create(const double &o_x, const double &o_y, const double &c_dia,
-				       Point3d &point)
-    {
-      return (new ceres::AutoDiffCostFunction< SimpleCircleTargetCameraReprjErrorWithDistortionPK, 2, 6, 9>
-	      (new SimpleCircleTargetCameraReprjErrorWithDistortionPK(o_x, o_y, c_dia, point)));
-    }
-    double ox_; /** observed x location of object in image */
-    double oy_; /** observed y location of object in image */
-    double circle_diameter_; //** diameter of circle being observed */
-    Point3d point_; /** point expressed in target coordinates */
-  };
-
-  class  CircleTargetCameraReprjErrorWithDistortionPK
-  {
-  public:
-    CircleTargetCameraReprjErrorWithDistortionPK(const double ob_x, const double ob_y, const double c_dia, const Point3d point) :
-      ox_(ob_x), oy_(ob_y), circle_diameter_(c_dia), point_(point)
-    {
-    }
-
-    template<typename T>
-    bool operator()(const T* const c_p1, /** extrinsic parameters [6] */
-		    const T* const c_p2,  /** 6Dof transform of target into world frame [6] */
-		    const T* const c_p3, /** intrinsic parameters of camera fx,fy,cx,cy,k1,k2,k2,p1,p2 [9] */
-		    T* residual) const
-    {
-      const T *camera_aa(&c_p1[0]);
-      const T *camera_tx(&c_p1[3]);
-      const T *target_aa(& c_p3[0]);
-      const T *target_tx(& c_p3[3]);
-      T fx, fy, cx, cy, k1, k2, k3, p1, p2;      
-      extractCameraIntrinsics(c_p2, fx, fy, cx, cy, k1, k2, k3, p1, p2);
-      T world_point[3]; /** point in world coordinates */
-      T camera_point[3]; /** point in world coordinates */
-      T R_WtoC[9]; // rotation from world to camera coordinates
-      T R_TtoW[9]; // rotation from target to world coordinates
-      T R_TtoC[9];  // rotation from target to camera coordinates (assume circle lies in x-y plane of target coordinates)
-
-      /** compute necessary rotation matrices */
-      ceres::AngleAxisToRotationMatrix(camera_aa, R_WtoC);  
-      ceres::AngleAxisToRotationMatrix(target_aa, R_TtoW);
-
-      /** transform point into camera coordinates */
-      transformPoint3d(target_aa, target_tx, point_, world_point);
-      transformPoint(camera_aa, camera_tx, world_point, camera_point);
-
-      // find rotation from target to camera coordinates
-      rotationProduct(R_WtoC, R_TtoW, R_TtoC); // R_WtoC*R_TtoW = R_TtoC
-
-      /** compute project point into image plane and compute residual */
-      T circle_diameter = T(circle_diameter_);
-      T ox = T(ox_);
-      T oy = T(oy_);
-      cameraCircResidualDist(camera_point, circle_diameter, R_TtoC, k1, k2, k3, p1, p2, fx, fy,cx,cy, ox, oy, residual);
-
-      return true;
-    } /** end of operator() */
-
-    /** Factory to hide the construction of the CostFunction object from */
-    /** the client code. */
-    static ceres::CostFunction* Create(const double o_x, const double o_y, const double c_dia, Point3d point)
-    {
-      return (new ceres::AutoDiffCostFunction<CircleTargetCameraReprjErrorWithDistortionPK, 2, 6, 6, 9>(											       new CircleTargetCameraReprjErrorWithDistortionPK(o_x, o_y, c_dia, point)));
-    }
-    double ox_; /** observed x location of object in image */
-    double oy_; /** observed y location of object in image */
-    double circle_diameter_; //** diameter of circle being observed */
-    Point3d point_;
-  };
-
-  class  CircleTargetCameraReprjError
-  {
-  public:
-    CircleTargetCameraReprjError(double ob_x, double ob_y, double c_dia, double fx, double fy, double cx, double cy) :
-      ox_(ob_x), oy_(ob_y), circle_diameter_(c_dia), fx_(fx), fy_(fy)
-    {
-    }
-
-    template<typename T>
-    bool operator()(const T* const c_p1, /** extrinsic parameters [6]*/
-		    const T* const c_p2, /** 6Dof transform of target into world frame [6]*/
-		    const T* const point, /** point described in target frame that is being seen [3]*/
-		    T* residual) const
-    {
-      const T *camera_aa(&c_p1[0]);
-      const T *camera_tx(&c_p1[3]);
-      const T *target_aa(& c_p2[0]);
-      const T *target_tx(& c_p2[3]);
-      T world_point[3]; /** point in world coordinates */
-      T camera_point[3];  /** point in camera coordinates*/ 
-      T R_WtoC[9]; // rotation from world to camera coordinates
-      T R_TtoW[9]; // rotation from target to world coordinates
-      T R_TtoC[9];  // rotation from target to camera coordinates (assume circle lies in x-y plane of target coordinates)
-
-      /** compute necessary rotation matrices */
-      ceres::AngleAxisToRotationMatrix(camera_aa, R_WtoC);  
-      ceres::AngleAxisToRotationMatrix(target_aa, R_TtoW);
-      
-      /** transform point into camera coordinates */
-      transformPoint(target_aa, target_tx, point, world_point);
-      transformPoint(camera_aa, camera_tx, world_point, camera_point);
-      
-      /** find rotation from target to camera coordinates */
-      rotationProduct(R_WtoC, R_TtoW, R_TtoC); // R_WtoC*R_TtoW = R_TtoC
-      
-      /** compute project point into image plane and compute residual */
-      T circle_diameter = T(circle_diameter_);
-      T fx = T(fx_);
-      T fy = T(fy_);
-      T cx = T(cx_);
-      T cy = T(cy_);
-      T ox = T(ox_);
-      T oy = T(oy_);
-      cameraCircResidual(camera_point, circle_diameter, R_TtoC, fx, fy,cx,cy, ox, oy, residual);
-
-      return true;
-    } /** end of operator() */
-    
-    /** Factory to hide the construction of the CostFunction object from */
-    /** the client code. */
-    static ceres::CostFunction* Create(const double o_x, const double o_y, const double c_dia, 
-				       const double fx, const double fy, const double cx, const double cy)
-    {
-      return (new ceres::AutoDiffCostFunction<CircleTargetCameraReprjError, 2, 6, 6, 3>(new CircleTargetCameraReprjError(o_x, o_y, c_dia, fx, fy, cx, cy)));
-    }
-    double ox_; /** observed x location of object in image */
-    double oy_; /** observed y location of object in image */
-    double circle_diameter_; //** diameter of circle being observed */
-    double fx_; /** focal length of camera in x (pixels) */
-    double fy_; /** focal length of camera in y (pixels) */
-    double cx_; /** focal center of camera in x (pixels) */
-    double cy_; /** focal center of camera in y (pixels) */
-  };
-
-  class  CircleTargetCameraReprjErrorPK
-  {
-  public:
-    CircleTargetCameraReprjErrorPK(double ob_x, double ob_y, double c_dia, double fx, double fy, double cx, double cy, Point3d point) :
-      ox_(ob_x), oy_(ob_y), circle_diameter_(c_dia), fx_(fx), fy_(fy), cx_(cx), cy_(cy), point_(point)
-    {
-    }
-
-    template<typename T>
-    bool operator()(const T* const c_p1, /** extrinsic parameters [6] */
-		    const T* const c_p2,  /** 6Dof transform of target into world frame [6] */
-		    T* residual) const
-    {
-      const T *camera_aa(&c_p1[0]);
-      const T *camera_tx(&c_p1[3]);
-      const T *target_aa(& c_p2[0]);
-      const T *target_tx(& c_p2[3]);
-      T world_point[3]; /** point in world coordinates */
-      T camera_point[3]; /** point in camera coordinates */
-      T R_WtoC[9]; // rotation from world to camera coordinates
-      T R_TtoW[9]; // rotation from target to world coordinates
-      T R_TtoC[9];  // rotation from target to camera coordinates (assume circle lies in x-y plane of target coordinates)
-
-      /** compute necessary rotation matrices */
-      ceres::AngleAxisToRotationMatrix(camera_aa, R_WtoC);  
-      ceres::AngleAxisToRotationMatrix(target_aa, R_TtoW);
-
-      /** transform point into camera frame */
-      transformPoint3d(target_aa, target_tx, point_, world_point);
-      transformPoint(camera_aa, camera_tx, world_point, camera_point);
-
-      /** find rotation from target to camera coordinates */
-      rotationProduct(R_WtoC, R_TtoW, R_TtoC); // R_WtoC*R_TtoW = R_TtoC
-      
-      /** compute project point into image plane and compute residual */
-      T circle_diameter = T(circle_diameter_);
-      T fx = T(fx_);
-      T fy = T(fy_);
-      T cx = T(cx_);
-      T cy = T(cy_);
-      T ox = T(ox_);
-      T oy = T(oy_);
-      cameraCircResidual(camera_point, circle_diameter, R_TtoC, fx, fy,cx,cy, ox, oy, residual);
-
-      return true;
-    } /** end of operator() */
-
-    /** Factory to hide the construction of the CostFunction object from */
-    /** the client code. */
-    static ceres::CostFunction* Create(const double o_x, const double o_y, const double c_dia,
-				       const double fx, const double fy, const double cx, const double cy,
-				       Point3d point)
-    {
-      return (new ceres::AutoDiffCostFunction<CircleTargetCameraReprjErrorPK, 2, 6, 6>(											       new CircleTargetCameraReprjErrorPK(o_x, o_y, c_dia, fx, fy, cx, cy, point)));
-    }
-    double ox_; /** observed x location of object in image */
-    double oy_; /** observed y location of object in image */
-    double circle_diameter_; //** diameter of circle being observed */
-    double fx_; /** focal length of camera in x (pixels) */
-    double fy_; /** focal length of camera in y (pixels) */
-    double cx_; /** focal center of camera in x (pixels) */
-    double cy_; /** focal center of camera in y (pixels) */
-    Point3d point_;
-  };
-
-  class  LinkCircleTargetCameraReprjError
-  {
-  public:
-    LinkCircleTargetCameraReprjError(double ob_x, double ob_y, double c_dia, double fx, double fy, double cx, double cy, Pose6d link_pose) :
-      ox_(ob_x), oy_(ob_y), circle_diameter_(c_dia), fx_(fx), fy_(fy), cx_(cx), cy_(cy), link_pose_(link_pose)
-    {
-    }
-
-    template<typename T>
-    bool operator()(const T* const c_p1, /** extrinsic parameters [6]*/
-		    const T* const c_p2, /** 6Dof transform of target into world frame [6]*/
-		    const T* const point, /** point described in target frame that is being seen [3]*/
-		    T* residual) const
-    {
-      const T *camera_aa(&c_p1[0]);
-      const T *camera_tx(&c_p1[3]);
-      const T *target_aa(& c_p2[0]);
-      const T *target_tx(& c_p2[3]);
-      T link_point[3]; /** point in link coordinates */
-      T world_point[3]; /** point in world coordinates */
-      T camera_point[3];  /** point in camera coordinates*/ 
-      T R_WtoC[9]; // rotation from world to camera coordinates
-      T R_TtoL[9]; // rotation from target to linkcoordinates
-      T R_LtoW[9]; // rotation from link to world coordinates
-      T R_TtoC[9];  // rotation from target to camera coordinates (assume circle lies in x-y plane of target coordinates)
-      T R_LtoC[9]; // rotation from link to camera coordinates
-
-      /** get necessary rotation matrices */
-      ceres::AngleAxisToRotationMatrix(camera_aa, R_WtoC);  
-      ceres::AngleAxisToRotationMatrix(target_aa, R_TtoL);
-      poseRotationMatrix(link_pose_, R_LtoW);
-
-      /** transform point into camera coordinates */
-      transformPoint(target_aa, target_tx, point, link_point);
-      poseTransformPoint(link_pose_, link_point, world_point);
-      transformPoint(camera_aa, camera_tx, world_point, camera_point);
-      
-      /** find rotation from target to camera coordinates */
-      rotationProduct(R_WtoC, R_LtoW, R_LtoC);
-      rotationProduct(R_LtoC, R_TtoL, R_TtoC); // R_WtoC*R_LtoW*R_TtoL = R_TtoC
-      
-      /** compute project point into image plane and compute residual */
-      T circle_diameter = T(circle_diameter_);
-      T fx = T(fx_);
-      T fy = T(fy_);
-      T cx = T(cx_);
-      T cy = T(cy_);
-      T ox = T(ox_);
-      T oy = T(oy_);
-      cameraCircResidual(camera_point, circle_diameter, R_TtoC, fx, fy,cx,cy, ox, oy, residual);
-
-      return true;
-    } /** end of operator() */
-    
-    /** Factory to hide the construction of the CostFunction object from */
-    /** the client code. */
-    static ceres::CostFunction* Create(const double o_x, const double o_y, const double c_dia,
-				       const double fx,  const double fy,
-				       const double cx,  const double cy,
-				       const Pose6d pose)
-    {
-      return (new ceres::AutoDiffCostFunction<LinkCircleTargetCameraReprjError, 2, 6, 6, 3>(new LinkCircleTargetCameraReprjError(o_x, o_y, c_dia, fx, fy, cx, cy, pose)));
-    }
-    double ox_; /** observed x location of object in image */
-    double oy_; /** observed y location of object in image */
-    double circle_diameter_; /** diameter of circle being observed */
-    Pose6d link_pose_; /** transform from link to world coordinates*/
-    double fx_; /** focal length of camera in x (pixels) */
-    double fy_; /** focal length of camera in y (pixels) */
-    double cx_; /** focal center of camera in x (pixels) */
-    double cy_; /** focal center of camera in y (pixels) */ 
- };
-
-  class  LinkCircleTargetCameraReprjErrorPK
-  {
-  public:
-  LinkCircleTargetCameraReprjErrorPK(double ob_x, double ob_y, double c_dia, double fx, double fy, double cx, double cy, 
-				     Pose6d link_pose, Point3d point) :
-    ox_(ob_x), oy_(ob_y), circle_diameter_(c_dia), fx_(fx), fy_(fy), cx_(cx), cy_(cy), link_pose_(link_pose), point_(point)
-    {
-    }
-
-    template<typename T>
-    bool operator()(const T* const c_p1, /** extrinsic parameters [6] */
-		    const T* const c_p2,  /** 6Dof transform of target into world frame [6] */
-		    T* residual) const
-    {
-      const T *camera_aa(&c_p1[0]);
-      const T *camera_tx(&c_p1[3]);
-      const T *target_aa(& c_p2[0]);
-      const T *target_tx(& c_p2[3]);
-      T link_point[3]; /** point in link coordinates */
-      T world_point[3];/** point in world coordinates */
-      T camera_point[3]; /** point in camera coordinates */
-      T R_WtoC[9]; // rotation from world to camera coordinates
-      T R_TtoL[9]; // rotation from target to linkcoordinates
-      T R_LtoW[9]; // rotation from link to world coordinates
-      T R_LtoC[9]; // rotation from link to camera coordinataes
-      T R_TtoC[9];  // rotation from target to camera coordinates (assume circle lies in x-y plane of target coordinates)
-
-      /** compute necessary rotation matrices */
-      ceres::AngleAxisToRotationMatrix(camera_aa, R_WtoC);  
-      ceres::AngleAxisToRotationMatrix(target_aa, R_TtoL);
-      poseRotationMatrix(link_pose_,R_LtoW);
-
-      /** transform point into camera frame */
-      transformPoint3d(target_aa, target_tx, point_, link_point);
-      poseTransformPoint(link_pose_, link_point, world_point);
-      transformPoint(camera_aa, camera_tx, world_point, camera_point);
-
-      /** find rotation from target to camera coordinates */
-      rotationProduct(R_WtoC, R_LtoW, R_LtoC);
-      rotationProduct(R_LtoC, R_TtoL, R_TtoC); // R_WtoC*R_LtoW*R_TtoL = R_TtoC
-      
-      /** compute project point into image plane and compute residual */
-      T circle_diameter = T(circle_diameter_);
-      T fx = T(fx_);
-      T fy = T(fy_);
-      T cx = T(cx_);
-      T cy = T(cy_);
-      T ox = T(ox_);
-      T oy = T(oy_);
-      cameraCircResidual(camera_point, circle_diameter, R_TtoC, fx, fy,cx,cy, ox, oy, residual);
-
-      return true;
-    } /** end of operator() */
-
-    /** Factory to hide the construction of the CostFunction object from */
-    /** the client code. */
-    static ceres::CostFunction* Create(const double o_x, const double o_y, const double c_dia,
-				       const double fx,  const double fy,
-				       const double cx,  const double cy,
-				       const Pose6d pose, Point3d point)
-    {
-      return (new ceres::AutoDiffCostFunction<LinkCircleTargetCameraReprjErrorPK, 2, 6, 6>
-	      (
-	       new LinkCircleTargetCameraReprjErrorPK(o_x, o_y, c_dia, fx, fy, cx, cy, pose, point)
-	       )
-	      );
-    }
-    double ox_; /** observed x location of object in image */
-    double oy_; /** observed y location of object in image */
-    double circle_diameter_; //** diameter of circle being observed */
-    Pose6d link_pose_; /** transform from link to world coordinates*/
-    double fx_; /** focal length of camera in x (pixels) */
-    double fy_; /** focal length of camera in y (pixels) */
-    double cx_; /** focal center of camera in x (pixels) */
-    double cy_; /** focal center of camera in y (pixels) */
-    Point3d point_; /** point expressed in target coordinates */
-  };
-
-
-  class  LinkCameraCircleTargetReprjError
-  {
-  public:
-    LinkCameraCircleTargetReprjError(double ob_x, double ob_y, double c_dia,
-				     double fx, double fy, double cx, double cy, Pose6d link_pose) :
-      ox_(ob_x), oy_(ob_y), circle_diameter_(c_dia), fx_(fx), fy_(fy), cx_(cx), cy_(cy), link_pose_(link_pose)
-    {
-      link_posei_ = link_pose_.getInverse();
-    }
-
-    template<typename T>
-    bool operator()(const T* const c_p1, /** extrinsic parameters [6]*/
-		    const T* const c_p2, /** 6Dof transform of target into world frame [6]*/
-		    const T* const point, /** point described in target frame that is being seen [3]*/
-		    T* residual) const
-    {
-      const T *camera_aa(&c_p1[0]);
-      const T *camera_tx(&c_p1[3]);
-      const T *target_aa(& c_p2[0]);
-      const T *target_tx(& c_p2[3]);
-      T world_point[3]; /** point in world coordinates */
-      T link_point[3]; /** point in link coordinates */
-      T camera_point[3];  /** point in camera coordinates*/ 
-      T R_LtoC[9]; // rotation from link to camera coordinates
-      T R_WtoL[9]; // rotation from world to link coordinates
-      T R_WtoC[9]; // rotation from world to camera coordinates, and intermediate transform
-      T R_TtoW[9]; // rotation from target to world coordinates
-      T R_TtoC[9];  // rotation from target to camera coordinates (assume circle lies in x-y plane of target coordinates)
-
-      /** compute necessary rotation matrices */
-      ceres::AngleAxisToRotationMatrix(camera_aa, R_LtoC);  
-      poseRotationMatrix(link_pose_, R_WtoL);
-      ceres::AngleAxisToRotationMatrix(target_aa, R_TtoW);
-      
-      /** transform point into camera coordinates */
-      transformPoint(target_aa, target_tx, point, world_point);
-      poseTransformPoint(link_posei_, world_point, link_point);
-      transformPoint(camera_aa, camera_tx, link_point, camera_point);
-      
-      /** find rotation from target to camera coordinates */
-      rotationProduct(R_LtoC,R_WtoL, R_WtoC);
-      rotationProduct(R_WtoC, R_TtoW, R_TtoC); 
-      
-      /** compute project point into image plane and compute residual */
-      T circle_diameter = T(circle_diameter_);
-      T fx = T(fx_);
-      T fy = T(fy_);
-      T cx = T(cx_);
-      T cy = T(cy_);
-      T ox = T(ox_);
-      T oy = T(oy_);
-      cameraCircResidual(camera_point, circle_diameter, R_TtoC, fx, fy,cx,cy, ox, oy, residual);
-
-      return true;
-    } /** end of operator() */
-    
-    /** Factory to hide the construction of the CostFunction object from */
-    /** the client code. */
-    static ceres::CostFunction* Create(const double o_x, const double o_y, const double c_dia,
-				       double fx, double fy, double cx, double cy, const Pose6d pose)
-    {
-      return (new ceres::AutoDiffCostFunction<LinkCameraCircleTargetReprjError, 2, 6, 6, 3>
-	      (new LinkCameraCircleTargetReprjError(o_x, o_y, c_dia, fx, fy, cx, cy, pose)));
-    }
-    double ox_; /** observed x location of object in image */
-    double oy_; /** observed y location of object in image */
-    double circle_diameter_; /** diameter of circle being observed */
-    Pose6d link_pose_; /** transform from link to world coordinates*/
-    Pose6d link_posei_; /** transform from world to link coordinates*/
-    double fx_; /** focal length of camera in x (pixels) */
-    double fy_; /** focal length of camera in y (pixels) */
-    double cx_; /** focal center of camera in x (pixels) */
-    double cy_; /** focal center of camera in y (pixels) */
-
-  };
-
-  class  LinkCameraCircleTargetReprjErrorPK
-  {
-  public:
-    LinkCameraCircleTargetReprjErrorPK(const double &ob_x, const double &ob_y, const double &c_dia,
-				       const double &fx, const double &fy, const double &cx, const double &cy,
-				       const Pose6d &link_pose, const Point3d &point) :
-      ox_(ob_x), oy_(ob_y), circle_diameter_(c_dia), fx_(fx), fy_(fy), cx_(cx), cy_(cy), link_pose_(link_pose), point_(point)
-    {
-      link_posei_ = link_pose_.getInverse();
-    }
-
-    void test_residual(const double *c_p1, const double  *c_p2, double *residual)
-    {
-      const double *camera_aa(&c_p1[0]);
-      const double *camera_tx(&c_p1[3]);
-      const double *target_aa(&c_p2[0]);
-      const double *target_tx(&c_p2[3]);
-      double point[3]; /** point in target coordinates */
-      double world_point[3]; /** point in world coordinates */
-      double link_point[3]; /** point in link coordinates */
-      double camera_point[3];  /** point in camera coordinates*/ 
-      double R_LtoC[9]; // rotation from link to camera coordinates
-      double R_WtoL[9]; // rotation from world to link coordinates
-      double R_WtoC[9]; // rotation from world to camera coordinates, and intermediate transform
-      double R_TtoW[9]; // rotation from target to world coordinates
-      double R_TtoC[9];  // rotation from target to camera coordinates (assume circle lies in x-y plane of target coordinates)
-      /** get necessary rotation matrices */
-      ceres::AngleAxisToRotationMatrix(camera_aa, R_LtoC);  
-      printf("camera_aa = %6.3lf %6.3lf %6.3lf\n", camera_aa[0], camera_aa[1], camera_aa[2]);
-      printf("R_camera \n");
-      for(int i=0;i<3;i++){
-	for(int j=0;j<3;j++){
-	  printf("%6.3lf",R_LtoC[i+j*3]);
-	  }
-	printf("\n");
-      }
-      poseRotationMatrix(link_posei_,R_WtoL);
-      printf("R_inverse link\n");
-      for(int i=0;i<3;i++){
-	for(int j=0;j<3;j++){
-	  printf("%6.3lf",R_WtoL[i+j*3]);
-	  }
-	printf("\n");
-      }
-
-      ceres::AngleAxisToRotationMatrix(target_aa, R_TtoW);
-      printf("R_target\n");
-      for(int i=0;i<3;i++){
-	for(int j=0;j<3;j++){
-	  printf("%6.3lf",R_TtoW[i+j*3]);
-	  }
-	printf("\n");
-      }
-      
-      printf("point_ = %6.3lf  %6.3lf %6.3lf\n", point_.x, point_.y, point_.z);
-      /** transform point into camera coordinates */
-      transformPoint3d(target_aa, target_tx, point_, world_point);
-      printf("world_point = %6.3lf  %6.3lf %6.3lf\n", world_point[0], world_point[1], world_point[2]);
-      poseTransformPoint(link_posei_, world_point, link_point);
-      printf("link_point = %6.3lf  %6.3lf %6.3lf\n", link_point[0], link_point[1], link_point[2]);
-      transformPoint(camera_aa, camera_tx, link_point, camera_point);
-      printf("camera_point = %6.3lf  %6.3lf %6.3lf\n", camera_point[0], camera_point[1], camera_point[2]);
-
-      /** find rotation from target to camera coordinates */
-      rotationProduct(R_LtoC, R_WtoL, R_WtoC);
-      rotationProduct(R_WtoC, R_TtoW, R_TtoC); 
-
-      /** compute project point into image plane and compute residual */
-      double circle_diameter = circle_diameter_;
-      double fx = fx_;
-      double fy = fy_;
-      double cx = cx_;
-      double cy = cy_;
-      double ox = ox_;
-      double oy = oy_;
-      //      cameraCircResidual(camera_point, circle_diameter, R_TtoC, fx, fy,cx,cy, ox, oy, residual);
-      cameraPntResidual(camera_point, fx, fy,cx,cy, ox, oy, residual);
-      
-    }
-    template<typename T>
-    bool operator()(const T* const c_p1, /** extrinsic parameters [6] */
-		    const T* const c_p2,  /** 6Dof transform of target into world frame [6] */
-		    T* residual) const
-    {
-      const T *camera_aa(&c_p1[0]);
-      const T *camera_tx(&c_p1[3]);
-      const T *target_aa(&c_p2[0]);
-      const T *target_tx(&c_p2[3]);
-      T point[3]; /** point in target coordinates */
-      T world_point[3]; /** point in world coordinates */
-      T link_point[3]; /** point in link coordinates */
-      T camera_point[3];  /** point in camera coordinates*/ 
-      T R_LtoC[9]; // rotation from link to camera coordinates
-      T R_WtoL[9]; // rotation from world to link coordinates
-      T R_WtoC[9]; // rotation from world to camera coordinates, and intermediate transform
-      T R_TtoW[9]; // rotation from target to world coordinates
-      T R_TtoC[9];  // rotation from target to camera coordinates (assume circle lies in x-y plane of target coordinates)
-
-      /** get necessary rotation matrices */
-      ceres::AngleAxisToRotationMatrix(camera_aa, R_LtoC);  
-      poseRotationMatrix(link_posei_,R_WtoL);
-      ceres::AngleAxisToRotationMatrix(target_aa, R_TtoW);
-
-      /** transform point into camera coordinates */
-      transformPoint3d(target_aa, target_tx, point_, world_point);
-      poseTransformPoint(link_posei_, world_point, link_point);
-      transformPoint(camera_aa, camera_tx, link_point, camera_point);
-
-      /** find rotation from target to camera coordinates */
-      rotationProduct(R_LtoC, R_WtoL, R_WtoC);
-      rotationProduct(R_WtoC, R_TtoW, R_TtoC); 
-
-      /** compute project point into image plane and compute residual */
-      T circle_diameter = T(circle_diameter_);
-      T fx = T(fx_);
-      T fy = T(fy_);
-      T cx = T(cx_);
-      T cy = T(cy_);
-      T ox = T(ox_);
-      T oy = T(oy_);
-      cameraCircResidual(camera_point, circle_diameter, R_TtoC, fx, fy,cx,cy, ox, oy, residual);
-
-      return true;
-    } /** end of operator() */
-
-    /** Factory to hide the construction of the CostFunction object from */
-    /** the client code. */
-    static ceres::CostFunction* Create(const double &o_x, const double &o_y, const double &c_dia,
-				       const double &fx,  const double &fy,
-				       const double &cx, const double &cy,
-				       const Pose6d &pose, Point3d &point)
-    {
-      return (new ceres::AutoDiffCostFunction<LinkCameraCircleTargetReprjErrorPK, 2, 6, 6>
-	      (new LinkCameraCircleTargetReprjErrorPK(o_x, o_y, c_dia, fx, fy, cx, cy, pose, point)));
-    }
-    double ox_; /** observed x location of object in image */
-    double oy_; /** observed y location of object in image */
-    double circle_diameter_; //** diameter of circle being observed */
-    Pose6d link_pose_; /** transform from link to world coordinates*/
-    Pose6d link_posei_; /** transform from world to link coordinates*/
-    double fx_; /** focal length of camera in x (pixels) */
-    double fy_; /** focal length of camera in y (pixels) */
-    double cx_; /** focal center of camera in x (pixels) */
-    double cy_; /** focal center of camera in y (pixels) */
-    Point3d point_; /** point expressed in target coordinates */
-
-  };
-
-  class  FixedCircleTargetCameraReprjErrorPK
-  {
-  public:
-    FixedCircleTargetCameraReprjErrorPK(const double &ob_x, const double &ob_y, const double &c_dia,
-					const double &fx, const double &fy, const double &cx, const double &cy,
-					const Pose6d &target_pose,
-					const Pose6d &camera_mounting_pose,
-					const Point3d &point) :
-      ox_(ob_x), oy_(ob_y), circle_diameter_(c_dia), fx_(fx), fy_(fy), cx_(cx), cy_(cy), 
-      target_pose_(target_pose), camera_mounting_pose_(camera_mounting_pose), point_(point)
-    {
-      // compute pose which transforms point in target frame to the mounting frame
-      mount_to_target_pose_ = camera_mounting_pose_.getInverse() * target_pose_;
-    }
-
-    void test_residual(const double *c_p1, double *resid)
-    {
-      const double *camera_aa(&c_p1[0]);
-      const double *camera_tx(&c_p1[3]);
-      double mount_point[3]; /** point in world coordinates */
-      double camera_point[3];  /** point in camera coordinates */ 
-      double point[3]; /** point in world coordinates  */
-      point[0] = point_.x;
-      point[1] = point_.y;
-      point[2] = point_.z;
-      /** transform point into camera coordinates */
-      poseTransformPoint(mount_to_target_pose_, point, mount_point);
-      printf("mount_point = %6.3lf  %6.3lf %6.3lf\n", mount_point[0], mount_point[1], mount_point[2]);
-      transformPoint(camera_aa, camera_tx, mount_point, camera_point);
-      printf("camera_point = %6.3lf  %6.3lf %6.3lf\n", camera_point[0], camera_point[1], camera_point[2]);
-
-      double R_optical_to_mount[9]; /** rotation from optical to camera mounting frame */
-      double R_mount_to_target[9]; /** rotation from mounting frame to target frame */
-
-      /** get necessary rotation matrices */
-      ceres::AngleAxisToRotationMatrix(camera_aa, R_optical_to_mount);  
-      poseRotationMatrix(mount_to_target_pose_, R_mount_to_target);
-
-      /** compute project point into image plane and compute residual */
-      double circle_diameter = circle_diameter_;
-      double fx = fx_;
-      double fy = fy_;
-      double cx = cx_;
-      double cy = cy_;
-      double ox = ox_;
-      double oy = oy_;
-      cameraCircResidual(camera_point, circle_diameter, R_mount_to_target, fx, fy, cx, cy, ox, oy, resid);
-    }
-    template<typename T>
-    bool operator()(const T* const c_p1, /** extrinsic parameters [6] */
-		    T* residual) const
-    {
-      const T *camera_aa(&c_p1[0]);
-      const T *camera_tx(&c_p1[3]);
-      T mount_point[3]; /** point in world coordinates */
-      T camera_point[3];  /** point in camera coordinates */ 
-      T R_optical_to_mount[9]; /** rotation from optical to camera mounting frame */
-      T R_mount_to_target[9]; /** rotation from mounting frame to target frame */
-      T R_optical_to_target[9]; /** rotation from optical frame to target frame */
-      T point[3];
-      point[0] = T(point_.x);
-      point[1] = T(point_.y);
-      point[2] = T(point_.z);
-
-      /** get necessary rotation matrices */
-      ceres::AngleAxisToRotationMatrix(camera_aa, R_optical_to_mount);  
-      poseRotationMatrix(mount_to_target_pose_,R_mount_to_target);
-
-      /** transform point into camera coordinates */
-      poseTransformPoint(mount_to_target_pose_, point, mount_point);
-      transformPoint(camera_aa, camera_tx, mount_point, camera_point);
-
-      /** find rotation from target to camera coordinates */
-      rotationProduct(R_optical_to_mount, R_mount_to_target, R_optical_to_target);
-
-      /** compute project point into image plane and compute residual */
-      T circle_diameter = T(circle_diameter_);
-      T fx = T(fx_);
-      T fy = T(fy_);
-      T cx = T(cx_);
-      T cy = T(cy_);
-      T ox = T(ox_);
-      T oy = T(oy_);
-      cameraCircResidual(camera_point, circle_diameter, R_optical_to_target, fx, fy, cx, cy, ox, oy, residual);
-
-      return true;
-    } /** end of operator() */
-
-    /** Factory to hide the construction of the CostFunction object from */
-    /** the client code. */
-    static ceres::CostFunction* Create(const double &o_x, const double &o_y, const double &c_dia,
-				       const double &fx,  const double &fy,
-				       const double &cx, const double &cy,
-				       const Pose6d &target_pose, 
-				       const Pose6d &camera_mounting_pose,
-				       Point3d &point)
-    {
-      return (new ceres::AutoDiffCostFunction< FixedCircleTargetCameraReprjErrorPK, 2, 6>
-	      (new FixedCircleTargetCameraReprjErrorPK(o_x, o_y, c_dia, fx, fy, cx, cy, target_pose, camera_mounting_pose, point)));
-    }
-    double ox_; /** observed x location of object in image */
-    double oy_; /** observed y location of object in image */
-    double circle_diameter_; //** diameter of circle being observed */
-    Pose6d target_pose_; /** pose of target relative to the reference coordinate frame */
-    Pose6d camera_mounting_pose_; /** pose camera mounting frame relative to the reference coordinate frame */
-    Pose6d mount_to_target_pose_; /** pose of target frame relative to camera's mounting frame */
-    double fx_; /** focal length of camera in x (pixels) */
-    double fy_; /** focal length of camera in y (pixels) */
-    double cx_; /** focal center of camera in x (pixels) */
-    double cy_; /** focal center of camera in y (pixels) */
-    Point3d point_; /** point expressed in target coordinates */
-  };
-
-  class  RailICal
-  {
-  public:
-    RailICal(double ob_x, double ob_y, double rail_position, Point3d point) :
-      ox_(ob_x), oy_(ob_y), rail_position_(rail_position), point_(point)
-    {
-    }
-
-    template<typename T>
-    bool operator()(	    const T* const c_p1,  /**intrinsics [9] */
-		    const T* const c_p2,  /**target_pose [6] */
-		    T* residual) const
-    {
-      T fx, fy, cx, cy, k1, k2, k3, p1, p2;      // extract intrinsics
-      extractCameraIntrinsics(c_p1, fx, fy, cx, cy, k1, k2, k3, p1, p2);
-      const T *target_aa(& c_p2[0]); // extract target's angle axis
-      const T *target_tx(& c_p2[3]); // extract target's position
-
-      /** transform point into camera frame */
-      T camera_point[3]; /** point in camera coordinates */
-      transformPoint3d(target_aa, target_tx, point_, camera_point);
-      camera_point[2] = camera_point[2] + T(rail_position_); // transform to camera's location along rail
-
-      /** compute project point into image plane and compute residual */
-      T ox = T(ox_);
-      T oy = T(oy_);
-      cameraPntResidualDist(camera_point, k1, k2, k3, p1, p2, fx, fy, cx, cy, ox, oy,  residual);
-
-      return true;
-    } /** end of operator() */
-
-    /** Factory to hide the construction of the CostFunction object from */
-    /** the client code. */
-    static ceres::CostFunction* Create(const double o_x, const double o_y, 
-				       const double rail_position,
-				       Point3d point)
-    {
-      return (new ceres::AutoDiffCostFunction<RailICal, 2, 9, 6>
-	      (
-	       new RailICal(o_x, o_y, rail_position, point)
-	       )
-	      );
-    }
-    double ox_; /** observed x location of object in image */
-    double oy_; /** observed y location of object in image */
-    double rail_position_; /** location of camera along rail */
-    Point3d point_; /** point expressed in target coordinates */
-  };
-
-} // end of namespace
+  double ox_;            /** observed x location of object in image */
+  double oy_;            /** observed y location of object in image */
+  double rail_position_; /** location of camera along rail */
+  Point3d point_;        /** point expressed in target coordinates */
+};
+
+}  // end of namespace
 #endif

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/ceres_costs_utils_test.hpp
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/ceres_costs_utils_test.hpp
@@ -25,10 +25,9 @@
 
 namespace industrial_extrinsic_cal
 {
-
 /* local prototypes of helper functions */
 
-/*! \brief print a quaternion plus position as a homogeneous transform 
+/*! \brief print a quaternion plus position as a homogeneous transform
  *  \param qx quaternion x value
  *  \param qy quaternion y value
  *  \param qz quaternion z value
@@ -72,7 +71,7 @@ void printAAasEuler(double ax, double ay, double az);
  */
 void printCameraParameters(CameraParameters C, std::string words);
 
-/*! \brief  computes image of point in cameras image plane 
+/*! \brief  computes image of point in cameras image plane
  *  \param  C both intrinsic and extrinsic camera parameters
  *  \param  P the point to be projected into image
  */
@@ -90,18 +89,18 @@ Observation projectPointWithDistortion(CameraParameters C, Point3d P)
   /* transform point into camera frame */
   /* note, camera transform takes points from camera frame into world frame */
   double aa[3];
-  aa[0]=C.pb_extrinsics[0];
-  aa[1]=C.pb_extrinsics[1];
-  aa[2]=C.pb_extrinsics[2];
+  aa[0] = C.pb_extrinsics[0];
+  aa[1] = C.pb_extrinsics[1];
+  aa[2] = C.pb_extrinsics[2];
   ceres::AngleAxisRotatePoint(aa, pt, p);
 
   // apply camera translation
   double xp1 = p[0] + C.pb_extrinsics[3];
   double yp1 = p[1] + C.pb_extrinsics[4];
   double zp1 = p[2] + C.pb_extrinsics[5];
-  //p[0] +=C.pb_extrinsics[3];
-  //p[1] +=C.pb_extrinsics[4];
-  //p[2] +=C.pb_extrinsics[5];
+  // p[0] +=C.pb_extrinsics[3];
+  // p[1] +=C.pb_extrinsics[4];
+  // p[2] +=C.pb_extrinsics[5];
 
   double xp = xp1 / zp1;
   double yp = yp1 / zp1;
@@ -115,10 +114,10 @@ Observation projectPointWithDistortion(CameraParameters C, Point3d P)
   double yp2 = yp * yp;
 
   /* apply the distortion coefficients to refine pixel location */
-  double xpp = xp + C.distortion_k1 * r2 * xp + C.distortion_k2 * r4 * xp +
-      C.distortion_k3 * r6 * xp + C.distortion_p2 * (r2 + 2 * xp2) + 2 * C.distortion_p1 * xp * yp;
-  double ypp = yp + C.distortion_k1 * r2 * yp + C.distortion_k2 * r4 * yp +
-      C.distortion_k3 * r6 * yp + C.distortion_p1 * (r2 + 2 * yp2) + 2 * C.distortion_p2 * xp * yp;
+  double xpp = xp + C.distortion_k1 * r2 * xp + C.distortion_k2 * r4 * xp + C.distortion_k3 * r6 * xp +
+               C.distortion_p2 * (r2 + 2 * xp2) + 2 * C.distortion_p1 * xp * yp;
+  double ypp = yp + C.distortion_k1 * r2 * yp + C.distortion_k2 * r4 * yp + C.distortion_k3 * r6 * yp +
+               C.distortion_p1 * (r2 + 2 * yp2) + 2 * C.distortion_p2 * xp * yp;
 
   /* perform projection using focal length and camera center into image plane */
   Observation O;
@@ -130,16 +129,16 @@ Observation projectPointWithDistortion(CameraParameters C, Point3d P)
 
 Observation projectPointNoDistortion(CameraParameters C, Point3d P)
 {
-  double p[3];                  // rotated into camera frame
-  double point[3];              // world location of point
-  double aa[3];                 // angle axis representation of camera transform
-  double tx = C.position[0];    // location of origin in camera frame x
-  double ty = C.position[1];    // location of origin in camera frame y
-  double tz = C.position[2];    // location of origin in camera frame z
-  double fx = C.focal_length_x; // focal length x
-  double fy = C.focal_length_y; // focal length y
-  double cx = C.center_x;       // optical center x
-  double cy = C.center_y;       // optical center y
+  double p[3];                   // rotated into camera frame
+  double point[3];               // world location of point
+  double aa[3];                  // angle axis representation of camera transform
+  double tx = C.position[0];     // location of origin in camera frame x
+  double ty = C.position[1];     // location of origin in camera frame y
+  double tz = C.position[2];     // location of origin in camera frame z
+  double fx = C.focal_length_x;  // focal length x
+  double fy = C.focal_length_y;  // focal length y
+  double cx = C.center_x;        // optical center x
+  double cy = C.center_y;        // optical center y
 
   aa[0] = C.angle_axis[0];
   aa[1] = C.angle_axis[1];
@@ -167,5 +166,5 @@ Observation projectPointNoDistortion(CameraParameters C, Point3d P)
   return (O);
 }
 
-} // end of namespace
+}  // end of namespace
 #endif

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/circle_cost_utils.hpp
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/circle_cost_utils.hpp
@@ -6,599 +6,563 @@
 
 namespace industrial_extrinsic_cal
 {
-  /** @brief A ceres reprojection error class which returns the reprojection error for a point in a target who's world
-                   location is parameterized by 6Dof, and the point itself has 3Dof defining its location in the target frame
-	    The circle's center is the feature, but when viewed obliquely it appears as an ellipse. The center of the 
-	    ellipse is not the projected center of the circle. This error model accounts for this shift.
-	    This complete version includes lens distortion
-  */
-  class  CircleTargetCameraReprjErrorOLD
+/** @brief A ceres reprojection error class which returns the reprojection error for a point in a target who's world
+                 location is parameterized by 6Dof, and the point itself has 3Dof defining its location in the target
+   frame
+    The circle's center is the feature, but when viewed obliquely it appears as an ellipse. The center of the
+    ellipse is not the projected center of the circle. This error model accounts for this shift.
+    This complete version includes lens distortion
+*/
+class CircleTargetCameraReprjErrorOLD
+{
+public:
+  /** @brief Constructor
+   *    @param ob_x observation -x value in image coordinates
+   *    @param ob_y observation -y value in image coordinates
+   *    @param c_dia diameter of circle being viewed
+   */
+  CircleTargetCameraReprjErrorOLD(double ob_x, double ob_y, double c_dia)
+    : ox_(ob_x), oy_(ob_y), circle_diameter_(c_dia){};
+
+  /** @brief operator ()
+   *    @param c_p1 extrinsic parameters [6]
+   *    @param c_p2  6Dof transform of target into world frame [6]
+   *    @param c_p3 intrinsic parameters fx,fy,cx,cy,k1,k2,k2,p1,p2 [9]
+   *    @param point  point being viewd described in target frame that is being seen [3]
+   *    @output resid the error between the observation and the reprojected values given the parameters
+   */
+  template < typename T >
+  bool operator()(const T* const c_p1, const T* const c_p2, const T* const c_p3, const T* const point, T* resid) const;
+
+  /**  @brief Factory to hide the construction of the CostFunction object from the client code
+   *    @param ob_x observation -x value in image coordinates
+   *    @param ob_y observation -y value in image coordinates
+   *    @param c_dia diameter of circle being viewed
+   */
+  static ceres::CostFunction* Create(const double o_x, const double o_y, const double c_dia)
   {
-  public:
+    return (new ceres::AutoDiffCostFunction< CircleTargetCameraReprjErrorOLD, 2, 6, 6, 9, 3 >(
+        new CircleTargetCameraReprjErrorOLD(o_x, o_y, c_dia)));
+  }
 
-    /** @brief Constructor
-     *    @param ob_x observation -x value in image coordinates
-     *    @param ob_y observation -y value in image coordinates
-     *    @param c_dia diameter of circle being viewed
-     */
-    CircleTargetCameraReprjErrorOLD(double ob_x, double ob_y, double c_dia)
-      : ox_(ob_x), oy_(ob_y), circle_diameter_(c_dia){};
+private:
+  double ox_;               /**< observed x location of object in image */
+  double oy_;               /**< observed y location of object in image */
+  double circle_diameter_;  //**< diameter of circle being observed */
+};
 
-    /** @brief operator ()
-     *    @param c_p1 extrinsic parameters [6] 
-     *    @param c_p2  6Dof transform of target into world frame [6]
-     *    @param c_p3 intrinsic parameters fx,fy,cx,cy,k1,k2,k2,p1,p2 [9]
-     *    @param point  point being viewd described in target frame that is being seen [3]
-     *    @output resid the error between the observation and the reprojected values given the parameters
-     */
-    template<typename T>
-    bool operator()(const T* const c_p1, 
-		    const T* const c_p2, 
-		    const T* const c_p3, 
-		    const T* const point,
-		    T* resid) const;
+// member function definitions
+template < typename T >
+bool industrial_extrinsic_cal::CircleTargetCameraReprjErrorOLD::operator()(const T* const c_p1, const T* const c_p2,
+                                                                           const T* const c_p3, const T* const point,
+                                                                           T* resid) const
+{
+  T camera_aa[3];  /**< angle axis  */
+  T camera_loc[3]; /**< point rotated */
+  T target_aa[3];  /**< angle axis for target */
+  T target_loc[3]; /**< location of target */
 
-    /**  @brief Factory to hide the construction of the CostFunction object from the client code
-     *    @param ob_x observation -x value in image coordinates
-     *    @param ob_y observation -y value in image coordinates
-     *    @param c_dia diameter of circle being viewed
-     */
-    static ceres::CostFunction* Create(const double o_x, const double o_y, const double c_dia)
-    {
-      return (new ceres::AutoDiffCostFunction<CircleTargetCameraReprjErrorOLD, 2, 6, 6, 9, 3>
-	      (
-	       new CircleTargetCameraReprjErrorOLD(o_x, o_y, c_dia))
-	      );
-    }
+  /** extract the variables from parameter blocks  */
+  int q = 0;                 /**< a temporary variable */
+  camera_aa[0] = c_p1[q++];  /**<  angle_axis x for rotation of camera		 */
+  camera_aa[1] = c_p1[q++];  /**<  angle_axis y for rotation of camera */
+  camera_aa[2] = c_p1[q++];  /**<  angle_axis z for rotation of camera */
+  camera_loc[0] = c_p1[q++]; /**<  translation of camera x (actualy of world in camera frame)*/
+  camera_loc[1] = c_p1[q++]; /**<  translation of camera y (actualy of world in camera frame)*/
+  camera_loc[2] = c_p1[q++]; /**<  translation of camera z (actualy of world in camera frame)*/
 
-  private:
-    double ox_; /**< observed x location of object in image */
-    double oy_; /**< observed y location of object in image */
-    double circle_diameter_; //**< diameter of circle being observed */
+  /** extract target pose block of parameters */
+  q = 0;
+  target_aa[0] = c_p2[q++];  /**<  target's ax angle axis value */
+  target_aa[1] = c_p2[q++];  /**<  target's ay angle axis value */
+  target_aa[2] = c_p2[q++];  /**<  target's az angle axis value */
+  target_loc[0] = c_p2[q++]; /**<  target's x location */
+  target_loc[1] = c_p2[q++]; /**<  target's y location */
+  target_loc[2] = c_p2[q++]; /**<  target's z location */
+
+  /** extract intrinsic block of parameters */
+  q = 0;
+  const T& fx = c_p3[q++]; /**< focal length x */
+  const T& fy = c_p3[q++]; /**< focal length y */
+  const T& cx = c_p3[q++]; /**< central point x */
+  const T& cy = c_p3[q++]; /**< central point y */
+  const T& k1 = c_p3[q++]; /**< distortion k1  */
+  const T& k2 = c_p3[q++]; /**< distortion k2  */
+  const T& k3 = c_p3[q++]; /**< distortion k3  */
+  const T& p1 = c_p3[q++]; /**< distortion p1  */
+  const T& p2 = c_p3[q++]; /**< distortion p2  */
+
+  /** rotate and translate point into world frame */
+  T world_point_loc[3];
+  ceres::AngleAxisRotatePoint(target_aa, point, world_point_loc);
+
+  /** apply target translation */
+  world_point_loc[0] = world_point_loc[0] + target_loc[0];
+  world_point_loc[1] = world_point_loc[1] + target_loc[1];
+  world_point_loc[2] = world_point_loc[2] + target_loc[2];
+
+  /** rotate and translate points into camera frame */
+  /*  Note that camera transform is from world into camera frame, not vise versa */
+  T camera_point_loc[3];
+  ceres::AngleAxisRotatePoint(camera_aa, world_point_loc, camera_point_loc);
+
+  /** apply camera translation */
+  camera_point_loc[0] = camera_point_loc[0] + camera_loc[0]; /**< point rotated and translated */
+  camera_point_loc[1] = camera_point_loc[1] + camera_loc[1];
+  camera_point_loc[2] = camera_point_loc[2] + camera_loc[2];
+
+  T xp1 = camera_point_loc[0];  // shorten variable names to make equations easier to read
+  T yp1 = camera_point_loc[1];
+  T zp1 = camera_point_loc[2];
+
+  // Circle Delta is the difference between the projection of the center of the circle
+  // and the center of the projected ellipse
+
+  // find rotation from target coordinates into camera coordinates
+  // The 3 columns represent:
+  // 1. the x-axis of the target in camera coordinates
+  // 2. the y-axis of the target in camera coordinates
+  // 3. the z-axis (normal of the target plane) in camera coordinates
+
+  T R_TtoW[9];  // rotation from target to world
+  T R_WtoC[9];  // rotation from world to camera
+  T R_TtoC[9];  // rotation from target to camera (computed as R_TtoC = R_WtoC*R_TtoW)
+  ceres::AngleAxisToRotationMatrix(target_aa, R_TtoW);  // output in column major order
+  ceres::AngleAxisToRotationMatrix(camera_aa, R_WtoC);  // output in column major order
+
+  // x-axis of target in camera coordinates
+  R_TtoC[0] = R_WtoC[0] * R_TtoW[0] + R_WtoC[3] * R_TtoW[1] + R_WtoC[6] * R_TtoW[2];
+  R_TtoC[1] = R_WtoC[1] * R_TtoW[0] + R_WtoC[4] * R_TtoW[1] + R_WtoC[7] * R_TtoW[2];
+  R_TtoC[2] = R_WtoC[2] * R_TtoW[0] + R_WtoC[5] * R_TtoW[1] + R_WtoC[8] * R_TtoW[2];
+  // y axis of target in camera coordinates
+  R_TtoC[3] = R_WtoC[0] * R_TtoW[3] + R_WtoC[3] * R_TtoW[4] + R_WtoC[6] * R_TtoW[5];
+  R_TtoC[4] = R_WtoC[1] * R_TtoW[3] + R_WtoC[4] * R_TtoW[4] + R_WtoC[7] * R_TtoW[5];
+  R_TtoC[5] = R_WtoC[2] * R_TtoW[3] + R_WtoC[5] * R_TtoW[4] + R_WtoC[8] * R_TtoW[5];
+  // z axis of target(normal vector) of target in camera coordinates
+  R_TtoC[6] = R_WtoC[0] * R_TtoW[6] + R_WtoC[3] * R_TtoW[7] + R_WtoC[6] * R_TtoW[8];
+  R_TtoC[7] = R_WtoC[1] * R_TtoW[6] + R_WtoC[4] * R_TtoW[7] + R_WtoC[7] * R_TtoW[8];
+  R_TtoC[8] = R_WtoC[2] * R_TtoW[6] + R_WtoC[5] * R_TtoW[7] + R_WtoC[8] * R_TtoW[8];
+
+  // NOTE: we assume target is an XY planar target (all points on target have nominal z=0)
+  //       in this case, the target plane is defined by the first two columns of R_TtoC
+  //       these are the x and y vectors of the target frame expressed in the camera coordinates
+
+  // Projection of distance vector D = [-xp1 -yp1 -zp1]/sqrt(xp1^2+yp1^2+zp1^2) on target plane
+  T C2T_dist = sqrt(xp1 * xp1 + yp1 * yp1 + zp1 * zp1);  // distance from camera to point on target
+  T D_targetx = -(xp1 * R_TtoC[0] + yp1 * R_TtoC[1] + zp1 * R_TtoC[2]) / C2T_dist;  // projection on target_x
+  T D_targety = -(xp1 * R_TtoC[3] + yp1 * R_TtoC[4] + zp1 * R_TtoC[5]) / C2T_dist;  // projection on target_y
+  T D_targetz = -(xp1 * R_TtoC[6] + yp1 * R_TtoC[7] + zp1 * R_TtoC[8]) / C2T_dist;  // projection on target_z
+  T s_theta = D_targetz;  // Note theta's the complemetary angle used to compute delta
+  T c_theta = sqrt(T(1.0) - s_theta * s_theta);
+
+  // projection of D onto target xy plane expressed in camera frame is given by
+  // D_targetx * R_TtoC(1stcol) + D_targety * R_TtoC(2ndcol)
+  T r = T(circle_diameter_ / 2.0);
+  T Delta = r * s_theta * (T(1.0) / (C2T_dist - r * c_theta) - T(1.0) / (C2T_dist + r * c_theta)) / T(2.0);
+
+  // Vx, Vy vector in target plane
+  T Vx = D_targetx * R_TtoC[0] + D_targety * R_TtoC[3];
+  T Vy = D_targetx * R_TtoC[1] + D_targety * R_TtoC[4];
+  T norm_vx = sqrt(Vx * Vx + Vy * Vy);
+  Vx = Vx / norm_vx;
+  Vy = Vy / norm_vx;
+
+  /** scale into the image plane by distance away from camera */
+  T xp = xp1 / zp1 + Delta * Vx;
+  T yp = yp1 / zp1 + Delta * Vy;
+
+  /* temporary variables for distortion model */
+  T xp2 = xp * xp;  /* x^2 */
+  T yp2 = yp * yp;  /* y^2 */
+  T r2 = xp2 + yp2; /* r^2 radius squared */
+  T r4 = r2 * r2;   /* r^4 */
+  T r6 = r2 * r4;   /* r^6 */
+
+  /* apply the distortion coefficients to refine pixel location */
+  T xpp = xp + k1 * r2 * xp           // 2nd order term
+          + k2 * r4 * xp              // 4th order term
+          + k3 * r6 * xp              // 6th order term
+          + p2 * (r2 + T(2.0) * xp2)  // tangential
+          + p1 * xp * yp * T(2.0);    // other tangential term
+  T ypp = yp + k1 * r2 * yp           // 2nd order term
+          + k2 * r4 * yp              // 4th order term
+          + k3 * r6 * yp              // 6th order term
+          + p1 * (r2 + T(2.0) * yp2)  // tangential term
+          + p2 * xp * yp * T(2.0);    // other tangential term
+
+  /** perform projection using focal length and camera center into image plane */
+  resid[0] = fx * xpp + cx - T(ox_);
+  resid[1] = fy * ypp + cy - T(oy_);
+
+  return true;
+}  // end of operator()
+
+/** @brief A ceres reprojection error class which returns the reprojection error for a point in a target who's world
+                 location is parameterized by 6Dof, and the point itself has 3Dof defining its location in the target
+   frame
+    The circle's center is the feature, but when viewed obliquely it appears as an ellipse. The center of the
+    ellipse is not the projected center of the circle. This error model accounts for this shift.
+    This version has no lens distortion, and should be used when objects are located in rectified images
+*/
+class CircleTargetCameraReprjErrorNoDistortionOLD
+{
+public:
+  /** @brief Constructor
+   *    @param ob_x observation -x value in image coordinates
+   *    @param ob_y observation -y value in image coordinates
+   *    @param c_dia diameter of circle being viewed
+   *    @param fx  focal length in x units are pixels
+   *    @param fy  focal length in y units are pixels
+   *    @param cx optical center in x units are pixels
+   *    @param cy optical center in y units are pixels
+   */
+  CircleTargetCameraReprjErrorNoDistortionOLD(double ob_x, double ob_y, double c_dia, double fx, double fy, double cx,
+                                              double cy)
+    : ox_(ob_x), oy_(ob_y), circle_diameter_(c_dia), fx_(fx), fy_(fy), cx_(cx), cy_(cy){};
+
+  /** @brief operator ()
+   *    @param c_p1 extrinsic parameters [6]
+   *    @param c_p2  6Dof transform of target into world frame [6]
+   *    @param point  point being viewd described in target frame that is being seen [3]
+   *    @output resid the error between the observation and the reprojected values given the parameters
+   */
+  template < typename T >
+  bool operator()(const T* const c_p1,  /**< extrinsic parameters [6]*/
+                  const T* const c_p2,  /**< 6Dof transform of target into world frame [6]*/
+                  const T* const point, /**< point described in target frame that is being seen [3]*/
+                  T* resid) const;
+
+  /**  @brief Factory to hide the construction of the CostFunction object from the client code
+   *    @param ob_x observation -x value in image coordinates
+   *    @param ob_y observation -y value in image coordinates
+   *    @param c_dia diameter of circle being viewed
+   *    @param fx  focal length in x units are pixels
+   *    @param fy  focal length in y units are pixels
+   *    @param cx optical center in x units are pixels
+   *    @param cy optical center in y units are pixels
+   */
+  static ceres::CostFunction* Create(const double o_x, const double o_y, const double c_dia, const double fx,
+                                     const double fy, const double cx, const double cy)
+  {
+    return (new ceres::AutoDiffCostFunction< CircleTargetCameraReprjErrorNoDistortionOLD, 2, 6, 6, 3 >(
+        new CircleTargetCameraReprjErrorNoDistortionOLD(o_x, o_y, c_dia, fx, fy, cx, cy)));
+  }
+
+private:
+  double ox_;              /**< observed x location of object in image */
+  double oy_;              /**< observed y location of object in image */
+  double circle_diameter_; /**< diameter of circle being observed */
+  double fx_;              /**< focal length x */
+  double fy_;              /**< focal length y */
+  double cx_;              /**< optical center pixel x */
+  double cy_;              /**< optical center pixel y */
+};
+
+// member function definitions
+template < typename T >
+bool industrial_extrinsic_cal::CircleTargetCameraReprjErrorNoDistortionOLD::
+operator()(const T* const c_p1, const T* const c_p2, const T* const point, T* resid) const
+{
+  T camera_aa[3];  /**< angle axis  */
+  T camera_loc[3]; /**< point rotated */
+  T target_aa[3];  /**< angle axis for target */
+  T target_loc[3]; /**< location of target */
+
+  /** extract the variables from parameter blocks  */
+  int q = 0;                 /**< a temporary variable */
+  camera_aa[0] = c_p1[q++];  /**<  angle_axis x for rotation of camera		 */
+  camera_aa[1] = c_p1[q++];  /**<  angle_axis y for rotation of camera */
+  camera_aa[2] = c_p1[q++];  /**<  angle_axis z for rotation of camera */
+  camera_loc[0] = c_p1[q++]; /**<  translation of camera x (actualy of world in camera frame)*/
+  camera_loc[1] = c_p1[q++]; /**<  translation of camera y (actualy of world in camera frame)*/
+  camera_loc[2] = c_p1[q++]; /**<  translation of camera z (actualy of world in camera frame)*/
+
+  /** extract target pose block of parameters */
+  q = 0;
+  target_aa[0] = c_p2[q++];  /**<  target's ax angle axis value */
+  target_aa[1] = c_p2[q++];  /**<  target's ay angle axis value */
+  target_aa[2] = c_p2[q++];  /**<  target's az angle axis value */
+  target_loc[0] = c_p2[q++]; /**<  target's x location */
+  target_loc[1] = c_p2[q++]; /**<  target's y location */
+  target_loc[2] = c_p2[q++]; /**<  target's z location */
+
+  /** rotate and translate point into world frame */
+  T world_point_loc[3];
+  ceres::AngleAxisRotatePoint(target_aa, point, world_point_loc);
+
+  /** apply target translation */
+  world_point_loc[0] = world_point_loc[0] + target_loc[0];
+  world_point_loc[1] = world_point_loc[1] + target_loc[1];
+  world_point_loc[2] = world_point_loc[2] + target_loc[2];
+
+  /** rotate and translate points into camera frame */
+  /*  Note that camera transform is from world into camera frame, not vise versa */
+  T camera_point_loc[3];
+  ceres::AngleAxisRotatePoint(camera_aa, world_point_loc, camera_point_loc);
+
+  /** apply camera translation */
+  camera_point_loc[0] = camera_point_loc[0] + camera_loc[0]; /**< point rotated and translated */
+  camera_point_loc[1] = camera_point_loc[1] + camera_loc[1];
+  camera_point_loc[2] = camera_point_loc[2] + camera_loc[2];
+
+  T xp1 = camera_point_loc[0];  // shorten variable names to make equations easier to read
+  T yp1 = camera_point_loc[1];
+  T zp1 = camera_point_loc[2];
+
+  // Circle Delta is the difference between the projection of the center of the circle
+  // and the center of the projected ellipse
+
+  // find rotation from target coordinates into camera coordinates
+  // The 3 columns represent:
+  // 1. the x-axis of the target in camera coordinates
+  // 2. the y-axis of the target in camera coordinates
+  // 3. the z-axis (normal of the target plane) in camera coordinates
+
+  T R_TtoW[9];  // rotation from target to world
+  T R_WtoC[9];  // rotation from world to camera
+  T R_TtoC[9];  // rotation from target to camera (computed as R_TtoC = R_WtoC*R_TtoW)
+  ceres::AngleAxisToRotationMatrix(target_aa, R_TtoW);  // output in column major order
+  ceres::AngleAxisToRotationMatrix(camera_aa, R_WtoC);  // output in column major order
+
+  // x-axis of target in camera coordinates
+  R_TtoC[0] = R_WtoC[0] * R_TtoW[0] + R_WtoC[3] * R_TtoW[1] + R_WtoC[6] * R_TtoW[2];
+  R_TtoC[1] = R_WtoC[1] * R_TtoW[0] + R_WtoC[4] * R_TtoW[1] + R_WtoC[7] * R_TtoW[2];
+  R_TtoC[2] = R_WtoC[2] * R_TtoW[0] + R_WtoC[5] * R_TtoW[1] + R_WtoC[8] * R_TtoW[2];
+  // y axis of target in camera coordinates
+  R_TtoC[3] = R_WtoC[0] * R_TtoW[3] + R_WtoC[3] * R_TtoW[4] + R_WtoC[6] * R_TtoW[5];
+  R_TtoC[4] = R_WtoC[1] * R_TtoW[3] + R_WtoC[4] * R_TtoW[4] + R_WtoC[7] * R_TtoW[5];
+  R_TtoC[5] = R_WtoC[2] * R_TtoW[3] + R_WtoC[5] * R_TtoW[4] + R_WtoC[8] * R_TtoW[5];
+  // z axis of target(normal vector) of target in camera coordinates
+  R_TtoC[6] = R_WtoC[0] * R_TtoW[6] + R_WtoC[3] * R_TtoW[7] + R_WtoC[6] * R_TtoW[8];
+  R_TtoC[7] = R_WtoC[1] * R_TtoW[6] + R_WtoC[4] * R_TtoW[7] + R_WtoC[7] * R_TtoW[8];
+  R_TtoC[8] = R_WtoC[2] * R_TtoW[6] + R_WtoC[5] * R_TtoW[7] + R_WtoC[8] * R_TtoW[8];
+
+  // NOTE: we assume target is an XY planar target (all points on target have nominal z=0)
+  //       in this case, the target plane is defined by the first two columns of R_TtoC
+  //       these are the x and y vectors of the target frame expressed in the camera coordinates
+
+  // Projection of distance vector D = [-xp1 -yp1 -zp1]/sqrt(xp1^2+yp1^2+zp1^2) on target plane
+  T C2T_dist = sqrt(xp1 * xp1 + yp1 * yp1 + zp1 * zp1);  // distance from camera to point on target
+  T D_targetx = -(xp1 * R_TtoC[0] + yp1 * R_TtoC[1] + zp1 * R_TtoC[2]) / C2T_dist;  // projection on target_x
+  T D_targety = -(xp1 * R_TtoC[3] + yp1 * R_TtoC[4] + zp1 * R_TtoC[5]) / C2T_dist;  // projection on target_y
+  T D_targetz = -(xp1 * R_TtoC[6] + yp1 * R_TtoC[7] + zp1 * R_TtoC[8]) / C2T_dist;  // projection on target_z
+  T s_theta = D_targetz;  // Note theta's the complemetary angle used to compute delta
+  T c_theta = sqrt(T(1.0) - s_theta * s_theta);
+
+  // projection of D onto target xy plane expressed in camera frame is given by
+  // D_targetx * R_TtoC(1stcol) + D_targety * R_TtoC(2ndcol)
+  T r = T(circle_diameter_ / 2.0);
+  T Delta = r * s_theta * (T(1.0) / (C2T_dist - r * c_theta) - T(1.0) / (C2T_dist + r * c_theta)) / T(2.0);
+
+  // Vx, Vy vector in target plane
+  T Vx = D_targetx * R_TtoC[0] + D_targety * R_TtoC[3];
+  T Vy = D_targetx * R_TtoC[1] + D_targety * R_TtoC[4];
+  T norm_vx = sqrt(Vx * Vx + Vy * Vy);
+  Vx = Vx / norm_vx;
+  Vy = Vy / norm_vx;
+
+  /** scale into the image plane by distance away from camera */
+  T xp = xp1 / zp1 + Delta * Vx;
+  T yp = yp1 / zp1 + Delta * Vy;
+
+  /** perform projection using focal length and camera center into image plane */
+  resid[0] = T(fx_) * xp + T(cx_) - T(ox_);
+  resid[1] = T(fy_) * yp + T(cy_) - T(oy_);
+
+  return true;
+}  // end of operator()
+
+/** @brief A ceres reprojection error class which returns the reprojection error for a point in a target who's world
+                 location is parameterized by 6Dof, and the point itself has 3Dof defining its location in the target
+   frame
+    The circle's center is the feature, but when viewed obliquely it appears as an ellipse. The center of the
+    ellipse is not the projected center of the circle. This error model accounts for this shift.
+    This version has no lens distortion, and the point's location within the target is fixed.
+                 It should be used when objects are located in rectified images
+*/
+class CircleTargetCameraReprjErrorNoDFixedPointOLD
+{
+public:
+  /** @brief Constructor
+*   @param ob_x observation -x value in image coordinates
+*   @param ob_y observation -y value in image coordinates
+*   @param c_dia diameter of circle being viewed
+*   @param fx  focal length in x units are pixels
+*   @param fy  focal length in y units are pixels
+*   @param cx optical center in x units are pixels
+*   @param cy optical center in y units are pixels
+*   @param point_x location of point in target frame x value
+*   @param point_y location of point in target frame y value
+*   @param point_z location of point in target frame z value
+*/
+  CircleTargetCameraReprjErrorNoDFixedPointOLD(double ob_x, double ob_y, double c_dia, double fx, double fy, double cx,
+                                               double cy, double point_x, double point_y, double point_z)
+    : ox_(ob_x), oy_(ob_y), circle_diameter_(c_dia), fx_(fx), fy_(fy), cx_(cx), cy_(cy)
+  {
+    point_[0] = point_x;
+    point_[1] = point_y;
+    point_[2] = point_z;
   };
 
-  // member function definitions
-  template<typename T>
-  bool industrial_extrinsic_cal::CircleTargetCameraReprjErrorOLD::operator()(const T* const c_p1,
-							const T* const c_p2, 
-							const T* const c_p3, 
-							const T* const point,
-							T* resid) const
+  /** @brief operator ()
+   *    @param c_p1 extrinsic parameters [6]
+   *    @param c_p2  6Dof transform of target into world frame [6]
+   *    @output resid the error between the observation and the reprojected values given the parameters
+   */
+  template < typename T >
+  bool operator()(const T* const c_p1, /**< extrinsic parameters [6]*/
+                  const T* const c_p2, /**< 6Dof transform of target into world frame [6]*/
+                  T* resid) const;
+
+  /**  @brief Factory to hide the construction of the CostFunction object from the client code
+   *    @param ob_x observation -x value in image coordinates
+   *    @param ob_y observation -y value in image coordinates
+   *    @param c_dia diameter of circle being viewed
+   *    @param fx  focal length in x units are pixels
+   *    @param fy  focal length in y units are pixels
+   *    @param cx optical center in x units are pixels
+   *    @param cy optical center in y units are pixels
+   *    @param point_x location of point in target frame x value
+   *    @param point_y location of point in target frame y value
+   *    @param point_z location of point in target frame z value
+   */
+  static ceres::CostFunction* Create(const double o_x, const double o_y, const double c_dia, const double fx,
+                                     const double fy, const double cx, const double cy, const double point_x,
+                                     const double point_y, const double point_z)
   {
-    T camera_aa[3];		/**< angle axis  */
-    T camera_loc[3];	/**< point rotated */
-    T target_aa[3];		/**< angle axis for target */
-    T target_loc[3];		/**< location of target */
+    return (new ceres::AutoDiffCostFunction< CircleTargetCameraReprjErrorNoDFixedPointOLD, 2, 6, 6 >(
+        new CircleTargetCameraReprjErrorNoDFixedPointOLD(o_x, o_y, c_dia, fx, fy, cx, cy, point_x, point_y, point_z)));
+  }
 
-    /** extract the variables from parameter blocks  */
-    int q = 0; /**< a temporary variable */
-    camera_aa[0]  = c_p1[q++]; /**<  angle_axis x for rotation of camera		 */
-    camera_aa[1]  = c_p1[q++]; /**<  angle_axis y for rotation of camera */
-    camera_aa[2]  = c_p1[q++]; /**<  angle_axis z for rotation of camera */
-    camera_loc[0] = c_p1[q++]; /**<  translation of camera x (actualy of world in camera frame)*/
-    camera_loc[1] = c_p1[q++]; /**<  translation of camera y (actualy of world in camera frame)*/
-    camera_loc[2] = c_p1[q++]; /**<  translation of camera z (actualy of world in camera frame)*/
+private:
+  double ox_;               /**< observed x location of object in image */
+  double oy_;               /**< observed y location of object in image */
+  double circle_diameter_;  //**< diameter of circle being observed */
+  double fx_;               // focal length x
+  double fy_;               // focal length y
+  double cx_;               // optical center pixel x
+  double cy_;               // optical center pixel y
+  double point_[3];         // location of point in target frame
+};
 
-    /** extract target pose block of parameters */
-    q = 0;
-    target_aa[0]  = c_p2[q++]; /**<  target's ax angle axis value */
-    target_aa[1]  = c_p2[q++]; /**<  target's ay angle axis value */
-    target_aa[2]  = c_p2[q++]; /**<  target's az angle axis value */
-    target_loc[0] = c_p2[q++]; /**<  target's x location */
-    target_loc[1] = c_p2[q++]; /**<  target's y location */
-    target_loc[2] = c_p2[q++]; /**<  target's z location */
+// member function definitions
+template < typename T >
+bool industrial_extrinsic_cal::CircleTargetCameraReprjErrorNoDFixedPointOLD::operator()(const T* const c_p1,
+                                                                                        const T* const c_p2,
+                                                                                        T* resid) const
+{
+  T camera_aa[3];  /**< angle axis  */
+  T camera_loc[3]; /**< point rotated */
+  T target_aa[3];  /**< angle axis for target */
+  T target_loc[3]; /**< location of target */
 
-    /** extract intrinsic block of parameters */
-    q = 0;
-    const T& fx  = c_p3[q++]; /**< focal length x */
-    const T& fy  = c_p3[q++]; /**< focal length y */
-    const T& cx  = c_p3[q++]; /**< central point x */
-    const T& cy  = c_p3[q++]; /**< central point y */
-    const T& k1  = c_p3[q++]; /**< distortion k1  */
-    const T& k2  = c_p3[q++]; /**< distortion k2  */
-    const T& k3  = c_p3[q++]; /**< distortion k3  */
-    const T& p1  = c_p3[q++]; /**< distortion p1  */
-    const T& p2  = c_p3[q++]; /**< distortion p2  */
+  /** extract the variables from parameter blocks  */
+  int q = 0;                 /**< a temporary variable */
+  camera_aa[0] = c_p1[q++];  /**<  angle_axis x for rotation of camera		 */
+  camera_aa[1] = c_p1[q++];  /**<  angle_axis y for rotation of camera */
+  camera_aa[2] = c_p1[q++];  /**<  angle_axis z for rotation of camera */
+  camera_loc[0] = c_p1[q++]; /**<  translation of camera x (actualy of world in camera frame)*/
+  camera_loc[1] = c_p1[q++]; /**<  translation of camera y (actualy of world in camera frame)*/
+  camera_loc[2] = c_p1[q++]; /**<  translation of camera z (actualy of world in camera frame)*/
 
-    /** rotate and translate point into world frame */
-    T world_point_loc[3];
-    ceres::AngleAxisRotatePoint(target_aa, point, world_point_loc);
+  /** extract target pose block of parameters */
+  q = 0;
+  target_aa[0] = c_p2[q++];  /**<  target's ax angle axis value */
+  target_aa[1] = c_p2[q++];  /**<  target's ay angle axis value */
+  target_aa[2] = c_p2[q++];  /**<  target's az angle axis value */
+  target_loc[0] = c_p2[q++]; /**<  target's x location */
+  target_loc[1] = c_p2[q++]; /**<  target's y location */
+  target_loc[2] = c_p2[q++]; /**<  target's z location */
 
-    /** apply target translation */
-    world_point_loc[0] = world_point_loc[0] + target_loc[0];
-    world_point_loc[1] = world_point_loc[1] + target_loc[1];
-    world_point_loc[2] = world_point_loc[2] + target_loc[2];
+  /** rotate and translate point into world frame */
+  T world_point_loc[3];
+  T point[3];
+  point[0] = T(point_[0]);  // need to convert double to template type for auto-jacobian
+  point[1] = T(point_[1]);
+  point[2] = T(point_[2]);
+  ceres::AngleAxisRotatePoint(target_aa, point, world_point_loc);
 
-    /** rotate and translate points into camera frame */
-    /*  Note that camera transform is from world into camera frame, not vise versa */
-    T camera_point_loc[3];
-    ceres::AngleAxisRotatePoint(camera_aa, world_point_loc, camera_point_loc);
+  /** apply target translation */
+  world_point_loc[0] = world_point_loc[0] + target_loc[0];
+  world_point_loc[1] = world_point_loc[1] + target_loc[1];
+  world_point_loc[2] = world_point_loc[2] + target_loc[2];
 
-    /** apply camera translation */
-    camera_point_loc[0] = camera_point_loc[0] + camera_loc[0]; /**< point rotated and translated */
-    camera_point_loc[1] = camera_point_loc[1] + camera_loc[1];
-    camera_point_loc[2] = camera_point_loc[2] + camera_loc[2];
+  /** rotate and translate points into camera frame */
+  /*  Note that camera transform is from world into camera frame, not vise versa */
+  T camera_point_loc[3];
+  ceres::AngleAxisRotatePoint(camera_aa, world_point_loc, camera_point_loc);
 
-    T xp1 = camera_point_loc[0]; // shorten variable names to make equations easier to read
-    T yp1 = camera_point_loc[1];
-    T zp1 = camera_point_loc[2];
+  /** apply camera translation */
+  camera_point_loc[0] = camera_point_loc[0] + camera_loc[0]; /**< point rotated and translated */
+  camera_point_loc[1] = camera_point_loc[1] + camera_loc[1];
+  camera_point_loc[2] = camera_point_loc[2] + camera_loc[2];
 
-    // Circle Delta is the difference between the projection of the center of the circle
-    // and the center of the projected ellipse 
+  T xp1 = camera_point_loc[0];  // shorten variable names to make equations easier to read
+  T yp1 = camera_point_loc[1];
+  T zp1 = camera_point_loc[2];
 
-    // find rotation from target coordinates into camera coordinates
-    // The 3 columns represent:
-    // 1. the x-axis of the target in camera coordinates
-    // 2. the y-axis of the target in camera coordinates
-    // 3. the z-axis (normal of the target plane) in camera coordinates
+  // Circle Delta is the difference between the projection of the center of the circle
+  // and the center of the projected ellipse
 
-    T R_TtoW[9];// rotation from target to world
-    T R_WtoC[9];// rotation from world to camera
-    T R_TtoC[9];// rotation from target to camera (computed as R_TtoC = R_WtoC*R_TtoW)
-    ceres::AngleAxisToRotationMatrix(target_aa,R_TtoW);// output in column major order
-    ceres::AngleAxisToRotationMatrix(camera_aa,R_WtoC);// output in column major order
+  // find rotation from target coordinates into camera coordinates
+  // The 3 columns represent:
+  // 1. the x-axis of the target in camera coordinates
+  // 2. the y-axis of the target in camera coordinates
+  // 3. the z-axis (normal of the target plane) in camera coordinates
 
-    // x-axis of target in camera coordinates
-    R_TtoC[0] = R_WtoC[0]*R_TtoW[0] +  R_WtoC[3]*R_TtoW[1] +  R_WtoC[6]*R_TtoW[2];
-    R_TtoC[1] = R_WtoC[1]*R_TtoW[0] +  R_WtoC[4]*R_TtoW[1] +  R_WtoC[7]*R_TtoW[2];
-    R_TtoC[2] = R_WtoC[2]*R_TtoW[0] +  R_WtoC[5]*R_TtoW[1] +  R_WtoC[8]*R_TtoW[2];
-    // y axis of target in camera coordinates
-    R_TtoC[3] = R_WtoC[0]*R_TtoW[3] +  R_WtoC[3]*R_TtoW[4] +  R_WtoC[6]*R_TtoW[5];
-    R_TtoC[4] = R_WtoC[1]*R_TtoW[3] +  R_WtoC[4]*R_TtoW[4] +  R_WtoC[7]*R_TtoW[5];
-    R_TtoC[5] = R_WtoC[2]*R_TtoW[3] +  R_WtoC[5]*R_TtoW[4] +  R_WtoC[8]*R_TtoW[5];
-    // z axis of target(normal vector) of target in camera coordinates
-    R_TtoC[6] = R_WtoC[0]*R_TtoW[6] +  R_WtoC[3]*R_TtoW[7] +  R_WtoC[6]*R_TtoW[8];
-    R_TtoC[7] = R_WtoC[1]*R_TtoW[6] +  R_WtoC[4]*R_TtoW[7] +  R_WtoC[7]*R_TtoW[8];
-    R_TtoC[8] = R_WtoC[2]*R_TtoW[6] +  R_WtoC[5]*R_TtoW[7] +  R_WtoC[8]*R_TtoW[8];
-      
-    // NOTE: we assume target is an XY planar target (all points on target have nominal z=0)
-    //       in this case, the target plane is defined by the first two columns of R_TtoC
-    //       these are the x and y vectors of the target frame expressed in the camera coordinates
+  T R_TtoW[9];  // rotation from target to world
+  T R_WtoC[9];  // rotation from world to camera
+  T R_TtoC[9];  // rotation from target to camera (computed as R_TtoC = R_WtoC*R_TtoW)
+  ceres::AngleAxisToRotationMatrix(target_aa, R_TtoW);  // output in column major order
+  ceres::AngleAxisToRotationMatrix(camera_aa, R_WtoC);  // output in column major order
 
-    // Projection of distance vector D = [-xp1 -yp1 -zp1]/sqrt(xp1^2+yp1^2+zp1^2) on target plane
-    T C2T_dist = sqrt(xp1*xp1 + yp1*yp1 + zp1*zp1); // distance from camera to point on target
-    T D_targetx = -(xp1*R_TtoC[0] + yp1*R_TtoC[1] + zp1*R_TtoC[2])/C2T_dist; // projection on target_x
-    T D_targety = -(xp1*R_TtoC[3] + yp1*R_TtoC[4] + zp1*R_TtoC[5])/C2T_dist; // projection on target_y
-    T D_targetz = -(xp1*R_TtoC[6] + yp1*R_TtoC[7] + zp1*R_TtoC[8])/C2T_dist; // projection on target_z
-    T s_theta   = D_targetz; // Note theta's the complemetary angle used to compute delta
-    T c_theta   = sqrt( T(1.0) - s_theta*s_theta);
+  // x-axis of target in camera coordinates
+  R_TtoC[0] = R_WtoC[0] * R_TtoW[0] + R_WtoC[3] * R_TtoW[1] + R_WtoC[6] * R_TtoW[2];
+  R_TtoC[1] = R_WtoC[1] * R_TtoW[0] + R_WtoC[4] * R_TtoW[1] + R_WtoC[7] * R_TtoW[2];
+  R_TtoC[2] = R_WtoC[2] * R_TtoW[0] + R_WtoC[5] * R_TtoW[1] + R_WtoC[8] * R_TtoW[2];
+  // y axis of target in camera coordinates
+  R_TtoC[3] = R_WtoC[0] * R_TtoW[3] + R_WtoC[3] * R_TtoW[4] + R_WtoC[6] * R_TtoW[5];
+  R_TtoC[4] = R_WtoC[1] * R_TtoW[3] + R_WtoC[4] * R_TtoW[4] + R_WtoC[7] * R_TtoW[5];
+  R_TtoC[5] = R_WtoC[2] * R_TtoW[3] + R_WtoC[5] * R_TtoW[4] + R_WtoC[8] * R_TtoW[5];
+  // z axis of target(normal vector) of target in camera coordinates
+  R_TtoC[6] = R_WtoC[0] * R_TtoW[6] + R_WtoC[3] * R_TtoW[7] + R_WtoC[6] * R_TtoW[8];
+  R_TtoC[7] = R_WtoC[1] * R_TtoW[6] + R_WtoC[4] * R_TtoW[7] + R_WtoC[7] * R_TtoW[8];
+  R_TtoC[8] = R_WtoC[2] * R_TtoW[6] + R_WtoC[5] * R_TtoW[7] + R_WtoC[8] * R_TtoW[8];
 
-    // projection of D onto target xy plane expressed in camera frame is given by 
-    // D_targetx * R_TtoC(1stcol) + D_targety * R_TtoC(2ndcol)
-    T r = T(circle_diameter_/2.0);
-    T Delta = r*s_theta*(T(1.0)/(C2T_dist-r*c_theta) - T(1.0)/(C2T_dist+r*c_theta))/T(2.0);
-    
-    // Vx, Vy vector in target plane
-    T Vx = D_targetx*R_TtoC[0] + D_targety*R_TtoC[3];
-    T Vy = D_targetx*R_TtoC[1] + D_targety*R_TtoC[4];
-    T norm_vx = sqrt(Vx*Vx + Vy*Vy);
-    Vx = Vx/norm_vx;
-    Vy = Vy/norm_vx;
-      
-    /** scale into the image plane by distance away from camera */
-    T xp = xp1 / zp1 + Delta*Vx;
-    T yp = yp1 / zp1 + Delta*Vy;
-    
-    /* temporary variables for distortion model */
-    T xp2 = xp * xp;		/* x^2 */
-    T yp2 = yp * yp;		/* y^2 */
-    T r2  = xp2 + yp2;	/* r^2 radius squared */
-    T r4  = r2 * r2;		/* r^4 */
-    T r6  = r2 * r4;		/* r^6 */
-      
-    /* apply the distortion coefficients to refine pixel location */
-    T xpp = xp 
-      + k1 * r2 * xp		// 2nd order term
-      + k2 * r4 * xp		// 4th order term
-      + k3 * r6 * xp		// 6th order term
-      + p2 * (r2 + T(2.0) * xp2) // tangential
-      + p1 * xp * yp * T(2.0); // other tangential term
-    T ypp = yp 
-      + k1 * r2 * yp		// 2nd order term
-      + k2 * r4 * yp		// 4th order term
-      + k3 * r6 * yp		// 6th order term
-      + p1 * (r2 + T(2.0) * yp2) // tangential term
-      + p2 * xp * yp * T(2.0); // other tangential term
+  // NOTE: we assume target is an XY planar target (all points on target have nominal z=0)
+  //       in this case, the target plane is defined by the first two columns of R_TtoC
+  //       these are the x and y vectors of the target frame expressed in the camera coordinates
 
-    /** perform projection using focal length and camera center into image plane */
-    resid[0] = fx * xpp + cx - T(ox_);
-    resid[1] = fy * ypp + cy - T(oy_);
+  // Projection of distance vector D = [-xp1 -yp1 -zp1]/sqrt(xp1^2+yp1^2+zp1^2) on target plane
+  T C2T_dist = sqrt(xp1 * xp1 + yp1 * yp1 + zp1 * zp1);  // distance from camera to point on target
+  T D_targetx = -(xp1 * R_TtoC[0] + yp1 * R_TtoC[1] + zp1 * R_TtoC[2]) / C2T_dist;  // projection on target_x
+  T D_targety = -(xp1 * R_TtoC[3] + yp1 * R_TtoC[4] + zp1 * R_TtoC[5]) / C2T_dist;  // projection on target_y
+  T D_targetz = -(xp1 * R_TtoC[6] + yp1 * R_TtoC[7] + zp1 * R_TtoC[8]) / C2T_dist;  // projection on target_z
+  T s_theta = D_targetz;  // Note theta's the complemetary angle used to compute delta
+  T c_theta = sqrt(T(1.0) - s_theta * s_theta);
 
-    return true;
-  } // end of operator() 
+  // projection of D onto target xy plane expressed in camera frame is given by
+  // D_targetx * R_TtoC(1stcol) + D_targety * R_TtoC(2ndcol)
+  T r = T(circle_diameter_ / 2.0);
+  T Delta = r * s_theta * (T(1.0) / (C2T_dist - r * c_theta) - T(1.0) / (C2T_dist + r * c_theta)) / T(2.0);
 
-  /** @brief A ceres reprojection error class which returns the reprojection error for a point in a target who's world
-                   location is parameterized by 6Dof, and the point itself has 3Dof defining its location in the target frame
-	    The circle's center is the feature, but when viewed obliquely it appears as an ellipse. The center of the 
-	    ellipse is not the projected center of the circle. This error model accounts for this shift.
-	    This version has no lens distortion, and should be used when objects are located in rectified images
-  */
-  class  CircleTargetCameraReprjErrorNoDistortionOLD
-  {
-  public:
-    /** @brief Constructor
-     *    @param ob_x observation -x value in image coordinates
-     *    @param ob_y observation -y value in image coordinates
-     *    @param c_dia diameter of circle being viewed
-     *    @param fx  focal length in x units are pixels
-     *    @param fy  focal length in y units are pixels
-     *    @param cx optical center in x units are pixels
-     *    @param cy optical center in y units are pixels
-     */
-    CircleTargetCameraReprjErrorNoDistortionOLD(double ob_x, double ob_y, double c_dia,
-					     double fx, double fy, double cx, double cy)
-      : ox_(ob_x), oy_(ob_y), circle_diameter_(c_dia), fx_(fx), fy_(fy), cx_(cx), cy_(cy){};
+  // Vx, Vy vector in target plane
+  T Vx = D_targetx * R_TtoC[0] + D_targety * R_TtoC[3];
+  T Vy = D_targetx * R_TtoC[1] + D_targety * R_TtoC[4];
+  T norm_vx = sqrt(Vx * Vx + Vy * Vy);
+  Vx = Vx / norm_vx;
+  Vy = Vy / norm_vx;
 
-    /** @brief operator ()
-     *    @param c_p1 extrinsic parameters [6] 
-     *    @param c_p2  6Dof transform of target into world frame [6]
-     *    @param point  point being viewd described in target frame that is being seen [3]
-     *    @output resid the error between the observation and the reprojected values given the parameters
-     */
-    template<typename T>
-    bool operator()(const T* const c_p1, /**< extrinsic parameters [6]*/
-		    const T* const c_p2, /**< 6Dof transform of target into world frame [6]*/
-		    const T* const point, /**< point described in target frame that is being seen [3]*/
-		    T* resid) const;
-    
-    /**  @brief Factory to hide the construction of the CostFunction object from the client code
-     *    @param ob_x observation -x value in image coordinates
-     *    @param ob_y observation -y value in image coordinates
-     *    @param c_dia diameter of circle being viewed
-     *    @param fx  focal length in x units are pixels
-     *    @param fy  focal length in y units are pixels
-     *    @param cx optical center in x units are pixels
-     *    @param cy optical center in y units are pixels
-     */
-    static ceres::CostFunction* Create(const double o_x, const double o_y, const double c_dia,
-				       const double fx, const double fy,
-				       const double cx, const double cy)
-    {
-      return (new ceres::AutoDiffCostFunction<CircleTargetCameraReprjErrorNoDistortionOLD, 2, 6, 6, 3>
-	      (
-	       new CircleTargetCameraReprjErrorNoDistortionOLD(o_x, o_y, c_dia, fx, fy, cx, cy))
-	      );
-    }
-    
-  private:
-    double ox_;			/**< observed x location of object in image */
-    double oy_;			/**< observed y location of object in image */
-    double circle_diameter_;	/**< diameter of circle being observed */
-    double fx_;			/**< focal length x */
-    double fy_;			/**< focal length y */
-    double cx_;			/**< optical center pixel x */
-    double cy_;			/**< optical center pixel y */
-  };
-  
-  // member function definitions
-  template<typename T>
-  bool industrial_extrinsic_cal::CircleTargetCameraReprjErrorNoDistortionOLD::operator()
-    (
-     const T* const c_p1,	
-     const T* const c_p2,	
-     const T* const point,	
-     T* resid
-     ) const
-  {
-    T camera_aa[3];		/**< angle axis  */
-    T camera_loc[3];		/**< point rotated */
-    T target_aa[3];		/**< angle axis for target */
-    T target_loc[3];		/**< location of target */
-    
-    /** extract the variables from parameter blocks  */
-    int q = 0; /**< a temporary variable */
-    camera_aa[0]  = c_p1[q++]; /**<  angle_axis x for rotation of camera		 */
-    camera_aa[1]  = c_p1[q++]; /**<  angle_axis y for rotation of camera */
-    camera_aa[2]  = c_p1[q++]; /**<  angle_axis z for rotation of camera */
-    camera_loc[0] = c_p1[q++]; /**<  translation of camera x (actualy of world in camera frame)*/
-    camera_loc[1] = c_p1[q++]; /**<  translation of camera y (actualy of world in camera frame)*/
-    camera_loc[2] = c_p1[q++]; /**<  translation of camera z (actualy of world in camera frame)*/
+  /** scale into the image plane by distance away from camera */
+  T xp = xp1 / zp1 + Delta * Vx;
+  T yp = yp1 / zp1 + Delta * Vy;
 
-    /** extract target pose block of parameters */
-    q = 0;
-    target_aa[0]  = c_p2[q++]; /**<  target's ax angle axis value */
-    target_aa[1]  = c_p2[q++]; /**<  target's ay angle axis value */
-    target_aa[2]  = c_p2[q++]; /**<  target's az angle axis value */
-    target_loc[0] = c_p2[q++]; /**<  target's x location */
-    target_loc[1] = c_p2[q++]; /**<  target's y location */
-    target_loc[2] = c_p2[q++]; /**<  target's z location */
+  /** perform projection using focal length and camera center into image plane */
+  resid[0] = T(fx_) * xp + T(cx_) - T(ox_);
+  resid[1] = T(fy_) * yp + T(cy_) - T(oy_);
 
-    /** rotate and translate point into world frame */
-    T world_point_loc[3];
-    ceres::AngleAxisRotatePoint(target_aa, point, world_point_loc);
-
-    /** apply target translation */
-    world_point_loc[0] = world_point_loc[0] + target_loc[0];
-    world_point_loc[1] = world_point_loc[1] + target_loc[1];
-    world_point_loc[2] = world_point_loc[2] + target_loc[2];
-
-    /** rotate and translate points into camera frame */
-    /*  Note that camera transform is from world into camera frame, not vise versa */
-    T camera_point_loc[3];
-    ceres::AngleAxisRotatePoint(camera_aa, world_point_loc, camera_point_loc);
-
-    /** apply camera translation */
-    camera_point_loc[0] = camera_point_loc[0] + camera_loc[0]; /**< point rotated and translated */
-    camera_point_loc[1] = camera_point_loc[1] + camera_loc[1];
-    camera_point_loc[2] = camera_point_loc[2] + camera_loc[2];
-
-    T xp1 = camera_point_loc[0]; // shorten variable names to make equations easier to read
-    T yp1 = camera_point_loc[1];
-    T zp1 = camera_point_loc[2];
-
-    // Circle Delta is the difference between the projection of the center of the circle
-    // and the center of the projected ellipse 
-
-    // find rotation from target coordinates into camera coordinates
-    // The 3 columns represent:
-    // 1. the x-axis of the target in camera coordinates
-    // 2. the y-axis of the target in camera coordinates
-    // 3. the z-axis (normal of the target plane) in camera coordinates
-
-    T R_TtoW[9];// rotation from target to world
-    T R_WtoC[9];// rotation from world to camera
-    T R_TtoC[9];// rotation from target to camera (computed as R_TtoC = R_WtoC*R_TtoW)
-    ceres::AngleAxisToRotationMatrix(target_aa,R_TtoW);// output in column major order
-    ceres::AngleAxisToRotationMatrix(camera_aa,R_WtoC);// output in column major order
-
-    // x-axis of target in camera coordinates
-    R_TtoC[0] = R_WtoC[0]*R_TtoW[0] +  R_WtoC[3]*R_TtoW[1] +  R_WtoC[6]*R_TtoW[2];
-    R_TtoC[1] = R_WtoC[1]*R_TtoW[0] +  R_WtoC[4]*R_TtoW[1] +  R_WtoC[7]*R_TtoW[2];
-    R_TtoC[2] = R_WtoC[2]*R_TtoW[0] +  R_WtoC[5]*R_TtoW[1] +  R_WtoC[8]*R_TtoW[2];
-    // y axis of target in camera coordinates
-    R_TtoC[3] = R_WtoC[0]*R_TtoW[3] +  R_WtoC[3]*R_TtoW[4] +  R_WtoC[6]*R_TtoW[5];
-    R_TtoC[4] = R_WtoC[1]*R_TtoW[3] +  R_WtoC[4]*R_TtoW[4] +  R_WtoC[7]*R_TtoW[5];
-    R_TtoC[5] = R_WtoC[2]*R_TtoW[3] +  R_WtoC[5]*R_TtoW[4] +  R_WtoC[8]*R_TtoW[5];
-    // z axis of target(normal vector) of target in camera coordinates
-    R_TtoC[6] = R_WtoC[0]*R_TtoW[6] +  R_WtoC[3]*R_TtoW[7] +  R_WtoC[6]*R_TtoW[8];
-    R_TtoC[7] = R_WtoC[1]*R_TtoW[6] +  R_WtoC[4]*R_TtoW[7] +  R_WtoC[7]*R_TtoW[8];
-    R_TtoC[8] = R_WtoC[2]*R_TtoW[6] +  R_WtoC[5]*R_TtoW[7] +  R_WtoC[8]*R_TtoW[8];
-      
-    // NOTE: we assume target is an XY planar target (all points on target have nominal z=0)
-    //       in this case, the target plane is defined by the first two columns of R_TtoC
-    //       these are the x and y vectors of the target frame expressed in the camera coordinates
-
-    // Projection of distance vector D = [-xp1 -yp1 -zp1]/sqrt(xp1^2+yp1^2+zp1^2) on target plane
-    T C2T_dist = sqrt(xp1*xp1 + yp1*yp1 + zp1*zp1); // distance from camera to point on target
-    T D_targetx = -(xp1*R_TtoC[0] + yp1*R_TtoC[1] + zp1*R_TtoC[2])/C2T_dist; // projection on target_x
-    T D_targety = -(xp1*R_TtoC[3] + yp1*R_TtoC[4] + zp1*R_TtoC[5])/C2T_dist; // projection on target_y
-    T D_targetz = -(xp1*R_TtoC[6] + yp1*R_TtoC[7] + zp1*R_TtoC[8])/C2T_dist; // projection on target_z
-    T s_theta   = D_targetz; // Note theta's the complemetary angle used to compute delta
-    T c_theta   = sqrt( T(1.0) - s_theta*s_theta);
-
-    // projection of D onto target xy plane expressed in camera frame is given by 
-    // D_targetx * R_TtoC(1stcol) + D_targety * R_TtoC(2ndcol)
-    T r = T(circle_diameter_/2.0);
-    T Delta = r*s_theta*(T(1.0)/(C2T_dist-r*c_theta) - T(1.0)/(C2T_dist+r*c_theta))/T(2.0);
-    
-    // Vx, Vy vector in target plane
-    T Vx = D_targetx*R_TtoC[0] + D_targety*R_TtoC[3];
-    T Vy = D_targetx*R_TtoC[1] + D_targety*R_TtoC[4];
-    T norm_vx = sqrt(Vx*Vx + Vy*Vy);
-    Vx = Vx/norm_vx;
-    Vy = Vy/norm_vx;
-      
-    /** scale into the image plane by distance away from camera */
-    T xp = xp1 / zp1 + Delta*Vx;
-    T yp = yp1 / zp1 + Delta*Vy;
-    
-    /** perform projection using focal length and camera center into image plane */
-    resid[0] = T(fx_) * xp + T(cx_) - T(ox_);
-    resid[1] = T(fy_) * yp + T(cy_) - T(oy_);
-
-    return true;
-  } // end of operator() 
-
-  /** @brief A ceres reprojection error class which returns the reprojection error for a point in a target who's world
-                   location is parameterized by 6Dof, and the point itself has 3Dof defining its location in the target frame
-	    The circle's center is the feature, but when viewed obliquely it appears as an ellipse. The center of the 
-	    ellipse is not the projected center of the circle. This error model accounts for this shift.
-	    This version has no lens distortion, and the point's location within the target is fixed.
-                   It should be used when objects are located in rectified images
-  */
-  class  CircleTargetCameraReprjErrorNoDFixedPointOLD
-  {
-  public:
-        /** @brief Constructor
-     *    @param ob_x observation -x value in image coordinates
-     *    @param ob_y observation -y value in image coordinates
-     *    @param c_dia diameter of circle being viewed
-     *    @param fx  focal length in x units are pixels
-     *    @param fy  focal length in y units are pixels
-     *    @param cx optical center in x units are pixels
-     *    @param cy optical center in y units are pixels
-     *    @param point_x location of point in target frame x value
-     *    @param point_y location of point in target frame y value
-     *    @param point_z location of point in target frame z value
-     */
-    CircleTargetCameraReprjErrorNoDFixedPointOLD(double ob_x, double ob_y,
-					      double c_dia,
-					      double fx, 
-					      double fy,
-					      double cx,
-					      double cy,
-					      double point_x,
-					      double point_y, 
-					      double point_z)
-      : ox_(ob_x), oy_(ob_y), circle_diameter_(c_dia), 
-	fx_(fx), fy_(fy), cx_(cx), cy_(cy)
-    {
-      point_[0] = point_x;
-      point_[1] = point_y;
-      point_[2] = point_z;
-    };
-
-    /** @brief operator ()
-     *    @param c_p1 extrinsic parameters [6] 
-     *    @param c_p2  6Dof transform of target into world frame [6]
-     *    @output resid the error between the observation and the reprojected values given the parameters
-     */
-    template<typename T>
-    bool operator()(const T* const c_p1, /**< extrinsic parameters [6]*/
-		    const T* const c_p2, /**< 6Dof transform of target into world frame [6]*/
-		    T* resid) const;
-    
-    /**  @brief Factory to hide the construction of the CostFunction object from the client code
-     *    @param ob_x observation -x value in image coordinates
-     *    @param ob_y observation -y value in image coordinates
-     *    @param c_dia diameter of circle being viewed
-     *    @param fx  focal length in x units are pixels
-     *    @param fy  focal length in y units are pixels
-     *    @param cx optical center in x units are pixels
-     *    @param cy optical center in y units are pixels
-     *    @param point_x location of point in target frame x value
-     *    @param point_y location of point in target frame y value
-     *    @param point_z location of point in target frame z value
-     */
-    static ceres::CostFunction* Create(const double o_x, const double o_y, 
-				       const double c_dia,
-				       const double fx, const double fy,
-				       const double cx, const double cy,
-				       const double point_x, const double point_y, const double point_z)
-    {
-      return (new ceres::AutoDiffCostFunction<CircleTargetCameraReprjErrorNoDFixedPointOLD, 2, 6, 6 >
-	      (
-	       new CircleTargetCameraReprjErrorNoDFixedPointOLD(o_x, o_y,
-							     c_dia, 
-							     fx, fy, cx, cy,
-							     point_x, point_y, point_z))
-	      );
-    }
-    
-  private:
-    double ox_; /**< observed x location of object in image */
-    double oy_; /**< observed y location of object in image */
-    double circle_diameter_; //**< diameter of circle being observed */
-    double fx_;			// focal length x
-    double fy_;			// focal length y
-    double cx_;			// optical center pixel x
-    double cy_;			// optical center pixel y
-    double point_[3];		// location of point in target frame
-
-  };
-  
-  // member function definitions
-  template<typename T>
-  bool industrial_extrinsic_cal::CircleTargetCameraReprjErrorNoDFixedPointOLD::operator()
-    (
-     const T* const c_p1,	
-     const T* const c_p2,	
-     T* resid
-     ) const
-  {
-    T camera_aa[3];		/**< angle axis  */
-    T camera_loc[3];		/**< point rotated */
-    T target_aa[3];		/**< angle axis for target */
-    T target_loc[3];		/**< location of target */
-    
-    /** extract the variables from parameter blocks  */
-    int q = 0; /**< a temporary variable */
-    camera_aa[0]  = c_p1[q++]; /**<  angle_axis x for rotation of camera		 */
-    camera_aa[1]  = c_p1[q++]; /**<  angle_axis y for rotation of camera */
-    camera_aa[2]  = c_p1[q++]; /**<  angle_axis z for rotation of camera */
-    camera_loc[0] = c_p1[q++]; /**<  translation of camera x (actualy of world in camera frame)*/
-    camera_loc[1] = c_p1[q++]; /**<  translation of camera y (actualy of world in camera frame)*/
-    camera_loc[2] = c_p1[q++]; /**<  translation of camera z (actualy of world in camera frame)*/
-
-    /** extract target pose block of parameters */
-    q = 0;
-    target_aa[0]  = c_p2[q++]; /**<  target's ax angle axis value */
-    target_aa[1]  = c_p2[q++]; /**<  target's ay angle axis value */
-    target_aa[2]  = c_p2[q++]; /**<  target's az angle axis value */
-    target_loc[0] = c_p2[q++]; /**<  target's x location */
-    target_loc[1] = c_p2[q++]; /**<  target's y location */
-    target_loc[2] = c_p2[q++]; /**<  target's z location */
-
-    /** rotate and translate point into world frame */
-    T world_point_loc[3];
-    T point[3];
-    point[0] = T(point_[0]);// need to convert double to template type for auto-jacobian
-    point[1] = T(point_[1]);
-    point[2] = T(point_[2]);
-    ceres::AngleAxisRotatePoint(target_aa, point, world_point_loc);
-
-    /** apply target translation */
-    world_point_loc[0] = world_point_loc[0] + target_loc[0];
-    world_point_loc[1] = world_point_loc[1] + target_loc[1];
-    world_point_loc[2] = world_point_loc[2] + target_loc[2];
-
-    /** rotate and translate points into camera frame */
-    /*  Note that camera transform is from world into camera frame, not vise versa */
-    T camera_point_loc[3];
-    ceres::AngleAxisRotatePoint(camera_aa, world_point_loc, camera_point_loc);
-
-    /** apply camera translation */
-    camera_point_loc[0] = camera_point_loc[0] + camera_loc[0]; /**< point rotated and translated */
-    camera_point_loc[1] = camera_point_loc[1] + camera_loc[1];
-    camera_point_loc[2] = camera_point_loc[2] + camera_loc[2];
-
-    T xp1 = camera_point_loc[0]; // shorten variable names to make equations easier to read
-    T yp1 = camera_point_loc[1];
-    T zp1 = camera_point_loc[2];
-
-    // Circle Delta is the difference between the projection of the center of the circle
-    // and the center of the projected ellipse 
-
-    // find rotation from target coordinates into camera coordinates
-    // The 3 columns represent:
-    // 1. the x-axis of the target in camera coordinates
-    // 2. the y-axis of the target in camera coordinates
-    // 3. the z-axis (normal of the target plane) in camera coordinates
-
-    T R_TtoW[9];// rotation from target to world
-    T R_WtoC[9];// rotation from world to camera
-    T R_TtoC[9];// rotation from target to camera (computed as R_TtoC = R_WtoC*R_TtoW)
-    ceres::AngleAxisToRotationMatrix(target_aa,R_TtoW);// output in column major order
-    ceres::AngleAxisToRotationMatrix(camera_aa,R_WtoC);// output in column major order
-
-    // x-axis of target in camera coordinates
-    R_TtoC[0] = R_WtoC[0]*R_TtoW[0] +  R_WtoC[3]*R_TtoW[1] +  R_WtoC[6]*R_TtoW[2];
-    R_TtoC[1] = R_WtoC[1]*R_TtoW[0] +  R_WtoC[4]*R_TtoW[1] +  R_WtoC[7]*R_TtoW[2];
-    R_TtoC[2] = R_WtoC[2]*R_TtoW[0] +  R_WtoC[5]*R_TtoW[1] +  R_WtoC[8]*R_TtoW[2];
-    // y axis of target in camera coordinates
-    R_TtoC[3] = R_WtoC[0]*R_TtoW[3] +  R_WtoC[3]*R_TtoW[4] +  R_WtoC[6]*R_TtoW[5];
-    R_TtoC[4] = R_WtoC[1]*R_TtoW[3] +  R_WtoC[4]*R_TtoW[4] +  R_WtoC[7]*R_TtoW[5];
-    R_TtoC[5] = R_WtoC[2]*R_TtoW[3] +  R_WtoC[5]*R_TtoW[4] +  R_WtoC[8]*R_TtoW[5];
-    // z axis of target(normal vector) of target in camera coordinates
-    R_TtoC[6] = R_WtoC[0]*R_TtoW[6] +  R_WtoC[3]*R_TtoW[7] +  R_WtoC[6]*R_TtoW[8];
-    R_TtoC[7] = R_WtoC[1]*R_TtoW[6] +  R_WtoC[4]*R_TtoW[7] +  R_WtoC[7]*R_TtoW[8];
-    R_TtoC[8] = R_WtoC[2]*R_TtoW[6] +  R_WtoC[5]*R_TtoW[7] +  R_WtoC[8]*R_TtoW[8];
-      
-    // NOTE: we assume target is an XY planar target (all points on target have nominal z=0)
-    //       in this case, the target plane is defined by the first two columns of R_TtoC
-    //       these are the x and y vectors of the target frame expressed in the camera coordinates
-
-    // Projection of distance vector D = [-xp1 -yp1 -zp1]/sqrt(xp1^2+yp1^2+zp1^2) on target plane
-    T C2T_dist = sqrt(xp1*xp1 + yp1*yp1 + zp1*zp1); // distance from camera to point on target
-    T D_targetx = -(xp1*R_TtoC[0] + yp1*R_TtoC[1] + zp1*R_TtoC[2])/C2T_dist; // projection on target_x
-    T D_targety = -(xp1*R_TtoC[3] + yp1*R_TtoC[4] + zp1*R_TtoC[5])/C2T_dist; // projection on target_y
-    T D_targetz = -(xp1*R_TtoC[6] + yp1*R_TtoC[7] + zp1*R_TtoC[8])/C2T_dist; // projection on target_z
-    T s_theta   = D_targetz; // Note theta's the complemetary angle used to compute delta
-    T c_theta   = sqrt( T(1.0) - s_theta*s_theta);
-
-    // projection of D onto target xy plane expressed in camera frame is given by 
-    // D_targetx * R_TtoC(1stcol) + D_targety * R_TtoC(2ndcol)
-    T r = T(circle_diameter_/2.0);
-    T Delta = r*s_theta*(T(1.0)/(C2T_dist-r*c_theta) - T(1.0)/(C2T_dist+r*c_theta))/T(2.0);
-    
-    // Vx, Vy vector in target plane
-    T Vx = D_targetx*R_TtoC[0] + D_targety*R_TtoC[3];
-    T Vy = D_targetx*R_TtoC[1] + D_targety*R_TtoC[4];
-    T norm_vx = sqrt(Vx*Vx + Vy*Vy);
-    Vx = Vx/norm_vx;
-    Vy = Vy/norm_vx;
-      
-    /** scale into the image plane by distance away from camera */
-    T xp = xp1 / zp1 + Delta*Vx;
-    T yp = yp1 / zp1 + Delta*Vy;
-    
-    /** perform projection using focal length and camera center into image plane */
-    resid[0] = T(fx_) * xp + T(cx_) - T(ox_);
-    resid[1] = T(fy_) * yp + T(cy_) - T(oy_);
-
-    return true;
-  } // end of operator() 
-
+  return true;
+}  // end of operator()
 }
 
 #endif

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/circle_detector.hpp
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/circle_detector.hpp
@@ -43,7 +43,7 @@
 
 /********************************************************************************************
 **   Slight Modification of OpenCV function to use ellipse fitting rather than center of mass of contour ****
-**  to provide the location of the circle                                                                                               ****
+**  to provide the location of the circle ****
 ********************************************************************************************/
 #ifndef CIRCLEDETECTOR_HPP
 #define CIRCLEDETECTOR_HPP
@@ -53,42 +53,41 @@
 
 using std::vector;
 
-namespace cv {
+namespace cv
+{
 class CV_EXPORTS_W CircleDetector : public FeatureDetector
 {
 public:
   struct CV_EXPORTS_W_SIMPLE Params
   {
-      CV_WRAP Params();
-      CV_PROP_RW float thresholdStep;
-      CV_PROP_RW float minThreshold;
-      CV_PROP_RW float maxThreshold;
-      CV_PROP_RW size_t minRepeatability;
-      CV_PROP_RW float minDistBetweenCircles;
-      CV_PROP_RW float minRadiusDiff;
+    CV_WRAP Params();
+    CV_PROP_RW float thresholdStep;
+    CV_PROP_RW float minThreshold;
+    CV_PROP_RW float maxThreshold;
+    CV_PROP_RW size_t minRepeatability;
+    CV_PROP_RW float minDistBetweenCircles;
+    CV_PROP_RW float minRadiusDiff;
 
-      CV_PROP_RW bool filterByColor;
-      CV_PROP_RW uchar circleColor;
+    CV_PROP_RW bool filterByColor;
+    CV_PROP_RW uchar circleColor;
 
-      CV_PROP_RW bool filterByArea;
-      CV_PROP_RW float minArea, maxArea;
+    CV_PROP_RW bool filterByArea;
+    CV_PROP_RW float minArea, maxArea;
 
-      CV_PROP_RW bool filterByCircularity;
-      CV_PROP_RW float minCircularity, maxCircularity;
+    CV_PROP_RW bool filterByCircularity;
+    CV_PROP_RW float minCircularity, maxCircularity;
 
-      CV_PROP_RW bool filterByInertia;
-      CV_PROP_RW float minInertiaRatio, maxInertiaRatio;
+    CV_PROP_RW bool filterByInertia;
+    CV_PROP_RW float minInertiaRatio, maxInertiaRatio;
 
-      CV_PROP_RW bool filterByConvexity;
-      CV_PROP_RW float minConvexity, maxConvexity;
+    CV_PROP_RW bool filterByConvexity;
+    CV_PROP_RW float minConvexity, maxConvexity;
 
-      void read( const FileNode& fn );
-      void write( FileStorage& fs ) const;
+    void read(const FileNode& fn);
+    void write(FileStorage& fs) const;
   };
 
-  CV_WRAP static Ptr<CircleDetector>
-    create(const CircleDetector::Params &parameters = CircleDetector::Params());
-
+  CV_WRAP static Ptr< CircleDetector > create(const CircleDetector::Params& parameters = CircleDetector::Params());
 };
 }
 #endif

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/mutable_joint_state_publisher.h
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/mutable_joint_state_publisher.h
@@ -20,7 +20,7 @@
 #define MUTABLE_JOINT_STATE_PUBLISHER_H
 
 #include <stdio.h>
-#include <ros/ros.h> 
+#include <ros/ros.h>
 #include <industrial_extrinsic_cal/set_mutable_joint_states.h>
 #include <industrial_extrinsic_cal/get_mutable_joint_states.h>
 #include <industrial_extrinsic_cal/store_mutable_joint_states.h>
@@ -28,65 +28,62 @@
 #include <sensor_msgs/JointState.h>
 namespace industrial_extrinsic_cal
 {
-
-  /** @brief 
-   *        This object continuously broadcasts a vector of joint states
-   *        It provides 3 services
-   *        get the joint values
-   *        set the joint values
-   *        store the joint names and current values to a yaml file
-   *        The intent is to provide a seamless interface for extrinsic calibration of "static" transforms
-   *        The static transform publisher does not allow updating its values, typically this involves updating the urdf
-   *        Instead, if the urdf defines a chain of x_trans, y_trans, z_trans, roll, pitch and yaw joints
-   *        One may then use this node to continuously publish the values of the joints defining the transform
-   *        Calibration routines call the service tied to setCallBack() so that path planners use updated pose info
-   *        Calibration routines also call the service tied to storeCallBack() so that future launches also use updated 
-   *        pose info without having to modify their urdf/xacro files. 
+/** @brief
+ *        This object continuously broadcasts a vector of joint states
+ *        It provides 3 services
+ *        get the joint values
+ *        set the joint values
+ *        store the joint names and current values to a yaml file
+ *        The intent is to provide a seamless interface for extrinsic calibration of "static" transforms
+ *        The static transform publisher does not allow updating its values, typically this involves updating the urdf
+ *        Instead, if the urdf defines a chain of x_trans, y_trans, z_trans, roll, pitch and yaw joints
+ *        One may then use this node to continuously publish the values of the joints defining the transform
+ *        Calibration routines call the service tied to setCallBack() so that path planners use updated pose info
+ *        Calibration routines also call the service tied to storeCallBack() so that future launches also use updated
+ *        pose info without having to modify their urdf/xacro files.
+ */
+class MutableJointStatePublisher
+{
+public:
+  /**
+   * @brief constructor
+   * @param yaml_file_name contains the names of the joints and their default values
    */
-  class MutableJointStatePublisher
-  {
-  public:
+  MutableJointStatePublisher(ros::NodeHandle nh);
 
-    /**
-     * @brief constructor
-     * @param yaml_file_name contains the names of the joints and their default values
-     */
-    MutableJointStatePublisher(ros::NodeHandle nh);
+  /**
+   * @brief Default destructor
+   */
+  ~MutableJointStatePublisher(){};
 
-    /**
-     * @brief Default destructor
-     */
-    ~MutableJointStatePublisher()  {  } ;
+  /** @brief  set the values of all 6 joints
+   *
+   */
+  bool setCallBack(industrial_extrinsic_cal::set_mutable_joint_states::Request& req,
+                   industrial_extrinsic_cal::set_mutable_joint_states::Response& res);
 
-    /** @brief  set the values of all 6 joints
-     *
-     */
-    bool setCallBack(industrial_extrinsic_cal::set_mutable_joint_states::Request &req,
-					       industrial_extrinsic_cal::set_mutable_joint_states::Response &res);
+  /** @brief gets the mutable joint state's names and values */
+  bool getCallBack(industrial_extrinsic_cal::get_mutable_joint_states::Request& req,
+                   industrial_extrinsic_cal::get_mutable_joint_states::Response& res);
 
-    /** @brief gets the mutable joint state's names and values */
-    bool getCallBack(industrial_extrinsic_cal::get_mutable_joint_states::Request &req,
-					       industrial_extrinsic_cal::get_mutable_joint_states::Response &res);
+  /** @brief writes the mutable joint states to the yaml file*/
+  bool storeCallBack(industrial_extrinsic_cal::store_mutable_joint_states::Request& req,
+                     industrial_extrinsic_cal::store_mutable_joint_states::Response& res);
 
-    /** @brief writes the mutable joint states to the yaml file*/
-    bool storeCallBack(industrial_extrinsic_cal::store_mutable_joint_states::Request &req,
-						 industrial_extrinsic_cal::store_mutable_joint_states::Response &res);
+  /** @brief publishes the joint states as a joint state message*/
+  bool publishJointStates();
 
-    /** @brief publishes the joint states as a joint state message*/
-    bool publishJointStates();
+private:
+  bool loadFromYamlFile();
+  std::string yaml_file_name_;
+  std::map< std::string, double > joints_;
+  ros::NodeHandle nh_;
+  ros::Publisher joint_state_pub_;
+  ros::ServiceServer get_server_;
+  ros::ServiceServer set_server_;
+  ros::ServiceServer store_server_;
+  std::string node_name_;
+};
 
-
-  private:
-    bool loadFromYamlFile();
-    std::string yaml_file_name_;
-    std::map<std::string, double> joints_;
-    ros::NodeHandle nh_;
-    ros::Publisher joint_state_pub_;
-    ros::ServiceServer get_server_;
-    ros::ServiceServer set_server_;
-    ros::ServiceServer store_server_;
-    std::string node_name_;
-  };
-
-} //end industrial_extrinsic_cal namespace
+}  // end industrial_extrinsic_cal namespace
 #endif /* ROS_CAMERA_OBSERVER_H_ */

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/observation_data_point.h
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/observation_data_point.h
@@ -24,14 +24,14 @@
 
 namespace industrial_extrinsic_cal
 {
-
-  /** @brief An observation data point contains all the information necessary to construct the cost function to be added to the 
-   *              bundle adjustment problem to be solved by ceres. When a camera makes an observation, it fills out this object
-   **/
+/** @brief An observation data point contains all the information necessary to construct the cost function to be added
+ *to the
+ *              bundle adjustment problem to be solved by ceres. When a camera makes an observation, it fills out this
+ *object
+ **/
 class ObservationDataPoint
 {
 public:
-
   /** @brief constructor
    * @param c_name camera name
    * @param t_name target name
@@ -47,11 +47,10 @@ public:
    * @param cost_type     Type of cost function to use
    * @param circle_dia    diameter of circles in the target, if it is a circle target
    */
-  ObservationDataPoint(const std::string &c_name, const  std::string &t_name, const  int &t_type, 
-		       const int s_id, const  P_BLOCK &c_intrinsics, const  P_BLOCK &c_extrinsics,
-		       const int &point_id, const  P_BLOCK &t_pose, const  P_BLOCK &p_position,
-		       const  double &image_x, const  double &image_y, const Cost_function cost_type, 
-		       const  Pose6d &intermediate_frame, const  double &circle_dia=0.0)
+  ObservationDataPoint(const std::string& c_name, const std::string& t_name, const int& t_type, const int s_id,
+                       const P_BLOCK& c_intrinsics, const P_BLOCK& c_extrinsics, const int& point_id,
+                       const P_BLOCK& t_pose, const P_BLOCK& p_position, const double& image_x, const double& image_y,
+                       const Cost_function cost_type, const Pose6d& intermediate_frame, const double& circle_dia = 0.0)
   {
     camera_name_ = c_name;
     target_name_ = t_name;
@@ -72,52 +71,50 @@ public:
   /** @brief Destructor */
   ~ObservationDataPoint(){};
 
-  std::string camera_name_;	/**< name of camera */
-  std::string target_name_;	/**< name of target */
-  unsigned int target_type_;	/**<type of target */
-  int scene_id_;		/**< scene's identifier */
-  int point_id_;		/**< idetifier of point  */
-  P_BLOCK camera_extrinsics_;	/**< pointer to block of camera's extrinsic parameters */
-  P_BLOCK camera_intrinsics_;	/**< pointer to block of camera's interinsic parameters */
-  P_BLOCK target_pose_;		/**< pointer to block of target's pose parameters */
-  P_BLOCK point_position_;	/**< pointer to block of point's position parameters */
-  double image_x_;		/**< location of point in image (observation) */
-  double image_y_;		/**< location of point in image (observation) */
-  Cost_function cost_type_;      /**< type of cost function */
-  double circle_dia_;		/**< diameter of circle being observed (only appies to circular fiducials) */
+  std::string camera_name_;   /**< name of camera */
+  std::string target_name_;   /**< name of target */
+  unsigned int target_type_;  /**<type of target */
+  int scene_id_;              /**< scene's identifier */
+  int point_id_;              /**< idetifier of point  */
+  P_BLOCK camera_extrinsics_; /**< pointer to block of camera's extrinsic parameters */
+  P_BLOCK camera_intrinsics_; /**< pointer to block of camera's interinsic parameters */
+  P_BLOCK target_pose_;       /**< pointer to block of target's pose parameters */
+  P_BLOCK point_position_;    /**< pointer to block of point's position parameters */
+  double image_x_;            /**< location of point in image (observation) */
+  double image_y_;            /**< location of point in image (observation) */
+  Cost_function cost_type_;   /**< type of cost function */
+  double circle_dia_;         /**< diameter of circle being observed (only appies to circular fiducials) */
   Pose6d intermediate_frame_; /**< indentity unless camera was mounted on robot link */
 };
 // end of class ObservationDataPoint
 
 /**
- * @brief a list of observation data points which allows all the collected information about the observations to be easily submitted to ceres
+ * @brief a list of observation data points which allows all the collected information about the observations to be
+ * easily submitted to ceres
  *        It also allows the problem data to be printed to files for debugging and external analysis
  */
 class ObservationDataPointList
 {
 public:
-
-/**
- * @brief constructor
- */
+  /**
+   * @brief constructor
+   */
   ObservationDataPointList();
 
-/**
- * @brief destructor
- */
+  /**
+   * @brief destructor
+   */
   ~ObservationDataPointList();
 
-
-  /** @brief add an observation point to the list 
+  /** @brief add an observation point to the list
    *   @param new_data_point the observation to add to the list
    */
   void addObservationPoint(ObservationDataPoint new_data_point);
 
   /** @brief vector of observations */
-  std::vector<ObservationDataPoint> items_;
+  std::vector< ObservationDataPoint > items_;
 };
 
-
-}//end namespace industrial_extrinsic_cal
+}  // end namespace industrial_extrinsic_cal
 
 #endif /* OBSERVATION_DATA_POINT_H_ */

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/observation_scene.h
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/observation_scene.h
@@ -28,8 +28,6 @@
 
 namespace industrial_extrinsic_cal
 {
-
-
 /*! \brief a command to take a set of observations from a group of cameras upon a trigger event */
 class ObservationScene
 {
@@ -37,8 +35,7 @@ public:
   /*! \brief Constructor,
    *   \param Trigger the type of trigger to initiate this observation
    */
-  ObservationScene(boost::shared_ptr<Trigger> trigger, int scene_id) :
-      scene_id_(scene_id)
+  ObservationScene(boost::shared_ptr< Trigger > trigger, int scene_id) : scene_id_(scene_id)
   {
     trigger_ = trigger;
   };
@@ -49,7 +46,6 @@ public:
     observation_command_list_.clear();
     cameras_in_scene_.clear();
   };
-
 
   /*! \brief  Clears all observations from the command */
   void clear();
@@ -65,7 +61,7 @@ public:
    * \brief Adds a camera to the scene
    * @param cameras_in_scene
    */
-  void addCameraToScene(boost::shared_ptr<Camera> cameras_in_scene);
+  void addCameraToScene(boost::shared_ptr< Camera > cameras_in_scene);
 
   /*!
    * \brief will populate the observation_command_list_
@@ -74,7 +70,8 @@ public:
    * @param roi the region of interest for this observation command
    * @param cost_type type of cost function to build with this observation
    */
-  void populateObsCmdList(boost::shared_ptr<Camera> camera, boost::shared_ptr<Target> target, Roi roi, Cost_function cost_type);
+  void populateObsCmdList(boost::shared_ptr< Camera > camera, boost::shared_ptr< Target > target, Roi roi,
+                          Cost_function cost_type);
 
   /*! \brief gets the id of this scene */
   int get_id()
@@ -82,9 +79,8 @@ public:
     return (scene_id_);
   };
 
-
   /*! \brief gets the trigger of this scene */
-  boost::shared_ptr<Trigger> get_trigger()
+  boost::shared_ptr< Trigger > get_trigger()
   {
     return (trigger_);
   };
@@ -102,20 +98,20 @@ public:
    * \brief set the trigger for this scene
    * @param trigger
    */
-  void setTrigger(boost::shared_ptr<Trigger>  trigger)
+  void setTrigger(boost::shared_ptr< Trigger > trigger)
   {
     trigger_ = trigger;
   };
 
-  std::vector<ObservationCmd> observation_command_list_; /*!< list of observations for a scene */
-  std::vector<boost::shared_ptr<Camera> > cameras_in_scene_; /*!< list of cameras in this scene */
+  std::vector< ObservationCmd > observation_command_list_;      /*!< list of observations for a scene */
+  std::vector< boost::shared_ptr< Camera > > cameras_in_scene_; /*!< list of cameras in this scene */
 
 private:
-  boost::shared_ptr<Trigger>  trigger_; /*!< event to trigger the observations in this command */
-  int scene_id_; /*!< unique identifier of this scene */
+  boost::shared_ptr< Trigger > trigger_; /*!< event to trigger the observations in this command */
+  int scene_id_;                         /*!< unique identifier of this scene */
 };
 // end of class ObservationScene
 
-}//end namespace industrial_extrinsic_cal
+}  // end namespace industrial_extrinsic_cal
 
 #endif /* OBSERVATION_SCENE_H_ */

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/points_yaml_parser.h
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/points_yaml_parser.h
@@ -5,15 +5,15 @@
 #include <industrial_extrinsic_cal/basic_types.h>
 #include <industrial_extrinsic_cal/yaml_utils.h>
 
-namespace industrial_extrinsic_cal {
+namespace industrial_extrinsic_cal
+{
+/** @brief parse a list of points from a file
+ *  @param points_input_file, the stream from which to parse the points
+ *  @param points the returned vector of points
+ *  @return true if success, false otherwise
+ */
+bool parsePoints(std::string& points_input_file, std::vector< industrial_extrinsic_cal::Point3d >& points);
 
-  /** @brief parse a list of points from a file
-   *  @param points_input_file, the stream from which to parse the points
-   *  @param points the returned vector of points
-   *  @return true if success, false otherwise
-   */
-  bool parsePoints(std::string &points_input_file, std::vector<industrial_extrinsic_cal::Point3d> &points);
-  
-}// end industrial_extrinsic_cal namespace
+}  // end industrial_extrinsic_cal namespace
 
 #endif

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/ros_camera_observer.h
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/ros_camera_observer.h
@@ -21,7 +21,7 @@
 
 #include <industrial_extrinsic_cal/camera_observer.hpp>
 #include <industrial_extrinsic_cal/basic_types.h>
-#include <industrial_extrinsic_cal/ceres_costs_utils.h> 
+#include <industrial_extrinsic_cal/ceres_costs_utils.h>
 #include <dynamic_reconfigure/server.h>
 #include <industrial_extrinsic_cal/circle_grid_finderConfig.h>
 
@@ -50,276 +50,281 @@
  */
 namespace pattern_options
 {
-  enum pattern_options_
-    {
-      Chessboard = 0, CircleGrid = 1,  ModifiedCircleGrid = 2, ARtag = 3, Balls = 4, SingleBall = 5
-    };
+enum pattern_options_
+{
+  Chessboard = 0,
+  CircleGrid = 1,
+  ModifiedCircleGrid = 2,
+  ARtag = 3,
+  Balls = 4,
+  SingleBall = 5
+};
 }
 typedef pattern_options::pattern_options_ PatternOption;
 
 namespace industrial_extrinsic_cal
 {
+class ROSCameraObserver : public CameraObserver
+{
+public:
+  /**
+   * @brief constructor
+   * @param image_topic name of published image topic
+   */
+  ROSCameraObserver(const std::string& image_topic, const std::string& camera_name = "");
 
-  class ROSCameraObserver : public CameraObserver
+  /**
+   * @brief Default destructor
+   */
+  ~ROSCameraObserver(){};
+
+  /**
+   * @brief add a target to look for and region to look in
+   * @param targ a target to look for
+   * @param roi Region of interest for target
+   * @param cost_type type of cost function for observations of this target
+   * @return true if successful, false if error in setting target or roi
+   */
+  bool addTarget(boost::shared_ptr< Target > targ, Roi& roi, Cost_function cost_type);
+
+  /**
+   * @brief remove all targets
+   */
+  void clearTargets();
+
+  /**
+   * @brief clear all previous observations
+   */
+  void clearObservations();
+
+  /**
+   * @brief return observations
+   * @param camera_observations output observations of targets defined
+   * @return 0 if failed to get observations, 1 if successful
+   */
+  int getObservations(CameraObservations& camera_observations);
+
+  /** @brief tells observer to process next incomming image to find the targets in list */
+  void triggerCamera();
+
+  /** @brief tells when camera has completed its observations */
+  bool observationsDone();
+
+private:
+  /**
+   * @brief name of pattern being looked for
+   */
+  PatternOption pattern_;
+
+  /**
+   * @brief topic name for image which is input at constructor
+   */
+  std::string image_topic_;
+
+  /**
+   * @brief topic name for camera_info which is input at constructor
+   */
+  std::string camera_name_;
+
+  /**
+   *  @brief cropped image based on original image and region of interest
+   */
+  cv::Mat image_roi_;
+
+  /*!
+   *  @brief cv rectangle region to crop image into
+   */
+  cv::Rect input_roi_;
+
+  /**
+   *  @brief target pattern grid number of rows
+   */
+  int pattern_rows_;
+
+  /**
+   *  @brief target pattern grid number of columns
+   */
+  int pattern_cols_;
+
+  /**
+   *  @brief circle grid target pattern true=symmetric
+   */
+  bool sym_circle_;
+
+  /**
+   * @brief cost type string
+   */
+  Cost_function cost_type_;
+
+  /**
+   *  @brief 2D values of corner/circle locations returned from cv methods
+   */
+  std::vector< cv::Point2f > observation_pts_;
+
+  /**
+   *  @brief private target which is initialized to input target
+   */
+  boost::shared_ptr< Target > instance_target_;
+
+  /**
+   *  @brief private CameraObservations which are set at the end of getObservations and cleared
+   */
+  CameraObservations camera_obs_;
+
+  // ROS specific params
+  /**
+   *  @brief ROS node handle for initializing point cloud publisher
+   */
+  ros::NodeHandle nh_;
+
+  /**
+   *  @brief ROS subscriber to image_topic_
+   */
+  ros::Subscriber image_sub_;
+
+  /**
+   *  @brief ROS publisher of out_bridge_ or output_bridge_
+   */
+  ros::Publisher results_pub_;
+
+  /**
+   *  @brief ROS publisher used for publishing images for debugging
+   */
+  ros::Publisher debug_pub_;
+
+  // Structures for interacting with ROS/CV messages
+  /**
+   *  @brief cv_bridge image for input image from ROS topic image_topic_
+   */
+  cv_bridge::CvImagePtr input_bridge_;
+
+  /**
+   *  @brief cv_bridge image for cropped color output image
+   */
+  cv_bridge::CvImagePtr output_bridge_;
+
+  /**
+   *  @brief cv_bridge image for cropped mono output image
+   */
+  cv_bridge::CvImagePtr out_bridge_;
+
+  /**
+   *  @brief circle_detector_ptr_ is a custom blob detector which localizes circles better than simple blob detection
+   */
+  cv::Ptr< cv::CircleDetector > circle_detector_ptr_;
+
+  /**
+   *  @brief blob_detector_ptr_ is a simple blob detector
+   */
+  cv::Ptr< cv::FeatureDetector > blob_detector_ptr_;
+
+  /**
+   *  @brief new_image_collected, set after the trigger is done
+   */
+  bool new_image_collected_;
+
+  /**
+   *  @brief store_observation_images_ flag to save images for later use
+   */
+  bool store_observation_images_;
+
+  /**
+   *  @brief load_observation_images_ flag to load images from image_directory rather than from subscribed topic
+   */
+  bool load_observation_images_;
+
+  /**
+   *  @brief Flag to indicate if the image used in pattern detection should be normalized.
+   */
+  bool normalize_calibration_image_;
+
+  /**
+   *  @brief image_directory_ place to save images
+   */
+  std::string image_directory_;
+
+  /**
+   *  @brief getImageNumber
+   */
+  int getImageNumber()
   {
-  public:
-    
-    /**
-     * @brief constructor
-     * @param image_topic name of published image topic
-     */
-    ROSCameraObserver(const std::string &image_topic, const std::string &camera_name="");
-    
-    /**
-     * @brief Default destructor
-     */
-    ~ROSCameraObserver()  { }  ;
-    
-    /**
-     * @brief add a target to look for and region to look in
-     * @param targ a target to look for
-     * @param roi Region of interest for target
-     * @param cost_type type of cost function for observations of this target
-     * @return true if successful, false if error in setting target or roi
-     */
-    bool addTarget(boost::shared_ptr<Target> targ, Roi &roi, Cost_function cost_type);
+    return (image_number_);
+  }
+  /**
+   *  @brief setImageNumber allows users of the load feature to switch to a different image for the next observation
+   */
+  void setImageNumber(int image_number)
+  {
+    image_number_ = image_number;
+  }
 
-    /**
-     * @brief remove all targets
-     */
-    void clearTargets();
+  /**
+   *  @brief get last image
+   *  @return the most recent image
+   */
+  cv::Mat getLastImage();
 
-    /**
-     * @brief clear all previous observations
-     */
-    void clearObservations();
+public:
+  /**
+   *  @brief push the computed camera parameters out to the camera driver
+   *  @param fx the focal length in x
+   *  @param fx the focal length in y
+   *  @param cx the optical center in x
+   *  @param cy the optical center in y
+   *  @param k1 the radial distortion 2nd order term
+   *  @param k2 the radial distortion 4th order term
+   *  @param k3 the radial distortion 6th order term
+   *  @param p1 the decentering distortion p1
+   *  @param p2 the decentering distortion p2
+   */
+  bool pushCameraInfo(double& fx, double& fy, double& cx, double& cy, double& k1, double& k2, double& k3, double& p1,
+                      double& p2);
 
-    /**
-     * @brief return observations
-     * @param camera_observations output observations of targets defined
-     * @return 0 if failed to get observations, 1 if successful
-     */
-    int getObservations(CameraObservations &camera_observations);
+  /**
+   *  @brief pull the computed camera parameters out to the camera driver
+   *  @param fx the focal length in x
+   *  @param fx the focal length in y
+   *  @param cx the optical center in x
+   *  @param cy the optical center in y
+   *  @param k1 the radial distortion 2nd order term
+   *  @param k2 the radial distortion 4th order term
+   *  @param k3 the radial distortion 6th order term
+   *  @param p1 the decentering distortion p1
+   *  @param p2 the decentering distortion p2
+   */
+  bool pullCameraInfo(double& fx, double& fy, double& cx, double& cy, double& k1, double& k2, double& k3, double& p1,
+                      double& p2);
 
-    /** @brief tells observer to process next incomming image to find the targets in list */
-    void triggerCamera();
+  /**
+   *  @brief pull the computed camera parameters out to the camera driver
+   *  @param fx the focal length in x
+   *  @param fx the focal length in y
+   *  @param cx the optical center in x
+   *  @param cy the optical center in y
+   *  @param k1 the radial distortion 2nd order term
+   *  @param k2 the radial distortion 4th order term
+   *  @param k3 the radial distortion 6th order term
+   *  @param p1 the decentering distortion p1
+   *  @param p2 the decentering distortion p2
+   *  @param width the image width
+   *  @param height the image height
+   */
+  bool pullCameraInfo(double& fx, double& fy, double& cx, double& cy, double& k1, double& k2, double& k3, double& p1,
+                      double& p2, int& width, int& height);
 
-    /** @brief tells when camera has completed its observations */
-    bool observationsDone();
+  void dynReConfCallBack(industrial_extrinsic_cal::circle_grid_finderConfig& config, uint32_t level);
 
-  private:
+private:
+  int image_number_;       /**< a counter of images recieved */
+  cv::Mat last_raw_image_; /**< the image last received */
+  bool use_circle_detector_;
+  bool white_blobs_;
+  ros::ServiceClient client_;
+  sensor_msgs::SetCameraInfo srv_;
+  ros::NodeHandle* rnh_;
+  dynamic_reconfigure::Server< industrial_extrinsic_cal::circle_grid_finderConfig >* server_;
+};
 
-    /**
-     * @brief name of pattern being looked for
-     */
-    PatternOption pattern_;
-
-    /**
-     * @brief topic name for image which is input at constructor
-     */
-    std::string image_topic_;
-
-    /**
-     * @brief topic name for camera_info which is input at constructor
-     */
-    std::string camera_name_;
-
-    /**
-     *  @brief cropped image based on original image and region of interest
-     */
-    cv::Mat image_roi_;
-
-    /*!
-     *  @brief cv rectangle region to crop image into
-     */
-    cv::Rect input_roi_;
-
-    /**
-     *  @brief target pattern grid number of rows
-     */
-    int pattern_rows_;
-
-    /**
-     *  @brief target pattern grid number of columns
-     */
-    int pattern_cols_;
-
-    /**
-     *  @brief circle grid target pattern true=symmetric
-     */
-    bool sym_circle_;
-
-    /**
-     * @brief cost type string
-     */
-    Cost_function cost_type_;
-
-    /**
-     *  @brief 2D values of corner/circle locations returned from cv methods
-     */
-    std::vector<cv::Point2f> observation_pts_;
-
-    /**
-     *  @brief private target which is initialized to input target
-     */
-    boost::shared_ptr<Target> instance_target_;
-
-    /**
-     *  @brief private CameraObservations which are set at the end of getObservations and cleared
-     */
-    CameraObservations camera_obs_;
-
-    //ROS specific params
-    /**
-     *  @brief ROS node handle for initializing point cloud publisher
-     */
-    ros::NodeHandle nh_;
-
-    /**
-     *  @brief ROS subscriber to image_topic_
-     */
-    ros::Subscriber image_sub_;
-
-    /**
-     *  @brief ROS publisher of out_bridge_ or output_bridge_
-     */
-    ros::Publisher results_pub_;
-
-    /**
-     *  @brief ROS publisher used for publishing images for debugging
-     */
-    ros::Publisher debug_pub_;
-
-    // Structures for interacting with ROS/CV messages
-    /**
-     *  @brief cv_bridge image for input image from ROS topic image_topic_
-     */
-    cv_bridge::CvImagePtr input_bridge_;
-
-    /**
-     *  @brief cv_bridge image for cropped color output image
-     */
-    cv_bridge::CvImagePtr output_bridge_;
-
-    /**
-     *  @brief cv_bridge image for cropped mono output image
-     */
-    cv_bridge::CvImagePtr out_bridge_;
-
-
-    /**
-     *  @brief circle_detector_ptr_ is a custom blob detector which localizes circles better than simple blob detection
-     */
-    cv::Ptr<cv::CircleDetector>  circle_detector_ptr_;
-
-    /**
-     *  @brief blob_detector_ptr_ is a simple blob detector
-     */
-    cv::Ptr<cv::FeatureDetector> blob_detector_ptr_;
-
-    /**
-     *  @brief new_image_collected, set after the trigger is done
-     */
-    bool new_image_collected_;
-
-    /**
-     *  @brief store_observation_images_ flag to save images for later use
-     */
-    bool store_observation_images_;
-
-    /**
-     *  @brief load_observation_images_ flag to load images from image_directory rather than from subscribed topic
-     */
-    bool load_observation_images_;
-
-    /**
-     *  @brief Flag to indicate if the image used in pattern detection should be normalized.
-     */
-    bool normalize_calibration_image_;
-
-    /**
-     *  @brief image_directory_ place to save images
-     */
-    std::string image_directory_;
-
-    /**
-     *  @brief getImageNumber 
-     */
-    int getImageNumber(){ return(image_number_);}
-    /**
-     *  @brief setImageNumber allows users of the load feature to switch to a different image for the next observation
-     */
-    void setImageNumber(int image_number){ image_number_ = image_number;}
-
-    /**
-     *  @brief get last image
-     *  @return the most recent image
-     */
-    cv::Mat getLastImage();
-
-  public:
-    /**
-     *  @brief push the computed camera parameters out to the camera driver
-     *  @param fx the focal length in x
-     *  @param fx the focal length in y
-     *  @param cx the optical center in x
-     *  @param cy the optical center in y
-     *  @param k1 the radial distortion 2nd order term
-     *  @param k2 the radial distortion 4th order term
-     *  @param k3 the radial distortion 6th order term
-     *  @param p1 the decentering distortion p1
-     *  @param p2 the decentering distortion p2
-     */
-    bool  pushCameraInfo(double &fx, double &fy,	 double &cx,  double &cy,  double &k1,	 double &k2, double &k3,  double &p1,	 double &p2);
-
-    /**
-     *  @brief pull the computed camera parameters out to the camera driver
-     *  @param fx the focal length in x
-     *  @param fx the focal length in y
-     *  @param cx the optical center in x
-     *  @param cy the optical center in y
-     *  @param k1 the radial distortion 2nd order term
-     *  @param k2 the radial distortion 4th order term
-     *  @param k3 the radial distortion 6th order term
-     *  @param p1 the decentering distortion p1
-     *  @param p2 the decentering distortion p2
-     */
-    bool  pullCameraInfo(double &fx, double &fy,	 double &cx,  double &cy,  double &k1,	 double &k2, double &k3,  double &p1,	 double &p2);
-
-    /**
-     *  @brief pull the computed camera parameters out to the camera driver
-     *  @param fx the focal length in x
-     *  @param fx the focal length in y
-     *  @param cx the optical center in x
-     *  @param cy the optical center in y
-     *  @param k1 the radial distortion 2nd order term
-     *  @param k2 the radial distortion 4th order term
-     *  @param k3 the radial distortion 6th order term
-     *  @param p1 the decentering distortion p1
-     *  @param p2 the decentering distortion p2
-     *  @param width the image width
-     *  @param height the image height
-     */
-    bool  pullCameraInfo(double &fx, double &fy,	 double &cx,  double &cy,  double &k1,	 double &k2, double &k3,  double &p1,	 double &p2,
-                         int &width, int &height);
-
-    void dynReConfCallBack(industrial_extrinsic_cal::circle_grid_finderConfig &config, uint32_t level);
-    
-  private:
-
-    int image_number_; /**< a counter of images recieved */
-    cv::Mat last_raw_image_; /**< the image last received */
-    bool use_circle_detector_;
-    bool white_blobs_;
-    ros::ServiceClient client_;    
-    sensor_msgs::SetCameraInfo srv_;
-    ros::NodeHandle *rnh_;
-    dynamic_reconfigure::Server<industrial_extrinsic_cal::circle_grid_finderConfig> *server_;
-    
-  };
-
-  
-} //end industrial_extrinsic_cal namespace
-
+}  // end industrial_extrinsic_cal namespace
 
 #endif /* ROS_CAMERA_OBSERVER_H_ */

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/ros_scene_triggers.h
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/ros_scene_triggers.h
@@ -25,73 +25,76 @@
 
 namespace industrial_extrinsic_cal
 {
-
-  class ROSParamSceneTrigger : public SceneTrigger
+class ROSParamSceneTrigger : public SceneTrigger
+{
+public:
+  /*! \brief Constructor,
+   */
+  ROSParamSceneTrigger(std::string parameter_name)
   {
-  public:
-    /*! \brief Constructor,
-     */
-    ROSParamSceneTrigger(std::string parameter_name) 
-      {
-	parameter_name_ = parameter_name;  
-	nh_.setParam(parameter_name_.c_str(),false);
-      };
-    /*! \brief Destructor
-     */
-    ~ROSParamSceneTrigger(){};
-    /*! \brief Initiates and waits for trigger to finish
-     */
-    bool waitForTrigger()
+    parameter_name_ = parameter_name;
+    nh_.setParam(parameter_name_.c_str(), false);
+  };
+  /*! \brief Destructor
+   */
+  ~ROSParamSceneTrigger(){};
+  /*! \brief Initiates and waits for trigger to finish
+   */
+  bool waitForTrigger()
+  {
+    ROS_ERROR("ROSParamSceneTrigger: waiting for %s to be true", parameter_name_.c_str());
+    bool pval = false;
+    while (!pval)
     {
-      ROS_ERROR("ROSParamSceneTrigger: waiting for %s to be true",parameter_name_.c_str());
-      bool pval = false;
-      while(!pval){
-	nh_.getParam(parameter_name_.c_str(),pval);
-      }
-      nh_.setParam(parameter_name_.c_str(),false);
-      return(true);
-    };
-  private: 
-    ros::NodeHandle nh_;
-    std::string parameter_name_;
+      nh_.getParam(parameter_name_.c_str(), pval);
+    }
+    nh_.setParam(parameter_name_.c_str(), false);
+    return (true);
   };
 
-  typedef actionlib::SimpleActionClient<industrial_extrinsic_cal::manual_triggerAction> Client;
+private:
+  ros::NodeHandle nh_;
+  std::string parameter_name_;
+};
 
-  class ROSActionServerSceneTrigger : public SceneTrigger
+typedef actionlib::SimpleActionClient< industrial_extrinsic_cal::manual_triggerAction > Client;
+
+class ROSActionServerSceneTrigger : public SceneTrigger
+{
+public:
+  /*! \brief Constructor,
+   */
+  ROSActionServerSceneTrigger(std::string server_name, std::string action_message)
   {
-  public:
-    /*! \brief Constructor,
-     */
-    ROSActionServerSceneTrigger(std::string server_name, std::string action_message) 
-      {
-	server_name_ = server_name;  
-	action_message_ = action_message;  
-      };
-    /*! \brief Destructor
-     */
-    ~ROSActionServerSceneTrigger(){};
-    /*! \brief Initiates and waits for trigger to finish
-     */
-    bool waitForTrigger()
+    server_name_ = server_name;
+    action_message_ = action_message;
+  };
+  /*! \brief Destructor
+   */
+  ~ROSActionServerSceneTrigger(){};
+  /*! \brief Initiates and waits for trigger to finish
+   */
+  bool waitForTrigger()
+  {
+    ROS_ERROR("ROSActionServerSceneTrigger: waiting for trigger server %s to complete ", server_name_.c_str());
+    Client client(server_name_.c_str(), true);
+    client.waitForServer();
+    industrial_extrinsic_cal::manual_triggerGoal goal;
+    goal.display_message = action_message_;
+    client.sendGoal(goal);
+    client.waitForResult(ros::Duration(5.0));
+    while (client.getState() != actionlib::SimpleClientGoalState::SUCCEEDED)
     {
-      ROS_ERROR("ROSActionServerSceneTrigger: waiting for trigger server %s to complete ",server_name_.c_str());
-      Client client(server_name_.c_str(),true);
-      client.waitForServer();
-      industrial_extrinsic_cal::manual_triggerGoal goal;
-      goal.display_message = action_message_;
-      client.sendGoal(goal);
+      ROS_INFO("Current State: %s", client.getState().toString().c_str());
       client.waitForResult(ros::Duration(5.0));
-      while(client.getState() != actionlib::SimpleClientGoalState::SUCCEEDED){
-	ROS_INFO("Current State: %s", client.getState().toString().c_str());
-	client.waitForResult(ros::Duration(5.0));
-      }
-      return(true);
-    };
-  private: 
-    ros::NodeHandle nh_;
-    std::string server_name_;
-    std::string action_message_;
+    }
+    return (true);
   };
-} // end of namespace
+
+private:
+  ros::NodeHandle nh_;
+  std::string server_name_;
+  std::string action_message_;
+};
+}  // end of namespace
 #endif

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/ros_transform_interface.h
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/ros_transform_interface.h
@@ -20,12 +20,12 @@
 #define ROS_TRANSFORM_INTERFACE_H_
 
 #include <stdio.h>
-#include <ros/ros.h> 
+#include <ros/ros.h>
 #include <tf/transform_listener.h>
 #include <tf/transform_broadcaster.h>
 
 #include <industrial_extrinsic_cal/transform_interface.hpp>
-#include <industrial_extrinsic_cal/basic_types.h> // for Pose6d
+#include <industrial_extrinsic_cal/basic_types.h>  // for Pose6d
 #include <industrial_extrinsic_cal/get_mutable_joint_states.h>
 #include <industrial_extrinsic_cal/set_mutable_joint_states.h>
 #include <industrial_extrinsic_cal/store_mutable_joint_states.h>
@@ -33,474 +33,513 @@
 
 namespace industrial_extrinsic_cal
 {
-
-  /** @brief this object is intened to be used for targets, not cameras
-   *            It simply listens to a pose from ref to transform frame, this must be set in a urdf
-   *            push does nothing
-   *            pull listens to tf for desired transform
-   *            store does nothing
+/** @brief this object is intened to be used for targets, not cameras
+ *            It simply listens to a pose from ref to transform frame, this must be set in a urdf
+ *            push does nothing
+ *            pull listens to tf for desired transform
+ *            store does nothing
+ */
+class ROSListenerTransInterface : public TransformInterface
+{
+public:
+  /**
+   * @brief constructor
+   * @param image_topic name of published image topic
    */
-  class ROSListenerTransInterface : public TransformInterface
-  {
-  public:
+  ROSListenerTransInterface(const std::string& transform_frame);
 
-    /**
-     * @brief constructor
-     * @param image_topic name of published image topic
-     */
-    ROSListenerTransInterface(const std::string & transform_frame);
-
-    /**
-     * @brief Default destructor
-     */
-    ~ROSListenerTransInterface()  {  } ;
-
-    /** @brief  this is a listener interface, so this does nothing */
-    bool pushTransform(Pose6d & Pose){ return(true);};
-
-    /** @brief get the transform from tf */
-    Pose6d pullTransform();
-
-    /** @brief this is a listener interface, does nothing */
-    bool store(std::string &filePath) { return(true);};
-
-    /** @brief sets the reference frame of the transform interface, sometimes not used */
-    void setReferenceFrame(std::string &ref_frame) {
-      ref_frame_ = ref_frame;
-      ref_frame_initialized_ = true;
-    }
-
-  private:
-    Pose6d pose_;
-    tf::TransformListener tf_listener_;
-    tf::StampedTransform transform_;
-  };
-
-  /** @brief this object is intened to be used for cameras not targets
-   *            It simply listens to a pose from camera's optical frame to reference frame, this must be set in a urdf
-   *            This is the inverse of the transform from world to camera's optical frame (opposite of the target transform)
-   *            push does nothing
-   *            pull listens to tf for desired transform
-   *            store does nothing
+  /**
+   * @brief Default destructor
    */
-  class ROSCameraListenerTransInterface : public TransformInterface
+  ~ROSListenerTransInterface(){};
+
+  /** @brief  this is a listener interface, so this does nothing */
+  bool pushTransform(Pose6d& Pose)
   {
-  public:
-
-    /**
-     * @brief constructor
-     * @param image_topic name of published image topic
-     */
-    ROSCameraListenerTransInterface(const std::string & transform_frame);
-
-    /**
-     * @brief Default destructor
-     */
-    ~ROSCameraListenerTransInterface()  {  } ;
-
-    /** @brief  the object is a listener, so this does nothing*/
-    bool pushTransform(Pose6d & Pose){ return(true);};
-
-    /** @brief this returns the transform from the optical frame to the reference frame as returned by tf */
-    Pose6d pullTransform();
-
-    /** @brief as a listener interface, this does nothing because transform defined by urdf*/
-    bool store(std::string &filePath) {return(true);};
-
-    /** @brief sets the reference frame of the transform interface, sometimes not used */
-    void setReferenceFrame(std::string &ref_frame) {
-      ref_frame_ = ref_frame;
-      ref_frame_initialized_ = true;
-    }
-
-  private:
-    Pose6d pose_;
-    tf::TransformListener tf_listener_;
-    tf::StampedTransform transform_;
+    return (true);
   };
 
-  /** @brief this is expected to be used by a camera who's position is defined by the urdf
-   *              For example the camera might be held by a robot. 
-   *              The pose kept internally is from the camera's optical frame to the reference frame
-   *            push does nothing
-   *            pull listens to tf for desired transform
-   *            store does nothing
+  /** @brief get the transform from tf */
+  Pose6d pullTransform();
+
+  /** @brief this is a listener interface, does nothing */
+  bool store(std::string& filePath)
+  {
+    return (true);
+  };
+
+  /** @brief sets the reference frame of the transform interface, sometimes not used */
+  void setReferenceFrame(std::string& ref_frame)
+  {
+    ref_frame_ = ref_frame;
+    ref_frame_initialized_ = true;
+  }
+
+private:
+  Pose6d pose_;
+  tf::TransformListener tf_listener_;
+  tf::StampedTransform transform_;
+};
+
+/** @brief this object is intened to be used for cameras not targets
+ *            It simply listens to a pose from camera's optical frame to reference frame, this must be set in a urdf
+ *            This is the inverse of the transform from world to camera's optical frame (opposite of the target
+ * transform)
+ *            push does nothing
+ *            pull listens to tf for desired transform
+ *            store does nothing
+ */
+class ROSCameraListenerTransInterface : public TransformInterface
+{
+public:
+  /**
+   * @brief constructor
+   * @param image_topic name of published image topic
    */
-  class ROSCameraHousingListenerTInterface : public TransformInterface
-  {
-  public:
+  ROSCameraListenerTransInterface(const std::string& transform_frame);
 
-    /**
-     * @brief constructor
-     * @param optical_frame The name of the optical frame defined in the urdf
-     * @param housing_frame The name of camera housing frame defined in the urdf
-     */
-    ROSCameraHousingListenerTInterface(const std::string & optical_frame, const std::string & housing_frame);
-
-    /**
-     * @brief Default destructor
-     */
-    ~ROSCameraHousingListenerTInterface()  {  } ;
-
-    /** @brief  as a listener interface, this does nothing. Transform is defined by the urdf */
-    bool pushTransform(Pose6d & Pose){return(true);};
-
-    /** @brief get the transform from the hardware or display */
-    Pose6d pullTransform();
-
-    /** @brief as a listener interface, this does nothing. Transform is defined by urdf */
-    bool store(std::string &filePath){ return(true);};
-
-    /** @brief sets the reference frame of the transform interface, sometimes not used */
-    void setReferenceFrame(std::string &ref_frame) {
-      ref_frame_ = ref_frame;
-      ref_frame_initialized_ = true;
-    }
-
-  private:
-    std::string housing_frame_; /**< housing frame name note, this is not used, but kept be symetry with broadcaster param list */
-    Pose6d pose_; /**< pose associated with the transform from reference frame to housing frame */
-    tf::TransformListener tf_listener_; /**< listener used to get the transform/pose_ from tf */
-  };
-
-  /** @brief This transform interface is used when the pose determined through calibration
-      /* The urdf should not define this transform, otherwise there will be a conflict
-      /* the pose from the yaml file is broadcast immediately 
-      /* Once calibrated, the pose may be pushed, then the updated pose will be observed by tf
-  */
-  class ROSBroadcastTransInterface : public TransformInterface
-  {
-  public:
-
-    /**
-     * @brief constructor
-     * @param transform_frame the frame associated with this transform
-     */
-    ROSBroadcastTransInterface(const std::string & transform_frame);
-
-    /**
-     * @brief Default destructor
-     */
-    ~ROSBroadcastTransInterface()  {  } ;
-
-    /** @brief  updates the pose being broadcast*/
-    bool pushTransform(Pose6d & pose);
-
-    /** @brief this is a broadcaster, this should return the value of the construtor, or the last value used in pullTransform(pose) */
-    Pose6d pullTransform() {return(pose_);};
-
-    /** @brief appends data as a static transform publisher to the file */
-    bool store(std::string &filePath);
-
-    /** @brief sets the reference frame of the transform interface, sometimes not used */
-    void setReferenceFrame(std::string &ref_frame);
-
-    /** @brief a timer callback that continuously broadcast the current pose as a tf */
-    void timerCallback(const ros::TimerEvent & timer_event);
-   
-  private:
-    Pose6d pose_; /**< pose associated with the transform */
-    ros::Timer timer_; /**< need a timer to initiate broadcast of transform */
-    tf::StampedTransform transform_; /**< the broadcaster needs this which we get values from pose_ */
-    tf::TransformBroadcaster tf_broadcaster_; /**< the broadcaster to tf */
-  };
-
-  /** @brief This transform interface is used when the camera pose  is determined through calibration
-      /* The urdf should not define this transform, otherwise there will be a conflict
-      /* the pose in the camera yaml file is broadcast imediately 
-      /* Once calibrated, the pose may be pushed to tf
-  */
-
-  class ROSCameraBroadcastTransInterface : public TransformInterface
-  {
-  public:
-
-    /**
-     * @brief constructor
-     * @param transform_frame the frame associated with this transform
-     */
-    ROSCameraBroadcastTransInterface(const std::string & transform_frame);
-
-    /**
-     * @brief Default destructor
-     */
-    ~ROSCameraBroadcastTransInterface()  {  } ;
-
-    /** @brief  updates the pose being broadcast*/
-    bool pushTransform(Pose6d & pose);
-
-    /** @brief this is a broadcaster, this should return the value of the construtor, or the last value used in pullTransform(pose) */
-    Pose6d pullTransform() {return(pose_);};
-
-    /** @brief appends data as a static transform publisher to the file */
-    bool store(std::string &filePath);
-
-    /** @brief sets the reference frame of the transform interface, sometimes not used */
-    void setReferenceFrame(std::string &ref_frame);
-
-    /** @brief a timer callback that continuously broadcast the current pose as a tf */
-    void timerCallback(const ros::TimerEvent & timer_event);
-   
-  private:
-    Pose6d pose_; /**< pose associated with the transform */
-    ros::Timer timer_; /**< need a timer to initiate broadcast of transform */
-    tf::StampedTransform transform_; /**< the broadcaster needs this which we get values from pose_ */
-    tf::TransformBroadcaster tf_broadcaster_; /**< the broadcaster to tf */
-  };
-
-
-  /** @brief This transform interface is used when the camera pose  is determined through calibration
-      /* The urdf should not define this transform, otherwise there will be a conflict
-      /* the pose in the camera yaml file is broadcast imediately 
-      /* Once calibrated, the pose may be pushed to tf
-  */
-  class ROSCameraHousingBroadcastTInterface : public TransformInterface
-  {
-  public:
-
-    /**
-     * @brief constructor
-     * @param transform_frame the frame associated with this transform
-     * @param housing_frame the camera's housing frame
-     * @param mounting_frame the camera's mounting frame
-     */
-    ROSCameraHousingBroadcastTInterface(const std::string & transform_frame, 
-					const std::string &housing_frame, 
-                                                                          const std::string &mounting_frame,
-					const Pose6d & pose);
-
-    /**
-     * @brief Default destructor
-     */
-    ~ROSCameraHousingBroadcastTInterface()  {  } ;
-
-    /** @brief  updates the pose being broadcast*/
-    bool pushTransform(Pose6d & Pose);
-
-    /** @brief returns the pose used in construction, or the one most recently pushed */
-    Pose6d pullTransform();
-
-    /** @brief appends pose as a static transform publisher to the file */
-    bool store(std::string &filePath);
-
-    /** @brief sets the reference frame of the transform interface, sometimes not used */
-    void setReferenceFrame(std::string &ref_frame);
-
-    /** @brief a timer callback that continuously broadcast the current pose as a tf */
-    void timerCallback(const ros::TimerEvent & timer_event);
-   
-  private:
-    Pose6d pose_; /**< pose associated with the transform */
-    ros::Timer timer_; /**< need a timer to initiate broadcast of transform */
-    tf::StampedTransform transform_; /**< the broadcaster needs this which we get values from pose_ */
-    tf::TransformBroadcaster tf_broadcaster_; /**< the broadcaster to tf */
-    tf::TransformListener tf_listener_; // need this to get the tranform from housing to optical frame from tf
-    std::string housing_frame_; /**< frame name for the housing */
-    std::string mounting_frame_; /**< mounting frame name */
-  };
-
-  /** @brief this is expected to be used by a camera who's position is defined by the urdf using the calibration xacro macro
-   *             The macro takes a child and a parent link, and defines the following joints
-   *             {child}_x_joint: 
-   *             {child}_y_joint: 
-   *             {child}_z_joint: 
-   *             {child}_yaw_joint: 
-   *             {child}_pitch_joint:
-   *             {child}_roll_joint:
-   *             it is expected that the launch file for the workcell will include a mutable_joint_state_publisher
-   *             and that these joints are defined in the file whose name is held in the  mutableJointStateYamlFile parameter
-   *             push updates the joint states by calling the set_mutable_joint_states service
-   *             pull listens to the joint states by calling the get_mutable_joint_states service, and computes the transform
-   *             store updates the yaml file by calling the store_mutable_joint_states service
+  /**
+   * @brief Default destructor
    */
-  class ROSCameraHousingCalTInterface : public TransformInterface
+  ~ROSCameraListenerTransInterface(){};
+
+  /** @brief  the object is a listener, so this does nothing*/
+  bool pushTransform(Pose6d& Pose)
   {
-  public:
-
-    /**
-     * @brief constructor
-     * @param transform_frame The name of camera's optical frame 
-     * @param housing_frame The name of camera housing's frame
-     * @param mounting_frame The name of frame on which the camera housing is mounted
-     */
-    ROSCameraHousingCalTInterface(const std::string &transform_frame, /* optical frame */
-				  const std::string &housing_frame,
-				  const std::string &mounting_frame);
-
-    /**
-     * @brief Default destructor
-     */
-    ~ROSCameraHousingCalTInterface()  {  
-    } ;
-
-    /** @brief  uses the pose to compute the new joint values, and sends them to the mutable joint state publisher
-     * @param Pose the pose is the transform from the optical frame to the reference frame
-     * This function assumes this Pose is composed of three frames
-     * one from optical frame to housing frame
-     * one from housing to mounting frame
-     * one from mounting to reference
-     * the middle one is the one which is decomposed into the 6DOF joint values, 
-     */
-    bool pushTransform(Pose6d & Pose);
-
-    /** @brief get the transform from the mutable transform publisher, and compute the optical to reference frame pose*/
-    Pose6d pullTransform();
-
-    /** @brief as a listener interface, tells the mutable transform publisher to store its current values in its yaml file */
-    bool store(std::string &filePath);
-
-    /** @brief sets the reference frame of the transform interface, sometimes not used */
-    void setReferenceFrame(std::string &ref_frame);
-
-    /** @brief used to get the pose of the mounting frame in ref_frame coordinates
-     *   @return returns the pose from ref_frame to mounting frame in the case where necessary, identity otherwise
-     */
-    Pose6d getIntermediateFrame();
-
-  private:
-    ros::NodeHandle *nh_;/**< the standard node handle for ros*/
-    std::string housing_frame_; /**< housing frame name */
-    std::string mounting_frame_; /**< mounting frame name */
-    Pose6d pose_; /**< pose associated with the transform from reference frame to housing frame */
-    tf::TransformListener tf_listener_; /**< listener used to get the transform/pose_ from tf */
-    ros::ServiceClient get_client_; /**< a client for calling the service to get the joint values associated with the transform */
-    ros::ServiceClient set_client_; /**< a client for calling the service to set the joint values associated with the transform */
-    ros::ServiceClient store_client_; /**< a client for calling the service to store the joint values associated with the transform */
-    std::vector<std::string> joint_names_; /**< names of joints  */
-    std::vector<double> joint_values_; /**< values of joints  */
-    industrial_extrinsic_cal::get_mutable_joint_states::Request get_request_; /**< request when transform is part of a mutable set */
-    industrial_extrinsic_cal::get_mutable_joint_states::Response get_response_; /**< response when transform is part of a mutable set */
-    industrial_extrinsic_cal::set_mutable_joint_states::Request set_request_; /**< request when transform is part of a mutable set */
-    industrial_extrinsic_cal::set_mutable_joint_states::Response set_response_; /**< response when transform is part of a mutable set */
-    industrial_extrinsic_cal::store_mutable_joint_states::Request store_request_; /**< request to store when  part of a mutable set */
-    industrial_extrinsic_cal::store_mutable_joint_states::Response  store_response_;/**< response to store when  part of a mutable set */
+    return (true);
   };
 
-  /** @brief this is expected to be used for calibrating a target
-   *             The macro takes a child and a parent link, and defines the following joints
-   *             {child}_x_joint: 
-   *             {child}_y_joint: 
-   *             {child}_z_joint: 
-   *             {child}_yaw_joint: 
-   *             {child}_pitch_joint:
-   *             {child}_roll_joint:
-   *             it is expected that the launch file for the workcell will include a mutable_joint_state_publisher
-   *             and that these joints are defined in the file whose name is held in the  mutableJointStateYamlFile parameter
-   *             push updates the joint states by calling the set_mutable_joint_states service
-   *             pull listens to the joint states by calling the get_mutable_joint_states service, and computes the transform
-   *             store updates the yaml file by calling the store_mutable_joint_states service
+  /** @brief this returns the transform from the optical frame to the reference frame as returned by tf */
+  Pose6d pullTransform();
+
+  /** @brief as a listener interface, this does nothing because transform defined by urdf*/
+  bool store(std::string& filePath)
+  {
+    return (true);
+  };
+
+  /** @brief sets the reference frame of the transform interface, sometimes not used */
+  void setReferenceFrame(std::string& ref_frame)
+  {
+    ref_frame_ = ref_frame;
+    ref_frame_initialized_ = true;
+  }
+
+private:
+  Pose6d pose_;
+  tf::TransformListener tf_listener_;
+  tf::StampedTransform transform_;
+};
+
+/** @brief this is expected to be used by a camera who's position is defined by the urdf
+ *              For example the camera might be held by a robot.
+ *              The pose kept internally is from the camera's optical frame to the reference frame
+ *            push does nothing
+ *            pull listens to tf for desired transform
+ *            store does nothing
+ */
+class ROSCameraHousingListenerTInterface : public TransformInterface
+{
+public:
+  /**
+   * @brief constructor
+   * @param optical_frame The name of the optical frame defined in the urdf
+   * @param housing_frame The name of camera housing frame defined in the urdf
    */
-  class ROSSimpleCalTInterface : public TransformInterface
-  {
-  public:
+  ROSCameraHousingListenerTInterface(const std::string& optical_frame, const std::string& housing_frame);
 
-    /**
-     * @brief constructor
-     * @param transform_frame The name of frame being calibrated
-     * @param parent_frame The name of camera housing's frame
-     */
-    ROSSimpleCalTInterface(const std::string &transform_frame,  const std::string &parent_frame);
-
-    /**
-     * @brief Default destructor
-     */
-    ~ROSSimpleCalTInterface()  {  
-    } ;
-
-    /** @brief  uses the pose to compute the new joint values, and sends them to the mutable joint state publisher
-     * @param Pose the pose is the transform from the parent frame to the transform
-     */
-    bool pushTransform(Pose6d & Pose);
-
-    /** @brief get the transform from the mutable transform publisher, and compute the optical to reference frame pose*/
-    Pose6d pullTransform();
-
-    /** @brief as a listener interface, tells the mutable transform publisher to store its current values in its yaml file */
-    bool store(std::string &filePath);
-
-    /** @brief sets the reference frame of the transform interface, sometimes not used */
-    void setReferenceFrame(std::string &ref_frame);
-
-  private:
-    ros::NodeHandle *nh_;
-    std::string transform_frame_; /**< transform frame name */
-    std::string parent_frame_; /**< parent's frame name */
-    Pose6d pose_; /**< pose associated with the transform from reference frame to housing frame */
-    ros::ServiceClient get_client_; /**< a client for calling the service to get the joint values associated with the transform */
-    ros::ServiceClient set_client_; /**< a client for calling the service to set the joint values associated with the transform */
-    ros::ServiceClient store_client_; /**< a client for calling the service to store the joint values associated with the transform */
-    std::vector<std::string> joint_names_; /**< names of joints  */
-    std::vector<double> joint_values_; /**< values of joints  */
-    industrial_extrinsic_cal::get_mutable_joint_states::Request get_request_;
-    industrial_extrinsic_cal::get_mutable_joint_states::Response get_response_;
-    industrial_extrinsic_cal::set_mutable_joint_states::Request set_request_;
-    industrial_extrinsic_cal::set_mutable_joint_states::Response set_response_;
-    industrial_extrinsic_cal::store_mutable_joint_states::Request store_request_;
-    industrial_extrinsic_cal::store_mutable_joint_states::Response  store_response_;
-  };
-
-  /** @brief this is expected to be used for calibrating a camera
-   *             The macro takes a child and a parent link, and defines the following joints
-   *             {child}_x_joint: 
-   *             {child}_y_joint: 
-   *             {child}_z_joint: 
-   *             {child}_yaw_joint: 
-   *             {child}_pitch_joint:
-   *             {child}_roll_joint:
-   *             it is expected that the launch file for the workcell will include a mutable_joint_state_publisher
-   *             and that these joints are defined in the file whose name is held in the  mutableJointStateYamlFile parameter
-   *             push updates the joint states by calling the set_mutable_joint_states service
-   *             pull listens to the joint states by calling the get_mutable_joint_states service, and computes the transform
-   *             store updates the yaml file by calling the store_mutable_joint_states service
+  /**
+   * @brief Default destructor
    */
-  class ROSSimpleCameraCalTInterface : public TransformInterface
+  ~ROSCameraHousingListenerTInterface(){};
+
+  /** @brief  as a listener interface, this does nothing. Transform is defined by the urdf */
+  bool pushTransform(Pose6d& Pose)
   {
-  public:
-
-    /**
-     * @brief constructor
-     * @param transform_frame The name of frame being calibrated
-     * @param parent_frame The name of camera housing's frame
-     */
-    ROSSimpleCameraCalTInterface(const std::string &transform_frame,  const std::string &parent_frame);
-
-    /**
-     * @brief Default destructor
-     */
-    ~ROSSimpleCameraCalTInterface()  {  
-    } ;
-
-    /** @brief  uses the pose to compute the new joint values, and sends them to the mutable joint state publisher
-     * @param Pose the pose is the transform from the parent frame to the transform
-     */
-    bool pushTransform(Pose6d & Pose);
-
-    /** @brief get the transform from the mutable transform publisher, and compute the optical to reference frame pose*/
-    Pose6d pullTransform();
-
-    /** @brief as a listener interface, tells the mutable transform publisher to store its current values in its yaml file */
-    bool store(std::string &filePath);
-
-    /** @brief sets the reference frame of the transform interface, sometimes not used */
-    void setReferenceFrame(std::string &ref_frame);
-
-  private:
-    ros::NodeHandle *nh_;
-    std::string transform_frame_; /**< transform frame name */
-    std::string parent_frame_; /**< parent's frame name */
-    Pose6d pose_; /**< pose associated with the transform from reference frame to housing frame */
-    ros::ServiceClient get_client_; /**< a client for calling the service to get the joint values associated with the transform */
-    ros::ServiceClient set_client_; /**< a client for calling the service to set the joint values associated with the transform */
-    ros::ServiceClient store_client_; /**< a client for calling the service to store the joint values associated with the transform */
-    std::vector<std::string> joint_names_; /**< names of joints  */
-    std::vector<double> joint_values_; /**< values of joints  */
-    industrial_extrinsic_cal::get_mutable_joint_states::Request get_request_;
-    industrial_extrinsic_cal::get_mutable_joint_states::Response get_response_;
-    industrial_extrinsic_cal::set_mutable_joint_states::Request set_request_;
-    industrial_extrinsic_cal::set_mutable_joint_states::Response set_response_;
-    industrial_extrinsic_cal::store_mutable_joint_states::Request store_request_;
-    industrial_extrinsic_cal::store_mutable_joint_states::Response  store_response_;
+    return (true);
   };
 
-} //end industrial_extrinsic_cal namespace
+  /** @brief get the transform from the hardware or display */
+  Pose6d pullTransform();
+
+  /** @brief as a listener interface, this does nothing. Transform is defined by urdf */
+  bool store(std::string& filePath)
+  {
+    return (true);
+  };
+
+  /** @brief sets the reference frame of the transform interface, sometimes not used */
+  void setReferenceFrame(std::string& ref_frame)
+  {
+    ref_frame_ = ref_frame;
+    ref_frame_initialized_ = true;
+  }
+
+private:
+  std::string
+      housing_frame_; /**< housing frame name note, this is not used, but kept be symetry with broadcaster param list */
+  Pose6d pose_;       /**< pose associated with the transform from reference frame to housing frame */
+  tf::TransformListener tf_listener_; /**< listener used to get the transform/pose_ from tf */
+};
+
+/** @brief This transform interface is used when the pose determined through calibration
+    /* The urdf should not define this transform, otherwise there will be a conflict
+    /* the pose from the yaml file is broadcast immediately
+    /* Once calibrated, the pose may be pushed, then the updated pose will be observed by tf
+*/
+class ROSBroadcastTransInterface : public TransformInterface
+{
+public:
+  /**
+   * @brief constructor
+   * @param transform_frame the frame associated with this transform
+   */
+  ROSBroadcastTransInterface(const std::string& transform_frame);
+
+  /**
+   * @brief Default destructor
+   */
+  ~ROSBroadcastTransInterface(){};
+
+  /** @brief  updates the pose being broadcast*/
+  bool pushTransform(Pose6d& pose);
+
+  /** @brief this is a broadcaster, this should return the value of the construtor, or the last value used in
+   * pullTransform(pose) */
+  Pose6d pullTransform()
+  {
+    return (pose_);
+  };
+
+  /** @brief appends data as a static transform publisher to the file */
+  bool store(std::string& filePath);
+
+  /** @brief sets the reference frame of the transform interface, sometimes not used */
+  void setReferenceFrame(std::string& ref_frame);
+
+  /** @brief a timer callback that continuously broadcast the current pose as a tf */
+  void timerCallback(const ros::TimerEvent& timer_event);
+
+private:
+  Pose6d pose_;                             /**< pose associated with the transform */
+  ros::Timer timer_;                        /**< need a timer to initiate broadcast of transform */
+  tf::StampedTransform transform_;          /**< the broadcaster needs this which we get values from pose_ */
+  tf::TransformBroadcaster tf_broadcaster_; /**< the broadcaster to tf */
+};
+
+/** @brief This transform interface is used when the camera pose  is determined through calibration
+    /* The urdf should not define this transform, otherwise there will be a conflict
+    /* the pose in the camera yaml file is broadcast imediately
+    /* Once calibrated, the pose may be pushed to tf
+*/
+
+class ROSCameraBroadcastTransInterface : public TransformInterface
+{
+public:
+  /**
+   * @brief constructor
+   * @param transform_frame the frame associated with this transform
+   */
+  ROSCameraBroadcastTransInterface(const std::string& transform_frame);
+
+  /**
+   * @brief Default destructor
+   */
+  ~ROSCameraBroadcastTransInterface(){};
+
+  /** @brief  updates the pose being broadcast*/
+  bool pushTransform(Pose6d& pose);
+
+  /** @brief this is a broadcaster, this should return the value of the construtor, or the last value used in
+   * pullTransform(pose) */
+  Pose6d pullTransform()
+  {
+    return (pose_);
+  };
+
+  /** @brief appends data as a static transform publisher to the file */
+  bool store(std::string& filePath);
+
+  /** @brief sets the reference frame of the transform interface, sometimes not used */
+  void setReferenceFrame(std::string& ref_frame);
+
+  /** @brief a timer callback that continuously broadcast the current pose as a tf */
+  void timerCallback(const ros::TimerEvent& timer_event);
+
+private:
+  Pose6d pose_;                             /**< pose associated with the transform */
+  ros::Timer timer_;                        /**< need a timer to initiate broadcast of transform */
+  tf::StampedTransform transform_;          /**< the broadcaster needs this which we get values from pose_ */
+  tf::TransformBroadcaster tf_broadcaster_; /**< the broadcaster to tf */
+};
+
+/** @brief This transform interface is used when the camera pose  is determined through calibration
+    /* The urdf should not define this transform, otherwise there will be a conflict
+    /* the pose in the camera yaml file is broadcast imediately
+    /* Once calibrated, the pose may be pushed to tf
+*/
+class ROSCameraHousingBroadcastTInterface : public TransformInterface
+{
+public:
+  /**
+   * @brief constructor
+   * @param transform_frame the frame associated with this transform
+   * @param housing_frame the camera's housing frame
+   * @param mounting_frame the camera's mounting frame
+   */
+  ROSCameraHousingBroadcastTInterface(const std::string& transform_frame, const std::string& housing_frame,
+                                      const std::string& mounting_frame, const Pose6d& pose);
+
+  /**
+   * @brief Default destructor
+   */
+  ~ROSCameraHousingBroadcastTInterface(){};
+
+  /** @brief  updates the pose being broadcast*/
+  bool pushTransform(Pose6d& Pose);
+
+  /** @brief returns the pose used in construction, or the one most recently pushed */
+  Pose6d pullTransform();
+
+  /** @brief appends pose as a static transform publisher to the file */
+  bool store(std::string& filePath);
+
+  /** @brief sets the reference frame of the transform interface, sometimes not used */
+  void setReferenceFrame(std::string& ref_frame);
+
+  /** @brief a timer callback that continuously broadcast the current pose as a tf */
+  void timerCallback(const ros::TimerEvent& timer_event);
+
+private:
+  Pose6d pose_;                             /**< pose associated with the transform */
+  ros::Timer timer_;                        /**< need a timer to initiate broadcast of transform */
+  tf::StampedTransform transform_;          /**< the broadcaster needs this which we get values from pose_ */
+  tf::TransformBroadcaster tf_broadcaster_; /**< the broadcaster to tf */
+  tf::TransformListener tf_listener_;       // need this to get the tranform from housing to optical frame from tf
+  std::string housing_frame_;               /**< frame name for the housing */
+  std::string mounting_frame_;              /**< mounting frame name */
+};
+
+/** @brief this is expected to be used by a camera who's position is defined by the urdf using the calibration xacro
+ * macro
+ *             The macro takes a child and a parent link, and defines the following joints
+ *             {child}_x_joint:
+ *             {child}_y_joint:
+ *             {child}_z_joint:
+ *             {child}_yaw_joint:
+ *             {child}_pitch_joint:
+ *             {child}_roll_joint:
+ *             it is expected that the launch file for the workcell will include a mutable_joint_state_publisher
+ *             and that these joints are defined in the file whose name is held in the  mutableJointStateYamlFile
+ * parameter
+ *             push updates the joint states by calling the set_mutable_joint_states service
+ *             pull listens to the joint states by calling the get_mutable_joint_states service, and computes the
+ * transform
+ *             store updates the yaml file by calling the store_mutable_joint_states service
+ */
+class ROSCameraHousingCalTInterface : public TransformInterface
+{
+public:
+  /**
+   * @brief constructor
+   * @param transform_frame The name of camera's optical frame
+   * @param housing_frame The name of camera housing's frame
+   * @param mounting_frame The name of frame on which the camera housing is mounted
+   */
+  ROSCameraHousingCalTInterface(const std::string& transform_frame, /* optical frame */
+                                const std::string& housing_frame, const std::string& mounting_frame);
+
+  /**
+   * @brief Default destructor
+   */
+  ~ROSCameraHousingCalTInterface(){};
+
+  /** @brief  uses the pose to compute the new joint values, and sends them to the mutable joint state publisher
+   * @param Pose the pose is the transform from the optical frame to the reference frame
+   * This function assumes this Pose is composed of three frames
+   * one from optical frame to housing frame
+   * one from housing to mounting frame
+   * one from mounting to reference
+   * the middle one is the one which is decomposed into the 6DOF joint values,
+   */
+  bool pushTransform(Pose6d& Pose);
+
+  /** @brief get the transform from the mutable transform publisher, and compute the optical to reference frame pose*/
+  Pose6d pullTransform();
+
+  /** @brief as a listener interface, tells the mutable transform publisher to store its current values in its yaml file
+   */
+  bool store(std::string& filePath);
+
+  /** @brief sets the reference frame of the transform interface, sometimes not used */
+  void setReferenceFrame(std::string& ref_frame);
+
+  /** @brief used to get the pose of the mounting frame in ref_frame coordinates
+   *   @return returns the pose from ref_frame to mounting frame in the case where necessary, identity otherwise
+   */
+  Pose6d getIntermediateFrame();
+
+private:
+  ros::NodeHandle* nh_;               /**< the standard node handle for ros*/
+  std::string housing_frame_;         /**< housing frame name */
+  std::string mounting_frame_;        /**< mounting frame name */
+  Pose6d pose_;                       /**< pose associated with the transform from reference frame to housing frame */
+  tf::TransformListener tf_listener_; /**< listener used to get the transform/pose_ from tf */
+  ros::ServiceClient get_client_;     /**< a client for calling the service to get the joint values associated with the
+                                         transform */
+  ros::ServiceClient set_client_;     /**< a client for calling the service to set the joint values associated with the
+                                         transform */
+  ros::ServiceClient
+      store_client_; /**< a client for calling the service to store the joint values associated with the transform */
+  std::vector< std::string > joint_names_;                                  /**< names of joints  */
+  std::vector< double > joint_values_;                                      /**< values of joints  */
+  industrial_extrinsic_cal::get_mutable_joint_states::Request get_request_; /**< request when transform is part of a
+                                                                               mutable set */
+  industrial_extrinsic_cal::get_mutable_joint_states::Response
+      get_response_; /**< response when transform is part of a mutable set */
+  industrial_extrinsic_cal::set_mutable_joint_states::Request set_request_; /**< request when transform is part of a
+                                                                               mutable set */
+  industrial_extrinsic_cal::set_mutable_joint_states::Response
+      set_response_; /**< response when transform is part of a mutable set */
+  industrial_extrinsic_cal::store_mutable_joint_states::Request store_request_; /**< request to store when  part of a
+                                                                                   mutable set */
+  industrial_extrinsic_cal::store_mutable_joint_states::Response
+      store_response_; /**< response to store when  part of a mutable set */
+};
+
+/** @brief this is expected to be used for calibrating a target
+ *             The macro takes a child and a parent link, and defines the following joints
+ *             {child}_x_joint:
+ *             {child}_y_joint:
+ *             {child}_z_joint:
+ *             {child}_yaw_joint:
+ *             {child}_pitch_joint:
+ *             {child}_roll_joint:
+ *             it is expected that the launch file for the workcell will include a mutable_joint_state_publisher
+ *             and that these joints are defined in the file whose name is held in the  mutableJointStateYamlFile
+ * parameter
+ *             push updates the joint states by calling the set_mutable_joint_states service
+ *             pull listens to the joint states by calling the get_mutable_joint_states service, and computes the
+ * transform
+ *             store updates the yaml file by calling the store_mutable_joint_states service
+ */
+class ROSSimpleCalTInterface : public TransformInterface
+{
+public:
+  /**
+   * @brief constructor
+   * @param transform_frame The name of frame being calibrated
+   * @param parent_frame The name of camera housing's frame
+   */
+  ROSSimpleCalTInterface(const std::string& transform_frame, const std::string& parent_frame);
+
+  /**
+   * @brief Default destructor
+   */
+  ~ROSSimpleCalTInterface(){};
+
+  /** @brief  uses the pose to compute the new joint values, and sends them to the mutable joint state publisher
+   * @param Pose the pose is the transform from the parent frame to the transform
+   */
+  bool pushTransform(Pose6d& Pose);
+
+  /** @brief get the transform from the mutable transform publisher, and compute the optical to reference frame pose*/
+  Pose6d pullTransform();
+
+  /** @brief as a listener interface, tells the mutable transform publisher to store its current values in its yaml file
+   */
+  bool store(std::string& filePath);
+
+  /** @brief sets the reference frame of the transform interface, sometimes not used */
+  void setReferenceFrame(std::string& ref_frame);
+
+private:
+  ros::NodeHandle* nh_;
+  std::string transform_frame_;   /**< transform frame name */
+  std::string parent_frame_;      /**< parent's frame name */
+  Pose6d pose_;                   /**< pose associated with the transform from reference frame to housing frame */
+  ros::ServiceClient get_client_; /**< a client for calling the service to get the joint values associated with the
+                                     transform */
+  ros::ServiceClient set_client_; /**< a client for calling the service to set the joint values associated with the
+                                     transform */
+  ros::ServiceClient
+      store_client_; /**< a client for calling the service to store the joint values associated with the transform */
+  std::vector< std::string > joint_names_; /**< names of joints  */
+  std::vector< double > joint_values_;     /**< values of joints  */
+  industrial_extrinsic_cal::get_mutable_joint_states::Request get_request_;
+  industrial_extrinsic_cal::get_mutable_joint_states::Response get_response_;
+  industrial_extrinsic_cal::set_mutable_joint_states::Request set_request_;
+  industrial_extrinsic_cal::set_mutable_joint_states::Response set_response_;
+  industrial_extrinsic_cal::store_mutable_joint_states::Request store_request_;
+  industrial_extrinsic_cal::store_mutable_joint_states::Response store_response_;
+};
+
+/** @brief this is expected to be used for calibrating a camera
+ *             The macro takes a child and a parent link, and defines the following joints
+ *             {child}_x_joint:
+ *             {child}_y_joint:
+ *             {child}_z_joint:
+ *             {child}_yaw_joint:
+ *             {child}_pitch_joint:
+ *             {child}_roll_joint:
+ *             it is expected that the launch file for the workcell will include a mutable_joint_state_publisher
+ *             and that these joints are defined in the file whose name is held in the  mutableJointStateYamlFile
+ * parameter
+ *             push updates the joint states by calling the set_mutable_joint_states service
+ *             pull listens to the joint states by calling the get_mutable_joint_states service, and computes the
+ * transform
+ *             store updates the yaml file by calling the store_mutable_joint_states service
+ */
+class ROSSimpleCameraCalTInterface : public TransformInterface
+{
+public:
+  /**
+   * @brief constructor
+   * @param transform_frame The name of frame being calibrated
+   * @param parent_frame The name of camera housing's frame
+   */
+  ROSSimpleCameraCalTInterface(const std::string& transform_frame, const std::string& parent_frame);
+
+  /**
+   * @brief Default destructor
+   */
+  ~ROSSimpleCameraCalTInterface(){};
+
+  /** @brief  uses the pose to compute the new joint values, and sends them to the mutable joint state publisher
+   * @param Pose the pose is the transform from the parent frame to the transform
+   */
+  bool pushTransform(Pose6d& Pose);
+
+  /** @brief get the transform from the mutable transform publisher, and compute the optical to reference frame pose*/
+  Pose6d pullTransform();
+
+  /** @brief as a listener interface, tells the mutable transform publisher to store its current values in its yaml file
+   */
+  bool store(std::string& filePath);
+
+  /** @brief sets the reference frame of the transform interface, sometimes not used */
+  void setReferenceFrame(std::string& ref_frame);
+
+private:
+  ros::NodeHandle* nh_;
+  std::string transform_frame_;   /**< transform frame name */
+  std::string parent_frame_;      /**< parent's frame name */
+  Pose6d pose_;                   /**< pose associated with the transform from reference frame to housing frame */
+  ros::ServiceClient get_client_; /**< a client for calling the service to get the joint values associated with the
+                                     transform */
+  ros::ServiceClient set_client_; /**< a client for calling the service to set the joint values associated with the
+                                     transform */
+  ros::ServiceClient
+      store_client_; /**< a client for calling the service to store the joint values associated with the transform */
+  std::vector< std::string > joint_names_; /**< names of joints  */
+  std::vector< double > joint_values_;     /**< values of joints  */
+  industrial_extrinsic_cal::get_mutable_joint_states::Request get_request_;
+  industrial_extrinsic_cal::get_mutable_joint_states::Response get_response_;
+  industrial_extrinsic_cal::set_mutable_joint_states::Request set_request_;
+  industrial_extrinsic_cal::set_mutable_joint_states::Response set_response_;
+  industrial_extrinsic_cal::store_mutable_joint_states::Request store_request_;
+  industrial_extrinsic_cal::store_mutable_joint_states::Response store_response_;
+};
+
+}  // end industrial_extrinsic_cal namespace
 #endif /* ROS_CAMERA_OBSERVER_H_ */

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/ros_triggers.h
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/ros_triggers.h
@@ -30,242 +30,253 @@
 
 namespace industrial_extrinsic_cal
 {
-  class ROSParamTrigger : public Trigger
+class ROSParamTrigger : public Trigger
+{
+public:
+  /*! \brief Constructor,
+   * @param parameter_name, name of trigger
+   */
+  ROSParamTrigger(const std::string& parameter_name)
   {
-  public:
-    /*! \brief Constructor,
-     * @param parameter_name, name of trigger
-     */
-    ROSParamTrigger(const std::string & parameter_name) 
-      {
-	parameter_name_ = parameter_name;  
-	nh_.setParam(parameter_name_.c_str(),false);
-      };
-    /*! \brief Destructor
-     */
-    ~ROSParamTrigger(){};
-    /*! \brief Initiates and waits for trigger to finish
-     */
-    bool waitForTrigger()
+    parameter_name_ = parameter_name;
+    nh_.setParam(parameter_name_.c_str(), false);
+  };
+  /*! \brief Destructor
+   */
+  ~ROSParamTrigger(){};
+  /*! \brief Initiates and waits for trigger to finish
+   */
+  bool waitForTrigger()
+  {
+    ROS_ERROR("ROSParamTrigger:  waiting for %s to be true", parameter_name_.c_str());
+    bool pval = false;
+    while (!pval)
     {
-      ROS_ERROR("ROSParamTrigger:  waiting for %s to be true",parameter_name_.c_str());
-      bool pval = false;
-      while(!pval){
-	nh_.getParam(parameter_name_.c_str(),pval);
-      }
-      nh_.setParam(parameter_name_.c_str(),false);
-      return(true);
-    };
-  private: 
-    ros::NodeHandle nh_;
-    std::string parameter_name_;
+      nh_.getParam(parameter_name_.c_str(), pval);
+    }
+    nh_.setParam(parameter_name_.c_str(), false);
+    return (true);
   };
 
-  typedef actionlib::SimpleActionClient<industrial_extrinsic_cal::manual_triggerAction> ManualClient;
+private:
+  ros::NodeHandle nh_;
+  std::string parameter_name_;
+};
 
-  class ROSActionServerTrigger : public Trigger
+typedef actionlib::SimpleActionClient< industrial_extrinsic_cal::manual_triggerAction > ManualClient;
+
+class ROSActionServerTrigger : public Trigger
+{
+public:
+  /*! \brief Constructor,
+   * @param server_name, name of tigger service
+   * @param action_message message to display
+   */
+  ROSActionServerTrigger(const std::string& server_name, const std::string& action_message)
   {
-  public:
-    /*! \brief Constructor,
-     * @param server_name, name of tigger service
-     * @param action_message message to display
-     */
-    ROSActionServerTrigger(const std::string & server_name, const  std::string  & action_message) 
-      {
-	server_name_ = server_name;  
-	action_message_ = action_message;  
-	client_ = new ManualClient(server_name_.c_str(),true);
-      };
-
-    /*! \brief Destructor
-     */
-    ~ROSActionServerTrigger(){};
-
-    /*! \brief Initiates and waits for trigger to finish
-     */
-    bool waitForTrigger()
-    {
-      ROS_INFO("ROSActionServerTrigger: waiting for trigger server %s to complete ",server_name_.c_str());
-      client_->waitForServer();
-      industrial_extrinsic_cal::manual_triggerGoal goal;
-      goal.display_message = action_message_;
-      client_->sendGoal(goal);
-      do{
-	client_->waitForResult(ros::Duration(5.0));
-	ROS_INFO("Current State: %s", client_->getState().toString().c_str());
-      } while(client_->getState() != actionlib::SimpleClientGoalState::SUCCEEDED
-	      && client_->getState() != actionlib::SimpleClientGoalState::ABORTED);
-      return(true);  /**< TODO implement a timeout, cancels action and with returns false*/
-    };
-  private: 
-    ManualClient *client_;
-    ros::NodeHandle nh_;	/**< node handle */
-    std::string server_name_;	/**< name of server */
-    std::string action_message_; /**< message sent to action server, often displayed by that server */
+    server_name_ = server_name;
+    action_message_ = action_message;
+    client_ = new ManualClient(server_name_.c_str(), true);
   };
 
+  /*! \brief Destructor
+   */
+  ~ROSActionServerTrigger(){};
 
-    typedef actionlib::SimpleActionClient<industrial_extrinsic_cal::robot_joint_values_triggerAction> RobotJointValuesClient;
-
-  class ROSRobotJointValuesActionServerTrigger : public Trigger
+  /*! \brief Initiates and waits for trigger to finish
+   */
+  bool waitForTrigger()
   {
-  public:
-    /*! \brief Constructor,
-     *  @param server name , name of server
-     *  @param joint_values, vector of joint values describing the pose of the robot for the trigger
-     */
-    ROSRobotJointValuesActionServerTrigger(const std::string & server_name, const  std::vector<double> &joint_values) 
-      {
-	server_name_ = server_name;  
-	joint_values_.clear();
-	for(int i=0; i< (int)joint_values.size(); i++){
-	  joint_values_.push_back(joint_values[i]);
-	}
-	client_ = new RobotJointValuesClient(server_name_.c_str(),true);
-      };
-
-    /*! \brief Destructor
-     */
-    ~ROSRobotJointValuesActionServerTrigger(){
-      delete(client_);
-    };
-
-    /*! \brief Initiates and waits for trigger to finish
-     */
-    bool waitForTrigger()
+    ROS_INFO("ROSActionServerTrigger: waiting for trigger server %s to complete ", server_name_.c_str());
+    client_->waitForServer();
+    industrial_extrinsic_cal::manual_triggerGoal goal;
+    goal.display_message = action_message_;
+    client_->sendGoal(goal);
+    do
     {
-      ROS_INFO("ROSRobotJointValuesActionServerTrigger: waiting for trigger server %s to complete ",server_name_.c_str());
-      client_->waitForServer();
-      industrial_extrinsic_cal::robot_joint_values_triggerGoal goal;
-      goal.joint_values.clear();
-      for(int i=0; i<(int)joint_values_.size();i++){
-	goal.joint_values.push_back(joint_values_[i]);
-      }
-      ROS_INFO("SENDING GOAL");
-      client_->sendGoal(goal);
-      do{
-	client_->waitForResult(ros::Duration(5.0));
-	ROS_INFO("Current State: %s", client_->getState().toString().c_str());
-      } while(client_->getState() != actionlib::SimpleClientGoalState::SUCCEEDED
-	      && client_->getState() != actionlib::SimpleClientGoalState::ABORTED);
-      return(true);  /**< TODO implement a timeout, cancels action and with returns false*/
-    };
-  private: 
-    RobotJointValuesClient *client_;
-    ros::NodeHandle nh_;	/**< node handle */
-    std::string server_name_;	/**< name of server */
-    std::vector<double> joint_values_; /**< joint values */
+      client_->waitForResult(ros::Duration(5.0));
+      ROS_INFO("Current State: %s", client_->getState().toString().c_str());
+    } while (client_->getState() != actionlib::SimpleClientGoalState::SUCCEEDED &&
+             client_->getState() != actionlib::SimpleClientGoalState::ABORTED);
+    return (true); /**< TODO implement a timeout, cancels action and with returns false*/
   };
 
-    typedef actionlib::SimpleActionClient<industrial_extrinsic_cal::robot_pose_triggerAction> Robot_Pose_Client;
- 
+private:
+  ManualClient* client_;
+  ros::NodeHandle nh_;         /**< node handle */
+  std::string server_name_;    /**< name of server */
+  std::string action_message_; /**< message sent to action server, often displayed by that server */
+};
 
-  class ROSRobotPoseActionServerTrigger : public Trigger
+typedef actionlib::SimpleActionClient< industrial_extrinsic_cal::robot_joint_values_triggerAction >
+    RobotJointValuesClient;
+
+class ROSRobotJointValuesActionServerTrigger : public Trigger
+{
+public:
+  /*! \brief Constructor,
+   *  @param server name , name of server
+   *  @param joint_values, vector of joint values describing the pose of the robot for the trigger
+   */
+  ROSRobotJointValuesActionServerTrigger(const std::string& server_name, const std::vector< double >& joint_values)
   {
-  public:
-    /*! \brief Constructor,
-     *   @param server_name name of the service
-     *   @param pose the pose of the robot for the trigger
-     */
-    ROSRobotPoseActionServerTrigger(const std::string & server_name, const  Pose6d pose) 
-      {
-	server_name_ = server_name;  
-	joint_values_.clear();
-	pose_.position.x = pose.x;
-	pose_.position.y = pose.y;
-	pose_.position.z = pose.z;
-	double qx,qy,qz,qw;
-	pose.getQuaternion(qx, qy, qz, qw);
-	pose_.orientation.x = qx;
-	pose_.orientation.y = qy;
-	pose_.orientation.z = qz;
-	pose_.orientation.w = qw;
-	client_ = new Robot_Pose_Client(server_name_.c_str(),true);
-      };
-
-    /*! \brief Destructor
-     */
-    ~ROSRobotPoseActionServerTrigger(){};
-
-    /*! \brief Initiates and waits for trigger to finish
-     */
-    bool waitForTrigger()
+    server_name_ = server_name;
+    joint_values_.clear();
+    for (int i = 0; i < (int)joint_values.size(); i++)
     {
-      ROS_INFO("ROSRobotPoseActionServerTrigger: waiting for trigger server %s to complete ",server_name_.c_str());
-      client_->waitForServer();
-      industrial_extrinsic_cal::robot_pose_triggerGoal goal;
-      goal.pose = pose_;
-      client_->sendGoal(goal);
-      do{
-	client_->waitForResult(ros::Duration(5.0));
-	ROS_INFO("Current State: %s", client_->getState().toString().c_str());
-      } while(client_->getState() != actionlib::SimpleClientGoalState::SUCCEEDED
-	      && client_->getState() != actionlib::SimpleClientGoalState::ABORTED);
-      return(true);  /**< TODO implement a timeout, cancels action and with returns false*/
-    };
-  private: 
-    Robot_Pose_Client *client_;
-    ros::NodeHandle nh_;	/**< node handle */
-    std::string server_name_;	/**< name of server */
-    geometry_msgs::Pose pose_; /**< pose of robot */
-    std::vector<double> joint_values_; /**< joint values */
+      joint_values_.push_back(joint_values[i]);
+    }
+    client_ = new RobotJointValuesClient(server_name_.c_str(), true);
   };
 
-  class ROSCameraObserverTrigger : public Trigger
+  /*! \brief Destructor
+   */
+  ~ROSRobotJointValuesActionServerTrigger()
   {
-  public:
-    /*! \brief Constructor,
-     *   @param service_name name of service
-     *    @param instructions a message for the user
-     *    @param image_topic the image to use and display to user to accept the trigger
-     *    @param roi the region of interest in the image displayed to the user
-     */
-    ROSCameraObserverTrigger(const std::string & service_name, 
-			     const std::string &instructions, 
-			     const std::string &image_topic, 
-			     const Roi &roi ) 
-      {
-	 nh_ = new ros::NodeHandle;
-	 service_name_ = service_name;  
-	 instructions_ = instructions;
-	 image_topic_ = image_topic;
-	 client_          = nh_->serviceClient<industrial_extrinsic_cal::camera_observer_trigger>(service_name_.c_str());
-	 roi_ = roi;
-      };
-
-    /*! \brief Destructor
-     */
-    ~ROSCameraObserverTrigger(){};
-
-    /*! \brief Initiates and waits for trigger to finish
-     */
-    bool waitForTrigger()
-    {
-      industrial_extrinsic_cal::camera_observer_trigger::Request request; 
-      industrial_extrinsic_cal::camera_observer_trigger::Response response;
-
-      ROS_INFO("ROSRobotPoseActionServerTrigger: waiting for trigger server %s to complete ",service_name_.c_str());
-      request.image_topic = image_topic_;
-      request.instructions = instructions_;
-      request.roi_min_x   = roi_.x_min;
-      request.roi_max_x   = roi_.x_max;
-      request.roi_min_y   = roi_.y_min;
-      request.roi_max_y   = roi_.y_max;
-
-      if(!client_.call(request, response)){
-	ROS_ERROR("Trigger failed");
-      }
-      return(true);  /**< TODO implement a timeout, cancels action and with returns false*/
-    };
-  private: 
-    ros::ServiceClient client_; /**< the client to call supplying this trigger */
-    ros::NodeHandle *nh_;	/**< node handle */
-    std::string service_name_;	/**< name of server */
-    std::string instructions_;	/**< instructions to display to user */
-    std::string image_topic_; /**< image from this ros topic used to find target within the given roi */
-    industrial_extrinsic_cal::Roi roi_; /**< region to find the target */
+    delete (client_);
   };
 
-}// end of namespace
+  /*! \brief Initiates and waits for trigger to finish
+   */
+  bool waitForTrigger()
+  {
+    ROS_INFO("ROSRobotJointValuesActionServerTrigger: waiting for trigger server %s to complete ",
+             server_name_.c_str());
+    client_->waitForServer();
+    industrial_extrinsic_cal::robot_joint_values_triggerGoal goal;
+    goal.joint_values.clear();
+    for (int i = 0; i < (int)joint_values_.size(); i++)
+    {
+      goal.joint_values.push_back(joint_values_[i]);
+    }
+    ROS_INFO("SENDING GOAL");
+    client_->sendGoal(goal);
+    do
+    {
+      client_->waitForResult(ros::Duration(5.0));
+      ROS_INFO("Current State: %s", client_->getState().toString().c_str());
+    } while (client_->getState() != actionlib::SimpleClientGoalState::SUCCEEDED &&
+             client_->getState() != actionlib::SimpleClientGoalState::ABORTED);
+    return (true); /**< TODO implement a timeout, cancels action and with returns false*/
+  };
+
+private:
+  RobotJointValuesClient* client_;
+  ros::NodeHandle nh_;                 /**< node handle */
+  std::string server_name_;            /**< name of server */
+  std::vector< double > joint_values_; /**< joint values */
+};
+
+typedef actionlib::SimpleActionClient< industrial_extrinsic_cal::robot_pose_triggerAction > Robot_Pose_Client;
+
+class ROSRobotPoseActionServerTrigger : public Trigger
+{
+public:
+  /*! \brief Constructor,
+   *   @param server_name name of the service
+   *   @param pose the pose of the robot for the trigger
+   */
+  ROSRobotPoseActionServerTrigger(const std::string& server_name, const Pose6d pose)
+  {
+    server_name_ = server_name;
+    joint_values_.clear();
+    pose_.position.x = pose.x;
+    pose_.position.y = pose.y;
+    pose_.position.z = pose.z;
+    double qx, qy, qz, qw;
+    pose.getQuaternion(qx, qy, qz, qw);
+    pose_.orientation.x = qx;
+    pose_.orientation.y = qy;
+    pose_.orientation.z = qz;
+    pose_.orientation.w = qw;
+    client_ = new Robot_Pose_Client(server_name_.c_str(), true);
+  };
+
+  /*! \brief Destructor
+   */
+  ~ROSRobotPoseActionServerTrigger(){};
+
+  /*! \brief Initiates and waits for trigger to finish
+   */
+  bool waitForTrigger()
+  {
+    ROS_INFO("ROSRobotPoseActionServerTrigger: waiting for trigger server %s to complete ", server_name_.c_str());
+    client_->waitForServer();
+    industrial_extrinsic_cal::robot_pose_triggerGoal goal;
+    goal.pose = pose_;
+    client_->sendGoal(goal);
+    do
+    {
+      client_->waitForResult(ros::Duration(5.0));
+      ROS_INFO("Current State: %s", client_->getState().toString().c_str());
+    } while (client_->getState() != actionlib::SimpleClientGoalState::SUCCEEDED &&
+             client_->getState() != actionlib::SimpleClientGoalState::ABORTED);
+    return (true); /**< TODO implement a timeout, cancels action and with returns false*/
+  };
+
+private:
+  Robot_Pose_Client* client_;
+  ros::NodeHandle nh_;                 /**< node handle */
+  std::string server_name_;            /**< name of server */
+  geometry_msgs::Pose pose_;           /**< pose of robot */
+  std::vector< double > joint_values_; /**< joint values */
+};
+
+class ROSCameraObserverTrigger : public Trigger
+{
+public:
+  /*! \brief Constructor,
+   *   @param service_name name of service
+   *    @param instructions a message for the user
+   *    @param image_topic the image to use and display to user to accept the trigger
+   *    @param roi the region of interest in the image displayed to the user
+   */
+  ROSCameraObserverTrigger(const std::string& service_name, const std::string& instructions,
+                           const std::string& image_topic, const Roi& roi)
+  {
+    nh_ = new ros::NodeHandle;
+    service_name_ = service_name;
+    instructions_ = instructions;
+    image_topic_ = image_topic;
+    client_ = nh_->serviceClient< industrial_extrinsic_cal::camera_observer_trigger >(service_name_.c_str());
+    roi_ = roi;
+  };
+
+  /*! \brief Destructor
+   */
+  ~ROSCameraObserverTrigger(){};
+
+  /*! \brief Initiates and waits for trigger to finish
+   */
+  bool waitForTrigger()
+  {
+    industrial_extrinsic_cal::camera_observer_trigger::Request request;
+    industrial_extrinsic_cal::camera_observer_trigger::Response response;
+
+    ROS_INFO("ROSRobotPoseActionServerTrigger: waiting for trigger server %s to complete ", service_name_.c_str());
+    request.image_topic = image_topic_;
+    request.instructions = instructions_;
+    request.roi_min_x = roi_.x_min;
+    request.roi_max_x = roi_.x_max;
+    request.roi_min_y = roi_.y_min;
+    request.roi_max_y = roi_.y_max;
+
+    if (!client_.call(request, response))
+    {
+      ROS_ERROR("Trigger failed");
+    }
+    return (true); /**< TODO implement a timeout, cancels action and with returns false*/
+  };
+
+private:
+  ros::ServiceClient client_;         /**< the client to call supplying this trigger */
+  ros::NodeHandle* nh_;               /**< node handle */
+  std::string service_name_;          /**< name of server */
+  std::string instructions_;          /**< instructions to display to user */
+  std::string image_topic_;           /**< image from this ros topic used to find target within the given roi */
+  industrial_extrinsic_cal::Roi roi_; /**< region to find the target */
+};
+
+}  // end of namespace
 
 #endif

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/runtime_utils.h
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/runtime_utils.h
@@ -37,18 +37,15 @@ namespace industrial_extrinsic_cal
 class ROSRuntimeUtils
 {
 public:
-
   /**
    * @brief constructor
    */
-  ROSRuntimeUtils()
-  {  };
+  ROSRuntimeUtils(){};
 
   /**
    * @brief Default destructor
    */
-  ~ROSRuntimeUtils()
-  {
+  ~ROSRuntimeUtils(){
 
   };
 
@@ -57,15 +54,15 @@ public:
    * @param optimized_input
    * @return Tranform to be published/broadcasted
    */
-  tf::Transform pblockToPose(industrial_extrinsic_cal::P_BLOCK &optimized_input);
-  tf::Transform pblockToPose2(industrial_extrinsic_cal::P_BLOCK &optimized_input);
+  tf::Transform pblockToPose(industrial_extrinsic_cal::P_BLOCK& optimized_input);
+  tf::Transform pblockToPose2(industrial_extrinsic_cal::P_BLOCK& optimized_input);
   /**
    * @brief saved final calibrated transforms as launch file
    * @param package_name directory to package path
    * @param file_name name to save under package path
    * @return true if tf's successfully written to file
    */
-  bool store_tf_broadcasters(std::string &package_name, std::string &file_name);
+  bool store_tf_broadcasters(std::string& package_name, std::string& file_name);
   /**
    * @brief file containing camera definition parameters
    */
@@ -85,63 +82,61 @@ public:
   /**
    *  @brief name frame for target points
    */
-  std::vector<std::string> target_frame_;
+  std::vector< std::string > target_frame_;
   /**
    *  @brief name of camera frame in which observations were made
    */
-  std::vector<std::string> camera_optical_frame_;
+  std::vector< std::string > camera_optical_frame_;
   /**
    *  @brief name of camera frame which links camera optical frame to reference frame
    */
-  std::vector<std::string> camera_intermediate_frame_;
+  std::vector< std::string > camera_intermediate_frame_;
 
-  //CalJob specific
+  // CalJob specific
   /**
    *  @brief set of initial extrinsics of camera(s)
    */
-  std::vector<industrial_extrinsic_cal::P_BLOCK> initial_extrinsics_;
+  std::vector< industrial_extrinsic_cal::P_BLOCK > initial_extrinsics_;
   /**
    *  @brief set of calibrated extrinsics of camera(s)
    */
-  std::vector<industrial_extrinsic_cal::P_BLOCK> calibrated_extrinsics_;
+  std::vector< industrial_extrinsic_cal::P_BLOCK > calibrated_extrinsics_;
   /**
    *  @brief set of calibrated extrinsics of target(s)
    */
-  std::vector<industrial_extrinsic_cal::P_BLOCK> target_poses_;
+  std::vector< industrial_extrinsic_cal::P_BLOCK > target_poses_;
 
-
-  //TF specific
+  // TF specific
   /**
    *  @brief set of initial transform of camera(s)
    */
-  std::vector<tf::Transform> initial_transforms_;
+  std::vector< tf::Transform > initial_transforms_;
   /**
    *  @brief set of resultant calibrated transform of camera(s)
    */
-  std::vector<tf::Transform> calibrated_transforms_;
+  std::vector< tf::Transform > calibrated_transforms_;
   /**
    *  @brief set of transforms of from camera intermediate to camera optical frames
    */
-  std::vector<tf::StampedTransform> camera_internal_transforms_;
+  std::vector< tf::StampedTransform > camera_internal_transforms_;
   /**
    *  @brief set of transforms of from camera intermediate to camera optical frames
    */
-  std::vector<tf::StampedTransform> points_to_world_transforms_;
+  std::vector< tf::StampedTransform > points_to_world_transforms_;
   /**
    *  @brief set target transforms
    */
-  std::vector<tf::Transform> target_transforms_;
+  std::vector< tf::Transform > target_transforms_;
   /**
    *  @brief set of broadcasters for transform of camera(s) and target(s)
    */
-  std::vector<tf::TransformBroadcaster> broadcasters_;
+  std::vector< tf::TransformBroadcaster > broadcasters_;
   /**
    *  @brief set of listeners for transform from camera intermediate to camera optical frames
    */
   tf::TransformListener listener_;
-
 };
 
-} //end industrial_extrinsic_cal namespace
+}  // end industrial_extrinsic_cal namespace
 
 #endif /* RUNTIME_UTILS_H_ */

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/target.h
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/target.h
@@ -20,60 +20,60 @@
 #define TARGET_H_
 
 #include <industrial_extrinsic_cal/basic_types.h> /* Pose6d,Roi,Observation,CameraObservations */
-#include <industrial_extrinsic_cal/transform_interface.hpp> 
+#include <industrial_extrinsic_cal/transform_interface.hpp>
 namespace industrial_extrinsic_cal
 {
-  /*! \brief A target's information */
-  class Target
-  {
-  public:
+/*! \brief A target's information */
+class Target
+{
+public:
   /*! \brief constructor*/
-    Target(){};
+  Target(){};
 
   /*! \brief destructor*/
-    ~Target(){};
+  ~Target(){};
 
-    /*! \brief sends pose_ to the transform interface*/
-    void pushTransform();
+  /*! \brief sends pose_ to the transform interface*/
+  void pushTransform();
 
-    /*! \brief gets pose_ from the transform interface*/
-    void pullTransform();
+  /*! \brief gets pose_ from the transform interface*/
+  void pullTransform();
 
-    /*! \brief sets the transform interface */
-    void setTransformInterface(boost::shared_ptr<TransformInterface> tranform_interface);
+  /*! \brief sets the transform interface */
+  void setTransformInterface(boost::shared_ptr< TransformInterface > tranform_interface);
 
-    /*! \brief gets the transform interface, why we have this for a public member, I don't know*/
-    boost::shared_ptr<TransformInterface> getTransformInterface();
+  /*! \brief gets the transform interface, why we have this for a public member, I don't know*/
+  boost::shared_ptr< TransformInterface > getTransformInterface();
 
-    /*! \brief sets the transform interface, reference frame*/
-    void setTIReferenceFrame(std::string ref_frame);
-  
-    // TODO make these each a derived class of a base target class
-    union
-    {
-      CheckerBoardParameters checker_board_parameters_;
-      CircleGridParameters circle_grid_parameters_;
-      ARTargetParameters ar_target_parameters_;
-    };
+  /*! \brief sets the transform interface, reference frame*/
+  void setTIReferenceFrame(std::string ref_frame);
 
-    // TODO make many of these private with interfaces
-    Pose6d pose_;		/**< pose of target */
-    unsigned int num_points_;	/**< number of points in the point array */
-    std::vector<Point3d> pts_;	/**< an array of points expressed relative to Pose p. */
-    bool is_moving_;		/**< observed in multiple locations or it fixed to ref frame */
-    std::string target_name_;	/**< Name of target */
-    std::string target_frame_;	/**< name of target's coordinate frame */
-    unsigned int target_type_;	/**< Type of target */
-    boost::shared_ptr<TransformInterface>  transform_interface_; /**< interface to transform */
-
-  private:
-  } ;
-  /*! \brief moving  need a new pose with each scene in which they are used */
-  typedef struct MovingTarget
+  // TODO make these each a derived class of a base target class
+  union
   {
-    boost::shared_ptr<Target> targ_; // must hold a copy of the target pose parameters,
-    int scene_id_; // but point parameters may be unused duplicates
-  } MovingTarget;
+    CheckerBoardParameters checker_board_parameters_;
+    CircleGridParameters circle_grid_parameters_;
+    ARTargetParameters ar_target_parameters_;
+  };
 
-}// end of namespace
+  // TODO make many of these private with interfaces
+  Pose6d pose_;                /**< pose of target */
+  unsigned int num_points_;    /**< number of points in the point array */
+  std::vector< Point3d > pts_; /**< an array of points expressed relative to Pose p. */
+  bool is_moving_;             /**< observed in multiple locations or it fixed to ref frame */
+  std::string target_name_;    /**< Name of target */
+  std::string target_frame_;   /**< name of target's coordinate frame */
+  unsigned int target_type_;   /**< Type of target */
+  boost::shared_ptr< TransformInterface > transform_interface_; /**< interface to transform */
+
+private:
+};
+/*! \brief moving  need a new pose with each scene in which they are used */
+typedef struct MovingTarget
+{
+  boost::shared_ptr< Target > targ_;  // must hold a copy of the target pose parameters,
+  int scene_id_;                      // but point parameters may be unused duplicates
+} MovingTarget;
+
+}  // end of namespace
 #endif

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/targets_yaml_parser.h
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/targets_yaml_parser.h
@@ -7,18 +7,19 @@
 #include <industrial_extrinsic_cal/basic_types.h>
 #include <industrial_extrinsic_cal/target.h>
 
-namespace industrial_extrinsic_cal {
-  // prototypes
-  /** @brief parse targets from a yaml file
-   *    @param target_input_file the stream from which to parse the targets
-   *    @param targets vector of shared pointers to targets parsed
-   *    @return true if successful
-   */
-  bool parseTargets(std::string &targets_input_file, std::vector<boost::shared_ptr<Target> > & targets);
-  /** @brief parse a single target
-   *    @param node, the yaml node from which to parse the target
-   */
-  boost::shared_ptr<Target> parseSingleTarget(const YAML::Node &node);
-}// end industrial_extrinsic_cal namespace
+namespace industrial_extrinsic_cal
+{
+// prototypes
+/** @brief parse targets from a yaml file
+ *    @param target_input_file the stream from which to parse the targets
+ *    @param targets vector of shared pointers to targets parsed
+ *    @return true if successful
+ */
+bool parseTargets(std::string& targets_input_file, std::vector< boost::shared_ptr< Target > >& targets);
+/** @brief parse a single target
+ *    @param node, the yaml node from which to parse the target
+ */
+boost::shared_ptr< Target > parseSingleTarget(const YAML::Node& node);
+}  // end industrial_extrinsic_cal namespace
 
 #endif

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/transform_interface.hpp
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/transform_interface.hpp
@@ -23,102 +23,120 @@
 #include <ros/ros.h>
 namespace industrial_extrinsic_cal
 {
+class TransformInterface
+{
+public:
+  /** @brief Default destructor */
+  virtual ~TransformInterface(){};
 
-  class TransformInterface
+  /** @brief push the transform to the hardware or display
+   *   @return true if successful, false if not
+   */
+  virtual bool pushTransform(Pose6d& pose) = 0;
+
+  /** @brief get the transform from the hardware or display */
+  virtual Pose6d pullTransform() = 0;
+
+  /** @brief output the results to a file
+   *   @param filePath full pathname of file to store resutlts in
+   */
+  virtual bool store(std::string& filePath) = 0;
+
+  /** @brief get the transform reference frame of transform
+   *   @param ref_frame the reference frame name
+  */
+  virtual void setReferenceFrame(std::string& ref_frame) = 0;
+
+  /** @brief set the transform reference frame of transform */
+  std::string getReferenceFrame()
   {
-  public:
-    /** @brief Default destructor */
-    virtual ~TransformInterface(){} ;
-
-    /** @brief push the transform to the hardware or display 
-     *   @return true if successful, false if not
-     */
-    virtual bool pushTransform(Pose6d & pose)=0;
-
-    /** @brief get the transform from the hardware or display */
-    virtual Pose6d pullTransform()=0;
-
-    /** @brief output the results to a file 
-     *   @param filePath full pathname of file to store resutlts in
-     */
-    virtual bool store(std::string & filePath)=0;
-
-    /** @brief get the transform reference frame of transform  
-     *   @param ref_frame the reference frame name
-    */
-    virtual void setReferenceFrame(std::string &ref_frame) =0;
-
-    /** @brief set the transform reference frame of transform */
-    std::string getReferenceFrame() { return(ref_frame_);};
-
-    /** @brief set the transform reference frame of transform 
-     *   @param transform_frame the transform frame name
-     */
-    void setTransformFrame(std::string & transform_frame) { transform_frame_ = transform_frame;};
-
-    /** @brief set the transform reference frame of transform 
-     *    @return the transform frame name
-     */
-    std::string getTransformFrame() { return(transform_frame_);};
-
-    /** @brief get an intermediate pose of a transform by name
-     *    @param name of desired transform 
-     *    @return the pose
-     */
-    virtual Pose6d getIntermediateFrame() { 
-      Pose6d Identity;// default constructor is all zero's for translation and anlge axis. 
-      return(Identity);
-      };
-
-    /** @brief  checks to see if the reference frame has been initialized */
-    bool isRefFrameInitialized(){ 
-      return(ref_frame_initialized_);
-    }
-  protected:
-    std::string ref_frame_; /*!< name of reference frame for transform (parent frame_id in  Rviz) */
-    std::string transform_frame_; /*!< name of frame being defined (frame_id in Rviz) */
-    bool ref_frame_initialized_;/*!< can't interact with a transform interface until the reference frame is set */
-
+    return (ref_frame_);
   };
 
-
-  class DefaultTransformInterface: public TransformInterface
+  /** @brief set the transform reference frame of transform
+   *   @param transform_frame the transform frame name
+   */
+  void setTransformFrame(std::string& transform_frame)
   {
-  public:
+    transform_frame_ = transform_frame;
+  };
 
-    /** @brief  constructor 
-     *   @param pose the pose associated with the transform interface
-     */
-    DefaultTransformInterface(){};
+  /** @brief set the transform reference frame of transform
+   *    @return the transform frame name
+   */
+  std::string getTransformFrame()
+  {
+    return (transform_frame_);
+  };
 
-    /** @brief  destructor */
-    ~DefaultTransformInterface(){} ;
+  /** @brief get an intermediate pose of a transform by name
+   *    @param name of desired transform
+   *    @return the pose
+   */
+  virtual Pose6d getIntermediateFrame()
+  {
+    Pose6d Identity;  // default constructor is all zero's for translation and anlge axis.
+    return (Identity);
+  };
 
-    /** @brief push the transform to the hardware or display 
-     *   @param pose the pose associated with the transform interface
-     */
-    bool pushTransform(Pose6d & pose){ pose_ = pose;};
+  /** @brief  checks to see if the reference frame has been initialized */
+  bool isRefFrameInitialized()
+  {
+    return (ref_frame_initialized_);
+  }
 
-    /** @brief get the transform from the hardware or display 
-     *    @return the pose
-     */
-    Pose6d pullTransform(){ return(pose_);};
+protected:
+  std::string ref_frame_;       /*!< name of reference frame for transform (parent frame_id in  Rviz) */
+  std::string transform_frame_; /*!< name of frame being defined (frame_id in Rviz) */
+  bool ref_frame_initialized_;  /*!< can't interact with a transform interface until the reference frame is set */
+};
 
-    /** @brief typically outputs the results to a file, but here does nothing 
-     *    @param the file path name, a dummy argument in this case
-     *    @return   always true
-     */
-    bool store(std::string &filePath){ return(true);}; 
+class DefaultTransformInterface : public TransformInterface
+{
+public:
+  /** @brief  constructor
+   *   @param pose the pose associated with the transform interface
+   */
+  DefaultTransformInterface(){};
 
-    /** @brief sets the reference frame of the transform interface, sometimes not used */
-    void setReferenceFrame(std::string &ref_frame) {
-      ref_frame_ = ref_frame;
-      ref_frame_initialized_ = true;
-    }
+  /** @brief  destructor */
+  ~DefaultTransformInterface(){};
 
-  protected:
-    Pose6d pose_; /*!< 6dof pose  */
-  };// end of default tranform interface
+  /** @brief push the transform to the hardware or display
+   *   @param pose the pose associated with the transform interface
+   */
+  bool pushTransform(Pose6d& pose)
+  {
+    pose_ = pose;
+  };
 
-} // end of namespace
+  /** @brief get the transform from the hardware or display
+   *    @return the pose
+   */
+  Pose6d pullTransform()
+  {
+    return (pose_);
+  };
+
+  /** @brief typically outputs the results to a file, but here does nothing
+   *    @param the file path name, a dummy argument in this case
+   *    @return   always true
+   */
+  bool store(std::string& filePath)
+  {
+    return (true);
+  };
+
+  /** @brief sets the reference frame of the transform interface, sometimes not used */
+  void setReferenceFrame(std::string& ref_frame)
+  {
+    ref_frame_ = ref_frame;
+    ref_frame_initialized_ = true;
+  }
+
+protected:
+  Pose6d pose_; /*!< 6dof pose  */
+};              // end of default tranform interface
+
+}  // end of namespace
 #endif

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/trigger.h
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/trigger.h
@@ -21,30 +21,31 @@
 
 namespace industrial_extrinsic_cal
 {
-
 /*! @brief what kind of trigger initiates the collection of data for this scene */
 class Trigger
 { /** Trigger */
- public:
-    /*! \brief Constructor,
-     */
-  Trigger() { };
+public:
+  /*! \brief Constructor,
+   */
+  Trigger(){};
 
-    /*! \brief Destructor
-     */
+  /*! \brief Destructor
+   */
   virtual ~Trigger(){};
 
-    /*! \brief Initiates and waits for trigger to finish
-     */
-    virtual bool waitForTrigger()=0;
-
-} ;
-
- class NoWaitTrigger: public Trigger
-{
-  bool waitForTrigger(){return(true);}; // don't wait
+  /*! \brief Initiates and waits for trigger to finish
+   */
+  virtual bool waitForTrigger() = 0;
 };
 
-}// end of namespace
+class NoWaitTrigger : public Trigger
+{
+  bool waitForTrigger()
+  {
+    return (true);
+  };  // don't wait
+};
 
-#endif 
+}  // end of namespace
+
+#endif

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/yaml_utils.h
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/yaml_utils.h
@@ -9,97 +9,105 @@
 #include <industrial_extrinsic_cal/transform_interface.hpp>
 #include <industrial_extrinsic_cal/trigger.h>
 
-namespace industrial_extrinsic_cal 
+namespace industrial_extrinsic_cal
 {
 #define YAML_ITERATOR YAML::const_iterator
-  
-  inline bool parseDouble(const YAML::Node &node, char const * var_name, double &var_value)
-  {
-    if(node[var_name]){
-      var_value = node[var_name].as<double> ();
-      return true;
-    }
-    return false;
-  }
 
-  inline bool parseInt(const YAML::Node &node, char const * var_name, int &var_value)
+inline bool parseDouble(const YAML::Node& node, char const* var_name, double& var_value)
+{
+  if (node[var_name])
   {
-    if(node[var_name]){
-      var_value = node[var_name].as<int> ();
-      return true;
-    }
-    return false;
+    var_value = node[var_name].as< double >();
+    return true;
   }
-  inline bool parseUInt(const YAML::Node &node, char const * var_name, unsigned int &var_value)
-  {
-    if(node[var_name]){
-      var_value = node[var_name].as<unsigned int> ();
-      return true;
-    }
-    return false;
-  }
+  return false;
+}
 
-  inline bool parseString(const YAML::Node &node, char const * var_name, std::string &var_value)
+inline bool parseInt(const YAML::Node& node, char const* var_name, int& var_value)
+{
+  if (node[var_name])
   {
-    if(node[var_name]){
-      var_value = node[var_name].as<std::string> ();
-      return true;
-    }
-    return false;
+    var_value = node[var_name].as< int >();
+    return true;
   }
+  return false;
+}
+inline bool parseUInt(const YAML::Node& node, char const* var_name, unsigned int& var_value)
+{
+  if (node[var_name])
+  {
+    var_value = node[var_name].as< unsigned int >();
+    return true;
+  }
+  return false;
+}
 
-  inline bool parseBool(const YAML::Node &node, char const * var_name, bool &var_value)
+inline bool parseString(const YAML::Node& node, char const* var_name, std::string& var_value)
+{
+  if (node[var_name])
   {
-    if(node[var_name]){
-      var_value = node[var_name];
-      return true;
-    }
-    return false;
+    var_value = node[var_name].as< std::string >();
+    return true;
   }
+  return false;
+}
 
-  inline bool parseVectorD(const YAML::Node &node, char const * var_name, std::vector<double> &var_value)
+inline bool parseBool(const YAML::Node& node, char const* var_name, bool& var_value)
+{
+  if (node[var_name])
   {
-    if(node[var_name]){
-      var_value.clear();
-      const YAML::Node n = node[var_name];
-      for(int i=0; i<(int) n.size(); i++){
-	double value;
-	value = n[i].as<double> ();
-	var_value.push_back(value);
-      }
-      return true;
-    }
-    return false;
+    var_value = node[var_name];
+    return true;
   }
+  return false;
+}
 
-  inline const YAML::Node  parseNode(const YAML::Node &node, char const * var_name)
+inline bool parseVectorD(const YAML::Node& node, char const* var_name, std::vector< double >& var_value)
+{
+  if (node[var_name])
   {
-    if(!node[var_name]){
-      ROS_ERROR("Can't parse node[%s]", var_name);
-    }
-    return(node[var_name]);
-  }
-  inline void parseKeyDValue(YAML::const_iterator &it, std::string &key, double &dvalue)
+    var_value.clear();
+    const YAML::Node n = node[var_name];
+    for (int i = 0; i < (int)n.size(); i++)
     {
-      key = it->first.as<std::string>();
-      dvalue = it->second.as<double>();
+      double value;
+      value = n[i].as< double >();
+      var_value.push_back(value);
     }
+    return true;
+  }
+  return false;
+}
 
-  inline bool yamlNodeFromFileName(std::string filename, YAML::Node & ynode)
-    {
-      bool rtn = true;
-      try
-	{
-	  ynode = YAML::LoadFile(filename.c_str());
-	}
-      catch( int e)
-	{
-	  ROS_ERROR("could not open %s in yamlNodeFromFileName()", filename.c_str());
-	  rtn= false;
-	}
-      return (rtn);
-    }
+inline const YAML::Node parseNode(const YAML::Node& node, char const* var_name)
+{
+  if (!node[var_name])
+  {
+    ROS_ERROR("Can't parse node[%s]", var_name);
+  }
+  return (node[var_name]);
+}
+inline void parseKeyDValue(YAML::const_iterator& it, std::string& key, double& dvalue)
+{
+  key = it->first.as< std::string >();
+  dvalue = it->second.as< double >();
+}
 
-} //end namespace
+inline bool yamlNodeFromFileName(std::string filename, YAML::Node& ynode)
+{
+  bool rtn = true;
+  try
+  {
+    ynode = YAML::LoadFile(filename.c_str());
+  }
+  catch (int e)
+  {
+    ROS_ERROR("could not open %s in yamlNodeFromFileName()", filename.c_str());
+    rtn = false;
+  }
+  return (rtn);
+}
+
+}  // end namespace
 
 #endif

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/yaml_utils_hydro.h
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/yaml_utils_hydro.h
@@ -10,104 +10,111 @@
 #include <industrial_extrinsic_cal/transform_interface.hpp>
 #include <industrial_extrinsic_cal/trigger.h>
 
-namespace industrial_extrinsic_cal 
+namespace industrial_extrinsic_cal
 {
-
 #define YAML_ITERATOR YAML::Iterator
-  
-  inline bool parseDouble(const YAML::Node &node, char const * var_name, double &var_value)
-  {
-    if(node.FindValue(var_name)){
-      node[var_name] >> var_value;
-      return true;
-    }
-    return false;
-  }
 
-  inline bool parseInt(const YAML::Node &node, char const * var_name, int &var_value)
+inline bool parseDouble(const YAML::Node& node, char const* var_name, double& var_value)
+{
+  if (node.FindValue(var_name))
   {
-    if(node.FindValue(var_name)){
-      node[var_name] >> var_value;
-      return true;
-    }
-    return false;
+    node[var_name] >> var_value;
+    return true;
   }
-  inline bool parseUInt(const YAML::Node &node, char const * var_name, unsigned int &var_value)
+  return false;
+}
+
+inline bool parseInt(const YAML::Node& node, char const* var_name, int& var_value)
+{
+  if (node.FindValue(var_name))
   {
-    if(node.FindValue(var_name)){
-      node[var_name] >> var_value;
-      return true;
-    }
-    return false;
+    node[var_name] >> var_value;
+    return true;
   }
-
-  inline bool parseString(const YAML::Node &node, char const * var_name, std::string &var_value)
+  return false;
+}
+inline bool parseUInt(const YAML::Node& node, char const* var_name, unsigned int& var_value)
+{
+  if (node.FindValue(var_name))
   {
-    if(node.FindValue(var_name)){
-      node[var_name] >> var_value;
-      return true;
-    }
-    return false;
+    node[var_name] >> var_value;
+    return true;
   }
+  return false;
+}
 
-  inline bool parseBool(const YAML::Node &node, char const * var_name, bool &var_value)
+inline bool parseString(const YAML::Node& node, char const* var_name, std::string& var_value)
+{
+  if (node.FindValue(var_name))
   {
-    if(node.FindValue(var_name)){
-      node[var_name] >> var_value;
-      return true;
-    }
-    return false;
+    node[var_name] >> var_value;
+    return true;
   }
+  return false;
+}
 
-  inline bool parseVectorD(const YAML::Node &node, char const * var_name, std::vector<double> &var_value)
+inline bool parseBool(const YAML::Node& node, char const* var_name, bool& var_value)
+{
+  if (node.FindValue(var_name))
   {
-    if(node.FindValue(var_name)){
-      var_value.clear();
-      const YAML::Node *n = node.FindValue(var_name);
-      for(int i=0; i<(int) n->size(); i++){
-	double value;
-	(*n)[i] >> value;
-	var_value.push_back(value);
-      }
-      return true;
-    }
-    return false;
+    node[var_name] >> var_value;
+    return true;
   }
+  return false;
+}
 
-  inline const YAML::Node& parseNode(const YAML::Node &node, char const * var_name)
+inline bool parseVectorD(const YAML::Node& node, char const* var_name, std::vector< double >& var_value)
+{
+  if (node.FindValue(var_name))
   {
-    
-    if(!node.FindValue(var_name)){
-      ROS_ERROR("Can't parse node %s", var_name);
-      return(YAML::Node());
-    } 
-    return(node[var_name]);
-
-  }
-
-  inline void parseKeyDValue(YAML::Iterator &it, std::string &key, double &dvalue)
+    var_value.clear();
+    const YAML::Node* n = node.FindValue(var_name);
+    for (int i = 0; i < (int)n->size(); i++)
     {
-      it.first() >> key;
-      it.second() >> dvalue;
+      double value;
+      (*n)[i] >> value;
+      var_value.push_back(value);
     }
+    return true;
+  }
+  return false;
+}
 
-  inline bool yamlNodeFromFileName(std::string filename, YAML::Node & ynode)
-    {
-      bool rtn;
-      std::ifstream fs;
-      fs.open(filename.c_str());
-      if(fs.fail()){
-	ROS_ERROR("could not open %s in yamlNodeFromFileName()", filename.c_str());
-	rtn = false;
-      }
-      else{
-	YAML::Parser parser(fs);
-	parser.GetNextDocument(ynode);
-	rtn = true;
-      }
-      return (rtn);
-    }
+inline const YAML::Node& parseNode(const YAML::Node& node, char const* var_name)
+{
+  if (!node.FindValue(var_name))
+  {
+    ROS_ERROR("Can't parse node %s", var_name);
+    return (YAML::Node());
+  }
+  return (node[var_name]);
+}
 
-} //end namespace
+inline void parseKeyDValue(YAML::Iterator& it, std::string& key, double& dvalue)
+{
+  it.first() >> key;
+  it.second() >> dvalue;
+}
+
+inline bool yamlNodeFromFileName(std::string filename, YAML::Node& ynode)
+{
+  bool rtn;
+  std::ifstream fs;
+  fs.open(filename.c_str());
+  if (fs.fail())
+  {
+    ROS_ERROR("could not open %s in yamlNodeFromFileName()", filename.c_str());
+    rtn = false;
+  }
+  else
+  {
+    YAML::Parser parser(fs);
+    parser.GetNextDocument(ynode);
+    rtn = true;
+  }
+  return (rtn);
+}
+
+}  // end namespace
 
 #endif

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/yaml_utils_indigo.h
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/yaml_utils_indigo.h
@@ -9,97 +9,105 @@
 #include <industrial_extrinsic_cal/transform_interface.hpp>
 #include <industrial_extrinsic_cal/trigger.h>
 
-namespace industrial_extrinsic_cal 
+namespace industrial_extrinsic_cal
 {
 #define YAML_ITERATOR YAML::const_iterator
-  
-  inline bool parseDouble(const YAML::Node &node, char const * var_name, double &var_value)
-  {
-    if(node[var_name]){
-      var_value = node[var_name].as<double> ();
-      return true;
-    }
-    return false;
-  }
 
-  inline bool parseInt(const YAML::Node &node, char const * var_name, int &var_value)
+inline bool parseDouble(const YAML::Node& node, char const* var_name, double& var_value)
+{
+  if (node[var_name])
   {
-    if(node[var_name]){
-      var_value = node[var_name].as<int> ();
-      return true;
-    }
-    return false;
+    var_value = node[var_name].as< double >();
+    return true;
   }
-  inline bool parseUInt(const YAML::Node &node, char const * var_name, unsigned int &var_value)
-  {
-    if(node[var_name]){
-      var_value = node[var_name].as<unsigned int> ();
-      return true;
-    }
-    return false;
-  }
+  return false;
+}
 
-  inline bool parseString(const YAML::Node &node, char const * var_name, std::string &var_value)
+inline bool parseInt(const YAML::Node& node, char const* var_name, int& var_value)
+{
+  if (node[var_name])
   {
-    if(node[var_name]){
-      var_value = node[var_name].as<std::string> ();
-      return true;
-    }
-    return false;
+    var_value = node[var_name].as< int >();
+    return true;
   }
+  return false;
+}
+inline bool parseUInt(const YAML::Node& node, char const* var_name, unsigned int& var_value)
+{
+  if (node[var_name])
+  {
+    var_value = node[var_name].as< unsigned int >();
+    return true;
+  }
+  return false;
+}
 
-  inline bool parseBool(const YAML::Node &node, char const * var_name, bool &var_value)
+inline bool parseString(const YAML::Node& node, char const* var_name, std::string& var_value)
+{
+  if (node[var_name])
   {
-    if(node[var_name]){
-      var_value = node[var_name];
-      return true;
-    }
-    return false;
+    var_value = node[var_name].as< std::string >();
+    return true;
   }
+  return false;
+}
 
-  inline bool parseVectorD(const YAML::Node &node, char const * var_name, std::vector<double> &var_value)
+inline bool parseBool(const YAML::Node& node, char const* var_name, bool& var_value)
+{
+  if (node[var_name])
   {
-    if(node[var_name]){
-      var_value.clear();
-      const YAML::Node n = node[var_name];
-      for(int i=0; i<(int) n.size(); i++){
-	double value;
-	value = n[i].as<double> ();
-	var_value.push_back(value);
-      }
-      return true;
-    }
-    return false;
+    var_value = node[var_name];
+    return true;
   }
+  return false;
+}
 
-  inline const YAML::Node  parseNode(const YAML::Node &node, char const * var_name)
+inline bool parseVectorD(const YAML::Node& node, char const* var_name, std::vector< double >& var_value)
+{
+  if (node[var_name])
   {
-    if(!node[var_name]){
-      ROS_ERROR("Can't parse node[%s]", var_name);
-    }
-    return(node[var_name]);
-  }
-  inline void parseKeyDValue(YAML::const_iterator &it, std::string &key, double &dvalue)
+    var_value.clear();
+    const YAML::Node n = node[var_name];
+    for (int i = 0; i < (int)n.size(); i++)
     {
-      key = it->first.as<std::string>();
-      dvalue = it->second.as<double>();
+      double value;
+      value = n[i].as< double >();
+      var_value.push_back(value);
     }
+    return true;
+  }
+  return false;
+}
 
-  inline bool yamlNodeFromFileName(std::string filename, YAML::Node & ynode)
-    {
-      bool rtn = true;
-      try
-	{
-	  ynode = YAML::LoadFile(filename.c_str());
-	}
-      catch( int e)
-	{
-	  ROS_ERROR("could not open %s in yamlNodeFromFileName()", filename.c_str());
-	  rtn= false;
-	}
-      return (rtn);
-    }
+inline const YAML::Node parseNode(const YAML::Node& node, char const* var_name)
+{
+  if (!node[var_name])
+  {
+    ROS_ERROR("Can't parse node[%s]", var_name);
+  }
+  return (node[var_name]);
+}
+inline void parseKeyDValue(YAML::const_iterator& it, std::string& key, double& dvalue)
+{
+  key = it->first.as< std::string >();
+  dvalue = it->second.as< double >();
+}
 
-} //end namespace
+inline bool yamlNodeFromFileName(std::string filename, YAML::Node& ynode)
+{
+  bool rtn = true;
+  try
+  {
+    ynode = YAML::LoadFile(filename.c_str());
+  }
+  catch (int e)
+  {
+    ROS_ERROR("could not open %s in yamlNodeFromFileName()", filename.c_str());
+    rtn = false;
+  }
+  return (rtn);
+}
+
+}  // end namespace
 
 #endif

--- a/industrial_extrinsic_cal/src/basic_types.cpp
+++ b/industrial_extrinsic_cal/src/basic_types.cpp
@@ -20,215 +20,240 @@
 
 namespace industrial_extrinsic_cal
 {
-  
-  Pose6d::Pose6d(double tx, double ty, double tz, double aax, double aay, double aaz)
-  {
-    x = tx;
-    y = ty;
-    z = tz;
-    ax = aax;
-    ay = aay;
-    az = aaz;
-  }
-  Pose6d::Pose6d()
-  {
-    x=y=z=ax=ay=az=0.0;
-  }
-  void Pose6d::setBasis( tf::Matrix3x3 & m)
-  { 
-    double R[9];
-    R[0] = m[0][0];     R[1] = m[1][0];    R[2] = m[2][0];
-    R[3] = m[0][1];     R[4] = m[1][1];    R[5] = m[2][1];
-    R[6] = m[0][2];     R[7] = m[1][2];    R[8] = m[2][2];
-    double angle_axis[3];
-    ceres::RotationMatrixToAngleAxis(R, angle_axis);
-    ax = angle_axis[0];
-    ay = angle_axis[1];
-    az = angle_axis[2];
-  }
-  
-  void Pose6d::setOrigin(tf::Vector3 & v)
-  {
-    x = v.m_floats[0];
-    y = v.m_floats[1];
-    z = v.m_floats[2];
-  }
-  
-  void Pose6d::setOrigin(double tx, double ty, double tz)
-  {
-    x = tx;
-    y = ty;
-    z = tz;
-  }
-  
-  void Pose6d::setEulerZYX(double ez, double ey, double ex)
-  {
-    double ci = cos(ex);
-    double cj = cos(ey);
-    double ch = cos(ez);
-    double si = sin(ex);
-    double sj = sin(ey);
-    double sh = sin(ez);
-    double cc = ci*ch;
-    double cs = ci*sh;
-    double sc = si*ch;
-    double ss = si*sh;
+Pose6d::Pose6d(double tx, double ty, double tz, double aax, double aay, double aaz)
+{
+  x = tx;
+  y = ty;
+  z = tz;
+  ax = aax;
+  ay = aay;
+  az = aaz;
+}
+Pose6d::Pose6d()
+{
+  x = y = z = ax = ay = az = 0.0;
+}
+void Pose6d::setBasis(tf::Matrix3x3& m)
+{
+  double R[9];
+  R[0] = m[0][0];
+  R[1] = m[1][0];
+  R[2] = m[2][0];
+  R[3] = m[0][1];
+  R[4] = m[1][1];
+  R[5] = m[2][1];
+  R[6] = m[0][2];
+  R[7] = m[1][2];
+  R[8] = m[2][2];
+  double angle_axis[3];
+  ceres::RotationMatrixToAngleAxis(R, angle_axis);
+  ax = angle_axis[0];
+  ay = angle_axis[1];
+  az = angle_axis[2];
+}
 
-    tf::Matrix3x3 m;
-    m[0][0] = cj*ch;  m[0][1] = sj*sc - cs;     m[0][2] = sj*cc + ss;
-    m[1][0] = cj*sh;  m[1][1] = sj*ss + cc;   m[1][2] = sj*cs - sc;
-    m[2][0] = -sj;      m[2][1] = cj*si;           m[2][2] =cj*ci ;
-    
-    setBasis(m);
-  }
-  
-  void Pose6d::setQuaternion(double qx, double qy, double qz, double qw)
-  {
-    double angle = 2.0 * acos(qw);
-    ax = qx / sqrt(1-qw*qw)*angle;
-    ay = qy / sqrt(1-qw*qw)*angle;
-    az = qz / sqrt(1-qw*qw)*angle;
-  }
+void Pose6d::setOrigin(tf::Vector3& v)
+{
+  x = v.m_floats[0];
+  y = v.m_floats[1];
+  z = v.m_floats[2];
+}
 
-  void Pose6d::setAngleAxis(double aax, double aay, double aaz)
-  {
-    ax = aax;
-    ay = aay;
-    az = aaz;
-  }
+void Pose6d::setOrigin(double tx, double ty, double tz)
+{
+  x = tx;
+  y = ty;
+  z = tz;
+}
 
-  tf::Matrix3x3 Pose6d::getBasis() const
+void Pose6d::setEulerZYX(double ez, double ey, double ex)
+{
+  double ci = cos(ex);
+  double cj = cos(ey);
+  double ch = cos(ez);
+  double si = sin(ex);
+  double sj = sin(ey);
+  double sh = sin(ez);
+  double cc = ci * ch;
+  double cs = ci * sh;
+  double sc = si * ch;
+  double ss = si * sh;
+
+  tf::Matrix3x3 m;
+  m[0][0] = cj * ch;
+  m[0][1] = sj * sc - cs;
+  m[0][2] = sj * cc + ss;
+  m[1][0] = cj * sh;
+  m[1][1] = sj * ss + cc;
+  m[1][2] = sj * cs - sc;
+  m[2][0] = -sj;
+  m[2][1] = cj * si;
+  m[2][2] = cj * ci;
+
+  setBasis(m);
+}
+
+void Pose6d::setQuaternion(double qx, double qy, double qz, double qw)
+{
+  double angle = 2.0 * acos(qw);
+  ax = qx / sqrt(1 - qw * qw) * angle;
+  ay = qy / sqrt(1 - qw * qw) * angle;
+  az = qz / sqrt(1 - qw * qw) * angle;
+}
+
+void Pose6d::setAngleAxis(double aax, double aay, double aaz)
+{
+  ax = aax;
+  ay = aay;
+  az = aaz;
+}
+
+tf::Matrix3x3 Pose6d::getBasis() const
+{
+  tf::Matrix3x3 R;
+  double angle = sqrt(ax * ax + ay * ay + az * az);
+  if (angle < .0001)
   {
-    tf::Matrix3x3 R;
-    double angle = sqrt(ax*ax + ay*ay + az*az);
-    if(angle < .0001){
-      R[0][0] = 1.0;  R[0][1] = 0.0;  R[0][2] = 0.0;
-      R[1][0] = 0.0;  R[1][1] = 1.0;  R[1][2] = 0.0;
-      R[2][0] = 0.0;  R[2][1] = 0.0;  R[2][2] = 1.0;
-      return(R);
+    R[0][0] = 1.0;
+    R[0][1] = 0.0;
+    R[0][2] = 0.0;
+    R[1][0] = 0.0;
+    R[1][1] = 1.0;
+    R[1][2] = 0.0;
+    R[2][0] = 0.0;
+    R[2][1] = 0.0;
+    R[2][2] = 1.0;
+    return (R);
+  }
+  double cos_theta = cos(angle);
+  double sin_theta = sin(angle);
+  double wx = ax / angle;
+  double wy = ay / angle;
+  double wz = az / angle;
+  double omct = 1.0 - cos_theta;
+  R[0][0] = cos_theta + wx * wx * omct;
+  R[0][1] = wx * wy * omct - wz * sin_theta;
+  R[0][2] = wx * wz * omct + wy * sin_theta;
+  R[1][0] = wy * wx * omct + wz * sin_theta;
+  R[1][1] = cos_theta + wy * wy * omct;
+  R[1][2] = wy * wz * omct - wx * sin_theta;
+  R[2][0] = wz * wx * omct - wy * sin_theta;
+  R[2][1] = wz * wy * omct + wx * sin_theta;
+  R[2][2] = cos_theta + wz * wz * omct;
+  return (R);
+}
+
+tf::Vector3 Pose6d::getOrigin() const
+{
+  tf::Vector3 V(x, y, z);
+  return (V);
+}
+
+void Pose6d::getEulerZYX(double& ez, double& ey, double& ex) const
+{
+  double PI = 4 * atan(1);
+  double theta;
+  double psi;
+  double phi;
+  tf::Matrix3x3 R = this->getBasis();
+
+  if (fabs(R[2][0]) != 1.0)
+  {  // cos(theta) = 0.0
+    theta = -asin(R[2][0]);
+    double cos_theta = cos(theta);
+    psi = atan2(R[2][1] / cos_theta, R[2][2] / cos_theta);
+    phi = atan2(R[1][0] / cos_theta, R[0][0] / cos_theta);
+  }
+  else
+  {
+    phi = 0.0;  // could be anything
+    if (R[2][0] == -1.0)
+    {
+      theta = PI / 2.0;
+      psi = phi + atan2(R[0][1], R[0][2]);
     }
-    double cos_theta = cos(angle);
-    double sin_theta = sin(angle);
-    double wx = ax/angle;
-    double wy = ay/angle;
-    double wz = az/angle;
-    double omct = 1.0 - cos_theta;
-    R[0][0] = cos_theta + wx*wx*omct;        R[0][1] = wx*wy*omct - wz*sin_theta;      R[0][2] = wx*wz*omct + wy*sin_theta; 
-    R[1][0] = wy*wx*omct + wz*sin_theta;   R[1][1] =  cos_theta+wy*wy*omct;          R[1][2] = wy*wz*omct - wx*sin_theta;  
-    R[2][0] = wz*wx*omct - wy*sin_theta;     R[2][1] =  wz*wy*omct + wx*sin_theta;   R[2][2] = cos_theta + wz*wz*omct;     
-    return(R);
-  }
-
-  tf::Vector3 Pose6d::getOrigin() const
-  {
-    tf::Vector3 V(x, y, z);
-    return(V);
-  }
-  
-  void Pose6d::getEulerZYX(double &ez, double &ey, double &ex) const
-  {
-    double PI = 4*atan(1);
-    double theta;
-    double psi;
-    double phi;
-    tf::Matrix3x3 R = this->getBasis();
-    
-    if( fabs(R[2][0]) != 1.0 ){ // cos(theta) = 0.0
-      theta = -asin(R[2][0]);
-      double cos_theta = cos(theta);
-      psi = atan2(R[2][1]/cos_theta, R[2][2]/cos_theta);
-      phi = atan2(R[1][0]/cos_theta,R[0][0]/cos_theta);
+    else
+    {
+      theta = -PI / 2.0;
+      psi = -phi + atan2(-R[0][1], -R[0][2]);
     }
-    else{
-      phi = 0.0; // could be anything
-      if(R[2][0] == -1.0){
-	theta = PI/2.0;
-	psi = phi + atan2(R[0][1], R[0][2]);
-      }
-      else{
-	theta = -PI/2.0;
-	psi = -phi + atan2(-R[0][1], -R[0][2]);
-       }
-    } // end of cos(theta) = 0
+  }  // end of cos(theta) = 0
 
-     // Rz(phi) * Ry(theta) * Rx(psi)
-     ez = phi;
-     ey = theta;
-     ex = psi;
-   }
-  void Pose6d::getQuaternion(double &qx,  double &qy, double &qz, double &qw) const
-  {
-    double angle_axis[3];
-    angle_axis[0] = ax;
-    angle_axis[1] = ay;
-    angle_axis[2] = az;
-    double quaternion[4];
-    ceres::AngleAxisToQuaternion(angle_axis, quaternion);
-    qw = quaternion[0];
-    qx = quaternion[1];
-    qy = quaternion[2];
-    qz = quaternion[3];
-  }
+  // Rz(phi) * Ry(theta) * Rx(psi)
+  ez = phi;
+  ey = theta;
+  ex = psi;
+}
+void Pose6d::getQuaternion(double& qx, double& qy, double& qz, double& qw) const
+{
+  double angle_axis[3];
+  angle_axis[0] = ax;
+  angle_axis[1] = ay;
+  angle_axis[2] = az;
+  double quaternion[4];
+  ceres::AngleAxisToQuaternion(angle_axis, quaternion);
+  qw = quaternion[0];
+  qx = quaternion[1];
+  qy = quaternion[2];
+  qz = quaternion[3];
+}
 
-  Pose6d Pose6d::getInverse() const
-  {
-    double newx,newy,newz;
-    tf::Matrix3x3 R = getBasis();
-    newx =-( R[0][0] * x + R[1][0] * y + R[2][0] * z);
-    newy = -(R[0][1] * x + R[1][1] * y + R[2][1] * z);
-    newz = -(R[0][2] * x + R[1][2] * y + R[2][2] * z);
-    Pose6d new_pose(newx, newy, newz, -ax, -ay, -az);
-    return(new_pose);
-  }
+Pose6d Pose6d::getInverse() const
+{
+  double newx, newy, newz;
+  tf::Matrix3x3 R = getBasis();
+  newx = -(R[0][0] * x + R[1][0] * y + R[2][0] * z);
+  newy = -(R[0][1] * x + R[1][1] * y + R[2][1] * z);
+  newz = -(R[0][2] * x + R[1][2] * y + R[2][2] * z);
+  Pose6d new_pose(newx, newy, newz, -ax, -ay, -az);
+  return (new_pose);
+}
 
-  void Pose6d::show(std::string message)
-  {
-    tf::Matrix3x3 basis = this->getBasis();
-    double ez_yaw, ey_pitch, ex_roll;
-    double qx, qy, qz, qw;
-    this->getEulerZYX(ez_yaw,ey_pitch,ex_roll);
-    this->getQuaternion(qx, qy, qz, qw);
-   printf("%s =[\n %6.3lf  %6.3lf  %6.3lf  %6.3lf\n  %6.3lf  %6.3lf  %6.3lf  %6.3lf\n  %6.3lf  %6.3lf %6.3lf  %6.3lf\n  %6.3lf  %6.3lf %6.3lf  %6.3lf];\n rpy= %6.3lf %6.3lf %6.3lf\n quat= %6.3lf  %6.3lf  %6.3lf %6.3lf\n ",
-	      message.c_str(),
-	      basis[0][0],basis[0][1], basis[0][2],this->x,
-	      basis[1][0],basis[1][1], basis[1][2],this->y,
-	      basis[2][0],basis[2][1], basis[2][2],this->z,
-	      0.0, 0.0, 0.0, 1.0,
-	      ez_yaw, ey_pitch, ex_roll,
-	      qx, qy, qz, qw);
-  }
+void Pose6d::show(std::string message)
+{
+  tf::Matrix3x3 basis = this->getBasis();
+  double ez_yaw, ey_pitch, ex_roll;
+  double qx, qy, qz, qw;
+  this->getEulerZYX(ez_yaw, ey_pitch, ex_roll);
+  this->getQuaternion(qx, qy, qz, qw);
+  printf("%s =[\n %6.3lf  %6.3lf  %6.3lf  %6.3lf\n  %6.3lf  %6.3lf  %6.3lf  %6.3lf\n  %6.3lf  %6.3lf %6.3lf  %6.3lf\n  "
+         "%6.3lf  %6.3lf %6.3lf  %6.3lf];\n rpy= %6.3lf %6.3lf %6.3lf\n quat= %6.3lf  %6.3lf  %6.3lf %6.3lf\n ",
+         message.c_str(), basis[0][0], basis[0][1], basis[0][2], this->x, basis[1][0], basis[1][1], basis[1][2],
+         this->y, basis[2][0], basis[2][1], basis[2][2], this->z, 0.0, 0.0, 0.0, 1.0, ez_yaw, ey_pitch, ex_roll, qx, qy,
+         qz, qw);
+}
 
-  Pose6d Pose6d::operator * ( Pose6d pose2) const
-  {
-    tf::Matrix3x3  R1   = getBasis();
-    tf::Matrix3x3 R2 = pose2.getBasis();
-    tf::Vector3 T1     = getOrigin();
-    tf::Vector3 T2     = pose2.getOrigin();
-    
-    tf::Matrix3x3 R3;
-    R3[0][0] = R1[0][0] * R2[0][0] + R1[0][1]*R2[1][0] + R1[0][2]*R2[2][0]; 
-    R3[1][0] = R1[1][0] * R2[0][0] + R1[1][1]*R2[1][0] + R1[1][2]*R2[2][0];
-    R3[2][0] = R1[2][0] * R2[0][0] + R1[2][1]*R2[1][0] + R1[2][2]*R2[2][0];
+Pose6d Pose6d::operator*(Pose6d pose2) const
+{
+  tf::Matrix3x3 R1 = getBasis();
+  tf::Matrix3x3 R2 = pose2.getBasis();
+  tf::Vector3 T1 = getOrigin();
+  tf::Vector3 T2 = pose2.getOrigin();
 
-    R3[0][1] = R1[0][0] * R2[0][1] + R1[0][1]*R2[1][1] + R1[0][2]*R2[2][1]; 
-    R3[1][1] = R1[1][0] * R2[0][1] + R1[1][1]*R2[1][1] + R1[1][2]*R2[2][1];
-    R3[2][1] = R1[2][0] * R2[0][1] + R1[2][1]*R2[1][1] + R1[2][2]*R2[2][1];
+  tf::Matrix3x3 R3;
+  R3[0][0] = R1[0][0] * R2[0][0] + R1[0][1] * R2[1][0] + R1[0][2] * R2[2][0];
+  R3[1][0] = R1[1][0] * R2[0][0] + R1[1][1] * R2[1][0] + R1[1][2] * R2[2][0];
+  R3[2][0] = R1[2][0] * R2[0][0] + R1[2][1] * R2[1][0] + R1[2][2] * R2[2][0];
 
-     R3[0][2] = R1[0][0] * R2[0][2] + R1[0][1]*R2[1][2] + R1[0][2]*R2[2][2]; 
-     R3[1][2] = R1[1][0] * R2[0][2] + R1[1][1]*R2[1][2] + R1[1][2]*R2[2][2];
-     R3[2][2] = R1[2][0] * R2[0][2] + R1[2][1]*R2[1][2] + R1[2][2]*R2[2][2];
+  R3[0][1] = R1[0][0] * R2[0][1] + R1[0][1] * R2[1][1] + R1[0][2] * R2[2][1];
+  R3[1][1] = R1[1][0] * R2[0][1] + R1[1][1] * R2[1][1] + R1[1][2] * R2[2][1];
+  R3[2][1] = R1[2][0] * R2[0][1] + R1[2][1] * R2[1][1] + R1[2][2] * R2[2][1];
 
-    double tempx, tempy, tempz;
-    tempx = R1[0][0] * T2.x() + R1[0][1]*T2.y() + R1[0][2]*T2.z() + T1.x();
-    tempy = R1[1][0] * T2.x() + R1[1][1]*T2.y() + R1[1][2]*T2.z() + T1.y();
-    tempz = R1[2][0] * T2.x() + R1[2][1]*T2.y() + R1[2][2]*T2.z() + T1.z();
-    tf::Vector3 T3(tempx, tempy, tempz);
+  R3[0][2] = R1[0][0] * R2[0][2] + R1[0][1] * R2[1][2] + R1[0][2] * R2[2][2];
+  R3[1][2] = R1[1][0] * R2[0][2] + R1[1][1] * R2[1][2] + R1[1][2] * R2[2][2];
+  R3[2][2] = R1[2][0] * R2[0][2] + R1[2][1] * R2[1][2] + R1[2][2] * R2[2][2];
 
-    Pose6d pose;
-    pose.setBasis(R3);
-    pose.setOrigin(T3);
+  double tempx, tempy, tempz;
+  tempx = R1[0][0] * T2.x() + R1[0][1] * T2.y() + R1[0][2] * T2.z() + T1.x();
+  tempy = R1[1][0] * T2.x() + R1[1][1] * T2.y() + R1[1][2] * T2.z() + T1.y();
+  tempz = R1[2][0] * T2.x() + R1[2][1] * T2.y() + R1[2][2] * T2.z() + T1.z();
+  tf::Vector3 T3(tempx, tempy, tempz);
 
-    return(pose);
-  }
+  Pose6d pose;
+  pose.setBasis(R3);
+  pose.setOrigin(T3);
 
-}// end of namespace
+  return (pose);
+}
+
+}  // end of namespace

--- a/industrial_extrinsic_cal/src/calibration_job_definition.cpp
+++ b/industrial_extrinsic_cal/src/calibration_job_definition.cpp
@@ -39,51 +39,54 @@ using industrial_extrinsic_cal::covariance_requests::CovarianceRequestType;
 
 namespace industrial_extrinsic_cal
 {
-  
-  /** @brief, a function used for debugging, and generating output for post processing */
-  void writeObservationData(std::string file_name, std::vector<ObservationDataPointList> odl)
+/** @brief, a function used for debugging, and generating output for post processing */
+void writeObservationData(std::string file_name, std::vector< ObservationDataPointList > odl)
 {
-  FILE *fp=NULL;
+  FILE* fp = NULL;
   fp = fopen(file_name.c_str(), "w");
-  if(fp == NULL){
+  if (fp == NULL)
+  {
     ROS_ERROR("Could not open %s", file_name.c_str());
     return;
   }
-  
-  int scene_id=-1;  
-  for(int i=0; (int) i<odl.size(); i++){
-    if(odl[i].items_.size()>0){
+
+  int scene_id = -1;
+  for (int i = 0; (int)i < odl.size(); i++)
+  {
+    if (odl[i].items_.size() > 0)
+    {
       scene_id = odl[i].items_[0].scene_id_;
       fprintf(fp, "scene_id = %d \n", scene_id);
       Pose6d t_pose;
       t_pose.ax = odl[i].items_[0].target_pose_[0];
       t_pose.ay = odl[i].items_[0].target_pose_[1];
       t_pose.az = odl[i].items_[0].target_pose_[2];
-      t_pose.x  = odl[i].items_[0].target_pose_[3];
-      t_pose.y  = odl[i].items_[0].target_pose_[4];
-      t_pose.z  = odl[i].items_[0].target_pose_[5];
+      t_pose.x = odl[i].items_[0].target_pose_[3];
+      t_pose.y = odl[i].items_[0].target_pose_[4];
+      t_pose.z = odl[i].items_[0].target_pose_[5];
       tf::Matrix3x3 basis = t_pose.getBasis();
-      fprintf(fp, "target_pose = [ %f %f %f %f;\n %f %f %f %f;\n %f %f %f %f;\n %f %f %f %f];\n",
-	      basis[0][0],basis[0][1], basis[0][2],t_pose.x,
-	      basis[1][0],basis[1][1], basis[1][2],t_pose.y,
-	      basis[2][0],basis[2][1], basis[2][2],t_pose.z,
-	      0.0, 0.0, 0.0, 1.0);
+      fprintf(fp, "target_pose = [ %f %f %f %f;\n %f %f %f %f;\n %f %f %f %f;\n %f %f %f %f];\n", basis[0][0],
+              basis[0][1], basis[0][2], t_pose.x, basis[1][0], basis[1][1], basis[1][2], t_pose.y, basis[2][0],
+              basis[2][1], basis[2][2], t_pose.z, 0.0, 0.0, 0.0, 1.0);
       fprintf(fp, "cameras = [ ");
       std::string camera_name("NULL");
-      for(int j=0; (int) j<odl[i].items_.size(); j++){
-	if(camera_name !=  odl[i].items_[j].camera_name_){
-	  fprintf(fp,"%s ", odl[i].items_[j].camera_name_.c_str());
-	}
-	camera_name =  odl[i].items_[j].camera_name_;
+      for (int j = 0; (int)j < odl[i].items_.size(); j++)
+      {
+        if (camera_name != odl[i].items_[j].camera_name_)
+        {
+          fprintf(fp, "%s ", odl[i].items_[j].camera_name_.c_str());
+        }
+        camera_name = odl[i].items_[j].camera_name_;
       }
       fprintf(fp, "]\n");
     }
   }
   fclose(fp);
-} 
-  CovarianceRequestType intToCovRequest(int request)
+}
+CovarianceRequestType intToCovRequest(int request)
+{
+  switch (request)
   {
-    switch (request){
     case 0:
       return covariance_requests::StaticCameraIntrinsicParams;
       break;
@@ -105,663 +108,565 @@ namespace industrial_extrinsic_cal
     default:
       return covariance_requests::DefaultInvalid;
       break;
-    }
-  }// end of intToCovRequestType
+  }
+}  // end of intToCovRequestType
 
-  bool CalibrationJob::load()
+bool CalibrationJob::load()
+{
+  if (!CalibrationJob::loadCamera())
   {
-    if(!CalibrationJob::loadCamera())
-      {
-	ROS_ERROR_STREAM("Camera file parsing failed");
-	return false;
-      }
-    if(!CalibrationJob::loadTarget())
-      {
-	ROS_ERROR_STREAM("Target file parsing failed");
-	return false;
-      }
-    if(!CalibrationJob::loadCalJob())
-      {
-	ROS_ERROR_STREAM("Calibration Job file parsing failed");
-	return false;
-      }
-
-    return (true);
-  } // end load()
-
-  void CalibrationJob::postProcessingOn(std::string post_proc_file_name)
+    ROS_ERROR_STREAM("Camera file parsing failed");
+    return false;
+  }
+  if (!CalibrationJob::loadTarget())
   {
-    post_proc_on_ = true;
-    post_proc_data_file_ = post_proc_file_name;
+    ROS_ERROR_STREAM("Target file parsing failed");
+    return false;
+  }
+  if (!CalibrationJob::loadCalJob())
+  {
+    ROS_ERROR_STREAM("Calibration Job file parsing failed");
+    return false;
   }
 
-  void CalibrationJob::postProcessingOff()
-  {
-    post_proc_on_ = false;
-  }
+  return (true);
+}  // end load()
 
-  bool CalibrationJob::loadCamera()
-  {
-    bool rtn=true;
-    std::vector<shared_ptr<Camera> >  all_cameras;
-    if(!parseCameras(camera_def_file_name_, all_cameras)){
-      ROS_ERROR("failed to parse cameras from %s", camera_def_file_name_.c_str());
-      rtn = false;
-    }
-    for(int i=0; i< (int) all_cameras.size(); i++){
-      if(all_cameras[i]->is_moving_) {
-	int scene_id = 0;
-	ceres_blocks_.addMovingCamera(all_cameras[i], scene_id);
-      }
-      else{
-	ceres_blocks_.addStaticCamera(all_cameras[i]);
-      }
-    }
-    return rtn;
-  }
-  
-  bool CalibrationJob::loadTarget()
-  {
-    bool rtn=true;
-    std::vector<shared_ptr<Target> >  all_targets;
-    if(!parseTargets(target_def_file_name_, all_targets)){
-      ROS_ERROR("failed to parse targets from %s", target_def_file_name_.c_str());
-      rtn = false;
-    }
-    else { // target file parses ok
-      for(int i=0; i< (int) all_targets.size(); i++){
-	if(all_targets[i]->is_moving_) {
-	  int scene_id = 0;
-	  ceres_blocks_.addMovingTarget(all_targets[i], scene_id);
-	}
-	else{
-	  ceres_blocks_.addStaticTarget(all_targets[i]);
-	}
-      }// end for every target found
-    }// end else target file parsed ok
-    return rtn;
-  }
-
-  bool CalibrationJob::loadCalJob()
-  {
-    bool rtn = true;
-    std::string reference_frame;
-    rtn = parseCaljob(caljob_def_file_name_, scene_list_, reference_frame, ceres_blocks_);
-    if(rtn) ceres_blocks_.setReferenceFrame(reference_frame);
-    return rtn;
+void CalibrationJob::postProcessingOn(std::string post_proc_file_name)
+{
+  post_proc_on_ = true;
+  post_proc_data_file_ = post_proc_file_name;
 }
 
-  bool CalibrationJob::run()
+void CalibrationJob::postProcessingOff()
+{
+  post_proc_on_ = false;
+}
+
+bool CalibrationJob::loadCamera()
+{
+  bool rtn = true;
+  std::vector< shared_ptr< Camera > > all_cameras;
+  if (!parseCameras(camera_def_file_name_, all_cameras))
   {
-    ROS_INFO("Collecting observations");
-    runObservations();
-    ROS_INFO("Running optimization");
-    solved_ = runOptimization();
-    if(solved_){
-      pushTransforms(); // sends updated transforms to their intefaces
-    }
-    else{
-      ROS_ERROR("Optimization failed");
-    }
-    return(solved_);
+    ROS_ERROR("failed to parse cameras from %s", camera_def_file_name_.c_str());
+    rtn = false;
   }
-
-  bool CalibrationJob::runObservations()
+  for (int i = 0; i < (int)all_cameras.size(); i++)
   {
-    // the result of this function are twofold
-    // First, it fills up observation_data_point_list_ with lists of observationspercamera
-    // Second it adds parameter blocks to the ceres_blocks
-    // extrinsics and intrinsics for each static camera
-    // The whole target for once every static target (parameter blocks are in  Pose6d and an array of points)
-    // The whole target once a scene for each moving target
-    observation_data_point_list_.clear(); // clear previously recorded observations
+    if (all_cameras[i]->is_moving_)
+    {
+      int scene_id = 0;
+      ceres_blocks_.addMovingCamera(all_cameras[i], scene_id);
+    }
+    else
+    {
+      ceres_blocks_.addStaticCamera(all_cameras[i]);
+    }
+  }
+  return rtn;
+}
 
-    // For each scene
-    BOOST_FOREACH(ObservationScene current_scene, scene_list_)
+bool CalibrationJob::loadTarget()
+{
+  bool rtn = true;
+  std::vector< shared_ptr< Target > > all_targets;
+  if (!parseTargets(target_def_file_name_, all_targets))
+  {
+    ROS_ERROR("failed to parse targets from %s", target_def_file_name_.c_str());
+    rtn = false;
+  }
+  else
+  {  // target file parses ok
+    for (int i = 0; i < (int)all_targets.size(); i++)
+    {
+      if (all_targets[i]->is_moving_)
       {
-	int scene_id = current_scene.get_id();
-	ROS_DEBUG_STREAM("Processing Scene " << scene_id+1<<" of "<< scene_list_.size());
-	current_scene.get_trigger()->waitForTrigger(); // this indicates scene is ready to capture
-	pullTransforms(scene_id); // gets transforms of targets and cameras from their interfaces
-	BOOST_FOREACH(shared_ptr<Camera> current_camera, current_scene.cameras_in_scene_)
-	  {			// clear camera of existing observations
-
-	    current_camera->camera_observer_->clearObservations(); // clear any recorded data
-	    current_camera->camera_observer_->clearTargets(); // clear all targets
-	  }
-	BOOST_FOREACH(ObservationCmd o_command, current_scene.observation_command_list_)
-	  {	// add each target and roi each camera's list of observations
-	    
-	    o_command.camera->camera_observer_->addTarget(o_command.target, o_command.roi, o_command.cost_type);
-	  }
-	BOOST_FOREACH( shared_ptr<Camera> current_camera, current_scene.cameras_in_scene_)
-	  {// trigger the cameras
-	    current_camera->camera_observer_->triggerCamera();
-	  }
-	// collect results
-	P_BLOCK intrinsics;
-	P_BLOCK extrinsics;
-	P_BLOCK target_pose;
-	P_BLOCK pnt_pos;
-	std::string camera_name;
-	std::string target_name;
-	unsigned int  target_type;
-	Cost_function cost_type;
-
-	// for each camera in scene get a list of observations, and add camera parameters to ceres_blocks
-	ObservationDataPointList listpercamera;
-	BOOST_FOREACH( shared_ptr<Camera> camera, current_scene.cameras_in_scene_)
-	  {
-	    // wait until observation is done
-	    while (!camera->camera_observer_->observationsDone()) ;
-	    camera_name = camera->camera_name_;
-	    if (camera->isMoving())
-	      {
-		// next line does nothing if camera already exist in blocks
-		ceres_blocks_.addMovingCamera(camera, scene_id);
-		// TODO why is there a second call to pull transforms here?
-		pullTransforms(scene_id); // gets transforms of targets and cameras from their interfaces
-		intrinsics = ceres_blocks_.getMovingCameraParameterBlockIntrinsics(camera_name);
-		extrinsics = ceres_blocks_.getMovingCameraParameterBlockExtrinsics(camera_name, scene_id);
-	      }
-	    else
-	      {
-		// next line does nothing if camera already exist in blocks
-		ceres_blocks_.addStaticCamera(camera);
-		intrinsics = ceres_blocks_.getStaticCameraParameterBlockIntrinsics(camera_name);
-		extrinsics = ceres_blocks_.getStaticCameraParameterBlockExtrinsics(camera_name);
-	      }
-	    // Get the observations from this camera whose P_BLOCKs are intrinsics and extrinsics
-	    CameraObservations camera_observations;
-	    int number_returned;
-	    number_returned = camera->getObservations(camera_observations);
-	    ROS_DEBUG_STREAM("Processing " << camera_observations.size() << " Observations");
-	    BOOST_FOREACH(Observation observation, camera_observations)
-	      {
-		target_name = observation.target->target_name_;
-		target_type = observation.target->target_type_;
-		cost_type = observation.cost_type;
-		double circle_dia=0.0;
-		if(target_type == pattern_options::CircleGrid || target_type == pattern_options::ModifiedCircleGrid){
-		  circle_dia = observation.target->circle_grid_parameters_.circle_diameter;
-		}
-		int pnt_id = observation.point_id;
-		double observation_x = observation.image_loc_x;
-		double observation_y = observation.image_loc_y;
-		if (observation.target->is_moving_)
-		  {
-		    ceres_blocks_.addMovingTarget(observation.target, scene_id);
-		    target_pose = ceres_blocks_.getMovingTargetPoseParameterBlock(target_name, scene_id);
-		    pnt_pos = ceres_blocks_.getMovingTargetPointParameterBlock(target_name, pnt_id);
-		  }
-		else
-		  {
-		    ceres_blocks_.addStaticTarget(observation.target); // if exist, does nothing
-		    target_pose = ceres_blocks_.getStaticTargetPoseParameterBlock(target_name);
-		    pnt_pos = ceres_blocks_.getStaticTargetPointParameterBlock(target_name, pnt_id);
-		  }
-		ObservationDataPoint temp_ODP(camera_name, target_name, target_type,
-					      scene_id, intrinsics, extrinsics, pnt_id, target_pose,
-					      pnt_pos, observation_x, observation_y, 
-					      cost_type, observation.intermediate_frame,
-					      circle_dia);
-		listpercamera.addObservationPoint(temp_ODP);
-	      }//end for each observed point
-	  }//end for each camera
-	observation_data_point_list_.push_back(listpercamera);
-      } //end for each scene
-    return true;
-  }
-
-  bool CalibrationJob::runOptimization()
-  {
-    if(post_proc_on_) writeObservationData(post_proc_data_file_, observation_data_point_list_);
-
-    // problem is declared here because we can't clear it as far as I can tell from the ceres documentation
-    if(problem_ != NULL) {
-      ROS_INFO("Deleting old problem.");
-      delete(problem_); 
-    }
-    problem_ = new ceres::Problem; /*!< This is the object which solves non-linear optimization problems */
-
-    total_observations_ =0;
-    for(int i=0;i<observation_data_point_list_.size();i++){
-      total_observations_ += observation_data_point_list_[i].items_.size();
-      std::stringstream observations_ss;
-      for (int pntIdx = 0; pntIdx < observation_data_point_list_[i].items_.size(); pntIdx++) {
-        const ObservationDataPoint& odp = observation_data_point_list_[i].items_[pntIdx];
-        ROS_DEBUG("%d: id=%d pos=[%f, %f, %f] img=[%f, %f]", pntIdx,
-		 odp.point_id_,
-		 odp.point_position_[0], odp.point_position_[1], odp.point_position_[2],
-		 odp.image_x_, odp.image_y_);
-        observations_ss << "[" << odp.image_x_ << ", " << odp.image_y_ << "],";
+        int scene_id = 0;
+        ceres_blocks_.addMovingTarget(all_targets[i], scene_id);
       }
-      ROS_DEBUG("project_points2d: %s", observations_ss.str().c_str());
-    }
-    if(total_observations_ == 0){ // TODO really need more than number of parameters being computed
-      ROS_ERROR("Too few observations: %d",total_observations_);
-      return(false);
-    } 
-    else{
-      ROS_INFO("total observations = %d", total_observations_);
-    }
-    
-    // TODO remove commented code     ceres_blocks_.displayMovingCameras();
-
-    // take all the data collected and create a Ceres optimization problem and run it
-    ROS_INFO("Running Optimization with %d scenes",(int)scene_list_.size());
-    ROS_DEBUG_STREAM("Optimizing "<<scene_list_.size()<<" scenes");
-    BOOST_FOREACH(ObservationScene current_scene, scene_list_)
+      else
       {
-	int scene_id = current_scene.get_id();
-	ROS_DEBUG_STREAM("Current observation data point list size: "<<observation_data_point_list_.at(scene_id).items_.size());
-	// take all the data collected and create a Ceres optimization problem and run it
-	P_BLOCK extrinsics;
-	P_BLOCK intrinsics;
-	P_BLOCK target_pose_params;
-	P_BLOCK point_position;
-	BOOST_FOREACH(ObservationDataPoint ODP, observation_data_point_list_.at(scene_id).items_)
-	  {
-	    // create cost function
-	    // there are several options
-	    // 1. the complete reprojection error cost function "Create(obs_x,obs_y)"
-	    //    this cost function has the following parameters:
-	    //      a. camera intrinsics
-	    //      b. camera extrinsics
-	    //      c. target pose
-	    //      d. point location in target frame
-	    // 2. the same as 1, but without d  "Create(obs_x,obs_y,t_pnt_x, t_pnt_y, t_pnt_z)
-	    // 3. the same as 1, but without a  "Create(obs_x,obs_y,fx,fy,cx,cy,cz)"
-	    //    Note that this one assumes we are using rectified images to compute the observations
-	    // 4. the same as 3, point location fixed too "Create(obs_x,obs_y,fx,fy,cx,cy,cz,t_x,t_y,t_z)"
-	    //        implemented in TargetCameraReprjErrorNoDistortion
-	    // 5. the same as 4, but with target in known location
-	    //    "Create(obs_x,obs_y,fx,fy,cx,cy,cz,t_x,t_y,t_z,p_tx,p_ty,p_tz,p_ax,p_ay,p_az)"
-	    // pull out the constants from the observation point data
-	    intrinsics = ODP.camera_intrinsics_;
-	    double focal_length_x = ODP.camera_intrinsics_[0]; // TODO, make this not so ugly
-	    double focal_length_y = ODP.camera_intrinsics_[1];
-	    double center_x   = ODP.camera_intrinsics_[2];
-	    double center_y   = ODP.camera_intrinsics_[3];
-	    double image_x        = ODP.image_x_;
-	    double image_y        = ODP.image_y_;
-	    Point3d point;
-	    Pose6d camera_mounting_pose = ODP.intermediate_frame_; // identity except when camera mounted on robot
-	    point.x = ODP.point_position_[0];// location of point within target frame
-	    point.y = ODP.point_position_[1];
-	    point.z = ODP.point_position_[2];
-	    unsigned int target_type    = ODP.target_type_;
-	    double circle_dia = ODP.circle_dia_; // sometimes this is not needed
+        ceres_blocks_.addStaticTarget(all_targets[i]);
+      }
+    }  // end for every target found
+  }    // end else target file parsed ok
+  return rtn;
+}
 
-	    // pull out pointers to the parameter blocks in the observation point data
-	    extrinsics        = ODP.camera_extrinsics_;
-	    target_pose_params     = ODP.target_pose_;
-	    Pose6d target_pose;
-	    target_pose.setAngleAxis(target_pose_params[0],target_pose_params[1], target_pose_params[2]);
-	    target_pose.setOrigin(target_pose_params[3],target_pose_params[4], target_pose_params[5]);
-	    point_position = ODP.point_position_;
-	    bool point_zero=false; // Set true to enable some debugging
+bool CalibrationJob::loadCalJob()
+{
+  bool rtn = true;
+  std::string reference_frame;
+  rtn = parseCaljob(caljob_def_file_name_, scene_list_, reference_frame, ceres_blocks_);
+  if (rtn) ceres_blocks_.setReferenceFrame(reference_frame);
+  return rtn;
+}
 
-	    if(0){// modify for debugging
-	      if(point.x == 0.0 && point.y == 0.0 && point.z == 0.0){
-		point_zero=true;
-		//		ROS_ERROR("Observing Target Origin");
-		//		showPose(target_pose_params, "target");
-		target_pose.show("target_pose");
-		showPose(extrinsics,"extrinsics");
-		ROS_ERROR("u,v %6.3f %6.3f",image_x, image_y);
-		//		showPose((P_BLOCK) &camera_mounting_pose.pb_pose[0], "camera_mounting_pose");
-	      }
-	    }
+bool CalibrationJob::run()
+{
+  ROS_INFO("Collecting observations");
+  runObservations();
+  ROS_INFO("Running optimization");
+  solved_ = runOptimization();
+  if (solved_)
+  {
+    pushTransforms();  // sends updated transforms to their intefaces
+  }
+  else
+  {
+    ROS_ERROR("Optimization failed");
+  }
+  return (solved_);
+}
 
-	    switch( ODP.cost_type_ ){
-	    case cost_functions::CameraReprjErrorWithDistortion:
-	      {
-		CostFunction* cost_function =
-		  CameraReprjErrorWithDistortion::Create(image_x, image_y);
-		problem_->AddResidualBlock(cost_function, NULL , extrinsics, intrinsics, point.pb);
-	      }
-	      break;
-	    case cost_functions::CameraReprjErrorWithDistortionPK:
-	      {
-		CostFunction* cost_function =
-		  CameraReprjErrorWithDistortionPK::Create(image_x, image_y, 
-							   point);
-		problem_->AddResidualBlock(cost_function, NULL , extrinsics, intrinsics);
-	      }
-	      break;
-	    case cost_functions::CameraReprjError:
-	      {
-		CostFunction* cost_function =
-		  CameraReprjError::Create(image_x, image_y, 
-					   focal_length_x, focal_length_y,
-					   center_x, center_y);
-		problem_->AddResidualBlock(cost_function, NULL , extrinsics, point.pb);
-	      }
-	      break;
-	    case cost_functions::CameraReprjErrorPK:
-	      {
-		CostFunction* cost_function =
-		  CameraReprjErrorPK::Create(image_x, image_y, 
-					     focal_length_x, focal_length_y,
-					     center_x, center_y,
-					     point);
-		problem_->AddResidualBlock(cost_function, NULL , extrinsics);
-	      }
-	      break;
-	    case cost_functions::TargetCameraReprjError:
-	      {
-		CostFunction* cost_function =
-		  TargetCameraReprjError::Create(image_x, image_y, 
-						 focal_length_x, focal_length_y,
-						 center_x, center_y);
+bool CalibrationJob::runObservations()
+{
+  // the result of this function are twofold
+  // First, it fills up observation_data_point_list_ with lists of observationspercamera
+  // Second it adds parameter blocks to the ceres_blocks
+  // extrinsics and intrinsics for each static camera
+  // The whole target for once every static target (parameter blocks are in  Pose6d and an array of points)
+  // The whole target once a scene for each moving target
+  observation_data_point_list_.clear();  // clear previously recorded observations
 
-		problem_->AddResidualBlock(cost_function, NULL , extrinsics, target_pose_params, point.pb);
-	      }
-	      break;
-	    case cost_functions::TargetCameraReprjErrorPK:
-	      {
-		CostFunction* cost_function = 
-		  TargetCameraReprjErrorPK::Create(image_x, image_y,
-						   focal_length_x,
-						   focal_length_y,
-						   center_x,
-						   center_y,
-						   point);
-		// add it as a residual using parameter blocks
-		problem_->AddResidualBlock(cost_function, NULL , extrinsics, target_pose_params);
-	      }
-	      break;
-	    case cost_functions::LinkTargetCameraReprjError:
-	      {
-		CostFunction* cost_function =
-		  LinkTargetCameraReprjError::Create(image_x, image_y, 
-						     focal_length_x,
-						     focal_length_y,
-						     center_x,
-						     center_y,
-						     camera_mounting_pose);
-		problem_->AddResidualBlock(cost_function, NULL , extrinsics, target_pose_params, point.pb);
-	      }
-	      break;
-	    case cost_functions::LinkTargetCameraReprjErrorPK:
-	      {
-		CostFunction* cost_function =
-		  LinkTargetCameraReprjErrorPK::Create(image_x, image_y, 
-						       focal_length_x,
-						       focal_length_y,
-						       center_x,
-						       center_y,
-						       camera_mounting_pose,
-						       point);
-		problem_->AddResidualBlock(cost_function, NULL , extrinsics, target_pose_params);
-	      }
-	      break;
-	    case cost_functions::PosedTargetCameraReprjErrorPK:
-	      {
-		if(point_zero){
-		  ROS_ERROR("u,v %f %f x,y,x %f %f %f", image_x, image_y, point.x, point.y, point.z);
-		}
-		CostFunction* cost_function =
-		  PosedTargetCameraReprjErrorPK::Create(image_x, image_y, 
-							focal_length_x,
-							focal_length_y,
-							center_x,
-							center_y,
-							target_pose,
-							point);
-		problem_->AddResidualBlock(cost_function, NULL , extrinsics);
-	      }
-	      break;
-	    case cost_functions::LinkCameraTargetReprjError:
-	      {
-		CostFunction* cost_function =
-		  LinkCameraTargetReprjError::Create(image_x, image_y, 
-						     focal_length_x,
-						     focal_length_y,
-						     center_x,
-						     center_y,
-						     camera_mounting_pose);
-		problem_->AddResidualBlock(cost_function, NULL , extrinsics, target_pose_params, point.pb);
-	      }
-	      break;
-	    case cost_functions::LinkCameraTargetReprjErrorPK:
-	      {
-		CostFunction* cost_function =
-		  LinkCameraTargetReprjErrorPK::Create(image_x, image_y, 
-						       focal_length_x,
-						       focal_length_y,
-						       center_x,
-						       center_y,
-						       camera_mounting_pose,
-						       point);
-		      
-		problem_->AddResidualBlock(cost_function, NULL , extrinsics, target_pose_params);
-	      }
-	      break;
-	    case cost_functions::CircleCameraReprjErrorWithDistortion:
-	      {
-		CostFunction* cost_function =
-		  CircleCameraReprjErrorWithDistortion::Create(image_x, image_y, circle_dia);
-		problem_->AddResidualBlock(cost_function, NULL , extrinsics, intrinsics, point.pb);
-	      }
-	      break;
-	    case cost_functions::CircleCameraReprjErrorWithDistortionPK:
-	      {
-		CostFunction* cost_function =
-		  CircleCameraReprjErrorWithDistortionPK::Create(image_x, image_y,
-								 circle_dia,
-								 point);
-		problem_->AddResidualBlock(cost_function, NULL , extrinsics, intrinsics, point.pb);
-	      }
-	      break;
-	    case cost_functions::CircleCameraReprjError:
-	      {
-		CostFunction* cost_function =
-		  CircleCameraReprjError::Create(image_x, image_y, 
-						 circle_dia,
-						 focal_length_x,
-						 focal_length_y,
-						 center_x,
-						 center_y);
-		problem_->AddResidualBlock(cost_function, NULL , extrinsics, point.pb);
-	      }
-	      break;
-	    case cost_functions::CircleCameraReprjErrorPK:
-	      {
-		CostFunction* cost_function =
-		  CircleCameraReprjErrorPK::Create(image_x, image_y, 
-						   circle_dia,
-						   focal_length_x,
-						   focal_length_y,
-						   center_x,
-						   center_y,
-						   point);
-		problem_->AddResidualBlock(cost_function, NULL , extrinsics);
-	      }
-	      break;
-	    case cost_functions::CircleTargetCameraReprjErrorWithDistortion:
-	      {
-		CostFunction* cost_function =
-		  CircleTargetCameraReprjErrorWithDistortion::Create(image_x, image_y,
-								     circle_dia);
-		problem_->AddResidualBlock(cost_function, NULL , extrinsics, intrinsics, point.pb);
-	      }
-	      break;
-	    case cost_functions::CircleTargetCameraReprjErrorWithDistortionPK:
-	      {
-		CostFunction* cost_function =
-		  CircleTargetCameraReprjErrorWithDistortionPK::Create(image_x, image_y, 
-								       circle_dia,
-								       point);
-		problem_->AddResidualBlock(cost_function, NULL , extrinsics, intrinsics, target_pose_params);
-	      }
-	      break;
-	    case cost_functions::FixedCircleTargetCameraReprjErrorWithDistortionPK:
-	      {
-		CostFunction* cost_function =
-		  FixedCircleTargetCameraReprjErrorWithDistortionPK::Create(image_x, image_y, 
-									    circle_dia,
-									    point);
-		problem_->AddResidualBlock(cost_function, NULL , extrinsics, intrinsics, target_pose_params);
-	      }
-	      break;
-	    case cost_functions::SimpleCircleTargetCameraReprjErrorWithDistortionPK:
-	      {
-		CostFunction* cost_function =
-		  SimpleCircleTargetCameraReprjErrorWithDistortionPK::Create(image_x, image_y, 
-									     circle_dia,
-									     point);
-		problem_->AddResidualBlock(cost_function, NULL , extrinsics, intrinsics);
-	      }
-	      break;
-	    case cost_functions::CircleTargetCameraReprjErrorPK:
-	      {
-		CostFunction* cost_function = 
-		  CircleTargetCameraReprjErrorPK::Create(image_x,  image_y,
-							 circle_dia,
-							 focal_length_x,
-							 focal_length_y,
-							 center_x,
-							 center_y,
-							 point);
-		problem_->AddResidualBlock(cost_function, NULL , extrinsics, target_pose_params);
-	      }
-	      break;
-	    case cost_functions::LinkCircleTargetCameraReprjError:
-	      {
-		CostFunction* cost_function =
-		  LinkCircleTargetCameraReprjError::Create(image_x, image_y, 
-							   circle_dia,
-							   focal_length_x,
-							   focal_length_y,
-							   center_x,
-							   center_y,
-							   camera_mounting_pose);
-		problem_->AddResidualBlock(cost_function, NULL , extrinsics, target_pose_params, point.pb);
-	      }
-	      break;
-	    case cost_functions::LinkCircleTargetCameraReprjErrorPK:
-	      {
-		CostFunction* cost_function =
-		  LinkCircleTargetCameraReprjErrorPK::Create(image_x, image_y, 
-							     circle_dia,
-							     focal_length_x,
-							     focal_length_y,
-							     center_x,
-							     center_y,
-							     camera_mounting_pose,
-							     point);
-		problem_->AddResidualBlock(cost_function, NULL , extrinsics, target_pose_params);
-	      }
-	      break;
-	    case cost_functions::LinkCameraCircleTargetReprjError:
-	      {
-		CostFunction* cost_function =
-		  LinkCameraCircleTargetReprjError::Create(image_x, image_y, 
-							   circle_dia,
-							   focal_length_x,
-							   focal_length_y,
-							   center_x,
-							   center_y,
-							   camera_mounting_pose);
-		problem_->AddResidualBlock(cost_function, NULL , extrinsics, target_pose_params, point.pb);
-	      }
-	      break;
-	    case cost_functions::LinkCameraCircleTargetReprjErrorPK:
-	      {
-		CostFunction* cost_function =
-		  LinkCameraCircleTargetReprjErrorPK::Create(image_x, image_y, 
-							     circle_dia,
-							     focal_length_x,
-							     focal_length_y,
-							     center_x,
-							     center_y,
-							     camera_mounting_pose,
-							     point);
-		problem_->AddResidualBlock(cost_function, NULL , extrinsics, target_pose_params);
-		if(point_zero){
-		  double residual[2];
-		  double *params[2];
-		  params[0] = &extrinsics[0];
-		  params[1] = &target_pose_params[0];
-		  cost_function->Evaluate(params, residual, NULL);
-		  ROS_INFO("Initial residual %6.3lf %6.3lf ix,iy = %6.3lf %6.3lf px,py = %6.3lf %6.3lf", residual[0], residual[1],image_x, image_y, residual[0]+image_x, residual[0]+image_y);
-		  point_zero=false;
-		  LinkCameraCircleTargetReprjErrorPK testIt(image_x, image_y, 
-							    circle_dia,
-							    focal_length_x,
-							    focal_length_y,
-							    center_x,
-							    center_y,
-							    camera_mounting_pose,
-							    point);
-		  testIt.test_residual(extrinsics, target_pose_params, residual);
+  // For each scene
+  BOOST_FOREACH (ObservationScene current_scene, scene_list_)
+  {
+    int scene_id = current_scene.get_id();
+    ROS_DEBUG_STREAM("Processing Scene " << scene_id + 1 << " of " << scene_list_.size());
+    current_scene.get_trigger()->waitForTrigger();  // this indicates scene is ready to capture
+    pullTransforms(scene_id);                       // gets transforms of targets and cameras from their interfaces
+    BOOST_FOREACH (shared_ptr< Camera > current_camera, current_scene.cameras_in_scene_)
+    {  // clear camera of existing observations
 
-		}
-	      }
-	      break;
-	    case cost_functions::FixedCircleTargetCameraReprjErrorPK:
-	      {
-		CostFunction* cost_function =
-		  FixedCircleTargetCameraReprjErrorPK::Create(image_x, image_y, 
-							      circle_dia,
-							      focal_length_x,
-							      focal_length_y,
-							      center_x,
-							      center_y,
-							      target_pose,
-							      camera_mounting_pose,
-							      point);
-		problem_->AddResidualBlock(cost_function, NULL , extrinsics);
-		if(point_zero){
-		  double residual[2];
-		  double *params[1];
-		  showPose(extrinsics,"extrinsics");
-		  params[0] = &extrinsics[0];
-		  cost_function->Evaluate(params, residual, NULL);
-		  ROS_ERROR("Initial residual %6.3lf %6.3lf ix,iy = %6.3lf %6.3lf px,py = %6.3lf %6.3lf", residual[0], residual[1],image_x, image_y, residual[0]+image_x, residual[0]+image_y);
-		  point_zero=false;
-		  FixedCircleTargetCameraReprjErrorPK testIt(image_x, image_y, 
-							     circle_dia,
-							     focal_length_x,
-							     focal_length_y,
-							     center_x,
-							     center_y,
-							     target_pose,
-							     camera_mounting_pose,
-							     point);
-		  testIt.test_residual(extrinsics, residual);
+      current_camera->camera_observer_->clearObservations();  // clear any recorded data
+      current_camera->camera_observer_->clearTargets();       // clear all targets
+    }
+    BOOST_FOREACH (ObservationCmd o_command, current_scene.observation_command_list_)
+    {  // add each target and roi each camera's list of observations
 
-		}
-	      }
-	      break;
-	    case cost_functions::TriangulationError:
-	      {
-		double x,y,z,ax,ay,az;
-		extractCameraExtrinsics(extrinsics, x, y, z, ax, ay, az);
-		Pose6d camera_pose(x, y, z, ax, ay, az);
-		CostFunction* cost_function =
-		  TriangulationError::Create(image_x, image_y, 
-					     focal_length_x,
-					     focal_length_y,
-					     center_x,
-					     center_y,
-					     camera_pose);
-		problem_->AddResidualBlock(cost_function, NULL , point.pb);
-	      }
-	      break;
-	    default:
-	      {
-		std::string cost_type_string = costType2String(ODP.cost_type_);
-		ROS_ERROR("No cost function of type %s", cost_type_string.c_str());
-	      }
-	      break;
-	    }// end of switch
-	  }//for each observation
-      }//for each scene
-    ROS_INFO("total observations: %d ",total_observations_);
-  
+      o_command.camera->camera_observer_->addTarget(o_command.target, o_command.roi, o_command.cost_type);
+    }
+    BOOST_FOREACH (shared_ptr< Camera > current_camera, current_scene.cameras_in_scene_)
+    {  // trigger the cameras
+      current_camera->camera_observer_->triggerCamera();
+    }
+    // collect results
+    P_BLOCK intrinsics;
+    P_BLOCK extrinsics;
+    P_BLOCK target_pose;
+    P_BLOCK pnt_pos;
+    std::string camera_name;
+    std::string target_name;
+    unsigned int target_type;
+    Cost_function cost_type;
+
+    // for each camera in scene get a list of observations, and add camera parameters to ceres_blocks
+    ObservationDataPointList listpercamera;
+    BOOST_FOREACH (shared_ptr< Camera > camera, current_scene.cameras_in_scene_)
+    {
+      // wait until observation is done
+      while (!camera->camera_observer_->observationsDone())
+        ;
+      camera_name = camera->camera_name_;
+      if (camera->isMoving())
+      {
+        // next line does nothing if camera already exist in blocks
+        ceres_blocks_.addMovingCamera(camera, scene_id);
+        // TODO why is there a second call to pull transforms here?
+        pullTransforms(scene_id);  // gets transforms of targets and cameras from their interfaces
+        intrinsics = ceres_blocks_.getMovingCameraParameterBlockIntrinsics(camera_name);
+        extrinsics = ceres_blocks_.getMovingCameraParameterBlockExtrinsics(camera_name, scene_id);
+      }
+      else
+      {
+        // next line does nothing if camera already exist in blocks
+        ceres_blocks_.addStaticCamera(camera);
+        intrinsics = ceres_blocks_.getStaticCameraParameterBlockIntrinsics(camera_name);
+        extrinsics = ceres_blocks_.getStaticCameraParameterBlockExtrinsics(camera_name);
+      }
+      // Get the observations from this camera whose P_BLOCKs are intrinsics and extrinsics
+      CameraObservations camera_observations;
+      int number_returned;
+      number_returned = camera->getObservations(camera_observations);
+      ROS_DEBUG_STREAM("Processing " << camera_observations.size() << " Observations");
+      BOOST_FOREACH (Observation observation, camera_observations)
+      {
+        target_name = observation.target->target_name_;
+        target_type = observation.target->target_type_;
+        cost_type = observation.cost_type;
+        double circle_dia = 0.0;
+        if (target_type == pattern_options::CircleGrid || target_type == pattern_options::ModifiedCircleGrid)
+        {
+          circle_dia = observation.target->circle_grid_parameters_.circle_diameter;
+        }
+        int pnt_id = observation.point_id;
+        double observation_x = observation.image_loc_x;
+        double observation_y = observation.image_loc_y;
+        if (observation.target->is_moving_)
+        {
+          ceres_blocks_.addMovingTarget(observation.target, scene_id);
+          target_pose = ceres_blocks_.getMovingTargetPoseParameterBlock(target_name, scene_id);
+          pnt_pos = ceres_blocks_.getMovingTargetPointParameterBlock(target_name, pnt_id);
+        }
+        else
+        {
+          ceres_blocks_.addStaticTarget(observation.target);  // if exist, does nothing
+          target_pose = ceres_blocks_.getStaticTargetPoseParameterBlock(target_name);
+          pnt_pos = ceres_blocks_.getStaticTargetPointParameterBlock(target_name, pnt_id);
+        }
+        ObservationDataPoint temp_ODP(camera_name, target_name, target_type, scene_id, intrinsics, extrinsics, pnt_id,
+                                      target_pose, pnt_pos, observation_x, observation_y, cost_type,
+                                      observation.intermediate_frame, circle_dia);
+        listpercamera.addObservationPoint(temp_ODP);
+      }  // end for each observed point
+    }    // end for each camera
+    observation_data_point_list_.push_back(listpercamera);
+  }  // end for each scene
+  return true;
+}
+
+bool CalibrationJob::runOptimization()
+{
+  if (post_proc_on_) writeObservationData(post_proc_data_file_, observation_data_point_list_);
+
+  // problem is declared here because we can't clear it as far as I can tell from the ceres documentation
+  if (problem_ != NULL)
+  {
+    ROS_INFO("Deleting old problem.");
+    delete (problem_);
+  }
+  problem_ = new ceres::Problem; /*!< This is the object which solves non-linear optimization problems */
+
+  total_observations_ = 0;
+  for (int i = 0; i < observation_data_point_list_.size(); i++)
+  {
+    total_observations_ += observation_data_point_list_[i].items_.size();
+    std::stringstream observations_ss;
+    for (int pntIdx = 0; pntIdx < observation_data_point_list_[i].items_.size(); pntIdx++)
+    {
+      const ObservationDataPoint& odp = observation_data_point_list_[i].items_[pntIdx];
+      ROS_DEBUG("%d: id=%d pos=[%f, %f, %f] img=[%f, %f]", pntIdx, odp.point_id_, odp.point_position_[0],
+                odp.point_position_[1], odp.point_position_[2], odp.image_x_, odp.image_y_);
+      observations_ss << "[" << odp.image_x_ << ", " << odp.image_y_ << "],";
+    }
+    ROS_DEBUG("project_points2d: %s", observations_ss.str().c_str());
+  }
+  if (total_observations_ == 0)
+  {  // TODO really need more than number of parameters being computed
+    ROS_ERROR("Too few observations: %d", total_observations_);
+    return (false);
+  }
+  else
+  {
+    ROS_INFO("total observations = %d", total_observations_);
+  }
+
+  // TODO remove commented code     ceres_blocks_.displayMovingCameras();
+
+  // take all the data collected and create a Ceres optimization problem and run it
+  ROS_INFO("Running Optimization with %d scenes", (int)scene_list_.size());
+  ROS_DEBUG_STREAM("Optimizing " << scene_list_.size() << " scenes");
+  BOOST_FOREACH (ObservationScene current_scene, scene_list_)
+  {
+    int scene_id = current_scene.get_id();
+    ROS_DEBUG_STREAM(
+        "Current observation data point list size: " << observation_data_point_list_.at(scene_id).items_.size());
+    // take all the data collected and create a Ceres optimization problem and run it
+    P_BLOCK extrinsics;
+    P_BLOCK intrinsics;
+    P_BLOCK target_pose_params;
+    P_BLOCK point_position;
+    BOOST_FOREACH (ObservationDataPoint ODP, observation_data_point_list_.at(scene_id).items_)
+    {
+      // create cost function
+      // there are several options
+      // 1. the complete reprojection error cost function "Create(obs_x,obs_y)"
+      //    this cost function has the following parameters:
+      //      a. camera intrinsics
+      //      b. camera extrinsics
+      //      c. target pose
+      //      d. point location in target frame
+      // 2. the same as 1, but without d  "Create(obs_x,obs_y,t_pnt_x, t_pnt_y, t_pnt_z)
+      // 3. the same as 1, but without a  "Create(obs_x,obs_y,fx,fy,cx,cy,cz)"
+      //    Note that this one assumes we are using rectified images to compute the observations
+      // 4. the same as 3, point location fixed too "Create(obs_x,obs_y,fx,fy,cx,cy,cz,t_x,t_y,t_z)"
+      //        implemented in TargetCameraReprjErrorNoDistortion
+      // 5. the same as 4, but with target in known location
+      //    "Create(obs_x,obs_y,fx,fy,cx,cy,cz,t_x,t_y,t_z,p_tx,p_ty,p_tz,p_ax,p_ay,p_az)"
+      // pull out the constants from the observation point data
+      intrinsics = ODP.camera_intrinsics_;
+      double focal_length_x = ODP.camera_intrinsics_[0];  // TODO, make this not so ugly
+      double focal_length_y = ODP.camera_intrinsics_[1];
+      double center_x = ODP.camera_intrinsics_[2];
+      double center_y = ODP.camera_intrinsics_[3];
+      double image_x = ODP.image_x_;
+      double image_y = ODP.image_y_;
+      Point3d point;
+      Pose6d camera_mounting_pose = ODP.intermediate_frame_;  // identity except when camera mounted on robot
+      point.x = ODP.point_position_[0];                       // location of point within target frame
+      point.y = ODP.point_position_[1];
+      point.z = ODP.point_position_[2];
+      unsigned int target_type = ODP.target_type_;
+      double circle_dia = ODP.circle_dia_;  // sometimes this is not needed
+
+      // pull out pointers to the parameter blocks in the observation point data
+      extrinsics = ODP.camera_extrinsics_;
+      target_pose_params = ODP.target_pose_;
+      Pose6d target_pose;
+      target_pose.setAngleAxis(target_pose_params[0], target_pose_params[1], target_pose_params[2]);
+      target_pose.setOrigin(target_pose_params[3], target_pose_params[4], target_pose_params[5]);
+      point_position = ODP.point_position_;
+      bool point_zero = false;  // Set true to enable some debugging
+
+      if (0)
+      {  // modify for debugging
+        if (point.x == 0.0 && point.y == 0.0 && point.z == 0.0)
+        {
+          point_zero = true;
+          //		ROS_ERROR("Observing Target Origin");
+          //		showPose(target_pose_params, "target");
+          target_pose.show("target_pose");
+          showPose(extrinsics, "extrinsics");
+          ROS_ERROR("u,v %6.3f %6.3f", image_x, image_y);
+          //		showPose((P_BLOCK) &camera_mounting_pose.pb_pose[0], "camera_mounting_pose");
+        }
+      }
+
+      switch (ODP.cost_type_)
+      {
+        case cost_functions::CameraReprjErrorWithDistortion:
+        {
+          CostFunction* cost_function = CameraReprjErrorWithDistortion::Create(image_x, image_y);
+          problem_->AddResidualBlock(cost_function, NULL, extrinsics, intrinsics, point.pb);
+        }
+        break;
+        case cost_functions::CameraReprjErrorWithDistortionPK:
+        {
+          CostFunction* cost_function = CameraReprjErrorWithDistortionPK::Create(image_x, image_y, point);
+          problem_->AddResidualBlock(cost_function, NULL, extrinsics, intrinsics);
+        }
+        break;
+        case cost_functions::CameraReprjError:
+        {
+          CostFunction* cost_function =
+              CameraReprjError::Create(image_x, image_y, focal_length_x, focal_length_y, center_x, center_y);
+          problem_->AddResidualBlock(cost_function, NULL, extrinsics, point.pb);
+        }
+        break;
+        case cost_functions::CameraReprjErrorPK:
+        {
+          CostFunction* cost_function =
+              CameraReprjErrorPK::Create(image_x, image_y, focal_length_x, focal_length_y, center_x, center_y, point);
+          problem_->AddResidualBlock(cost_function, NULL, extrinsics);
+        }
+        break;
+        case cost_functions::TargetCameraReprjError:
+        {
+          CostFunction* cost_function =
+              TargetCameraReprjError::Create(image_x, image_y, focal_length_x, focal_length_y, center_x, center_y);
+
+          problem_->AddResidualBlock(cost_function, NULL, extrinsics, target_pose_params, point.pb);
+        }
+        break;
+        case cost_functions::TargetCameraReprjErrorPK:
+        {
+          CostFunction* cost_function = TargetCameraReprjErrorPK::Create(image_x, image_y, focal_length_x,
+                                                                         focal_length_y, center_x, center_y, point);
+          // add it as a residual using parameter blocks
+          problem_->AddResidualBlock(cost_function, NULL, extrinsics, target_pose_params);
+        }
+        break;
+        case cost_functions::LinkTargetCameraReprjError:
+        {
+          CostFunction* cost_function = LinkTargetCameraReprjError::Create(
+              image_x, image_y, focal_length_x, focal_length_y, center_x, center_y, camera_mounting_pose);
+          problem_->AddResidualBlock(cost_function, NULL, extrinsics, target_pose_params, point.pb);
+        }
+        break;
+        case cost_functions::LinkTargetCameraReprjErrorPK:
+        {
+          CostFunction* cost_function = LinkTargetCameraReprjErrorPK::Create(
+              image_x, image_y, focal_length_x, focal_length_y, center_x, center_y, camera_mounting_pose, point);
+          problem_->AddResidualBlock(cost_function, NULL, extrinsics, target_pose_params);
+        }
+        break;
+        case cost_functions::PosedTargetCameraReprjErrorPK:
+        {
+          if (point_zero)
+          {
+            ROS_ERROR("u,v %f %f x,y,x %f %f %f", image_x, image_y, point.x, point.y, point.z);
+          }
+          CostFunction* cost_function = PosedTargetCameraReprjErrorPK::Create(
+              image_x, image_y, focal_length_x, focal_length_y, center_x, center_y, target_pose, point);
+          problem_->AddResidualBlock(cost_function, NULL, extrinsics);
+        }
+        break;
+        case cost_functions::LinkCameraTargetReprjError:
+        {
+          CostFunction* cost_function = LinkCameraTargetReprjError::Create(
+              image_x, image_y, focal_length_x, focal_length_y, center_x, center_y, camera_mounting_pose);
+          problem_->AddResidualBlock(cost_function, NULL, extrinsics, target_pose_params, point.pb);
+        }
+        break;
+        case cost_functions::LinkCameraTargetReprjErrorPK:
+        {
+          CostFunction* cost_function = LinkCameraTargetReprjErrorPK::Create(
+              image_x, image_y, focal_length_x, focal_length_y, center_x, center_y, camera_mounting_pose, point);
+
+          problem_->AddResidualBlock(cost_function, NULL, extrinsics, target_pose_params);
+        }
+        break;
+        case cost_functions::CircleCameraReprjErrorWithDistortion:
+        {
+          CostFunction* cost_function = CircleCameraReprjErrorWithDistortion::Create(image_x, image_y, circle_dia);
+          problem_->AddResidualBlock(cost_function, NULL, extrinsics, intrinsics, point.pb);
+        }
+        break;
+        case cost_functions::CircleCameraReprjErrorWithDistortionPK:
+        {
+          CostFunction* cost_function =
+              CircleCameraReprjErrorWithDistortionPK::Create(image_x, image_y, circle_dia, point);
+          problem_->AddResidualBlock(cost_function, NULL, extrinsics, intrinsics, point.pb);
+        }
+        break;
+        case cost_functions::CircleCameraReprjError:
+        {
+          CostFunction* cost_function = CircleCameraReprjError::Create(image_x, image_y, circle_dia, focal_length_x,
+                                                                       focal_length_y, center_x, center_y);
+          problem_->AddResidualBlock(cost_function, NULL, extrinsics, point.pb);
+        }
+        break;
+        case cost_functions::CircleCameraReprjErrorPK:
+        {
+          CostFunction* cost_function = CircleCameraReprjErrorPK::Create(image_x, image_y, circle_dia, focal_length_x,
+                                                                         focal_length_y, center_x, center_y, point);
+          problem_->AddResidualBlock(cost_function, NULL, extrinsics);
+        }
+        break;
+        case cost_functions::CircleTargetCameraReprjErrorWithDistortion:
+        {
+          CostFunction* cost_function =
+              CircleTargetCameraReprjErrorWithDistortion::Create(image_x, image_y, circle_dia);
+          problem_->AddResidualBlock(cost_function, NULL, extrinsics, intrinsics, point.pb);
+        }
+        break;
+        case cost_functions::CircleTargetCameraReprjErrorWithDistortionPK:
+        {
+          CostFunction* cost_function =
+              CircleTargetCameraReprjErrorWithDistortionPK::Create(image_x, image_y, circle_dia, point);
+          problem_->AddResidualBlock(cost_function, NULL, extrinsics, intrinsics, target_pose_params);
+        }
+        break;
+        case cost_functions::FixedCircleTargetCameraReprjErrorWithDistortionPK:
+        {
+          CostFunction* cost_function =
+              FixedCircleTargetCameraReprjErrorWithDistortionPK::Create(image_x, image_y, circle_dia, point);
+          problem_->AddResidualBlock(cost_function, NULL, extrinsics, intrinsics, target_pose_params);
+        }
+        break;
+        case cost_functions::SimpleCircleTargetCameraReprjErrorWithDistortionPK:
+        {
+          CostFunction* cost_function =
+              SimpleCircleTargetCameraReprjErrorWithDistortionPK::Create(image_x, image_y, circle_dia, point);
+          problem_->AddResidualBlock(cost_function, NULL, extrinsics, intrinsics);
+        }
+        break;
+        case cost_functions::CircleTargetCameraReprjErrorPK:
+        {
+          CostFunction* cost_function = CircleTargetCameraReprjErrorPK::Create(
+              image_x, image_y, circle_dia, focal_length_x, focal_length_y, center_x, center_y, point);
+          problem_->AddResidualBlock(cost_function, NULL, extrinsics, target_pose_params);
+        }
+        break;
+        case cost_functions::LinkCircleTargetCameraReprjError:
+        {
+          CostFunction* cost_function = LinkCircleTargetCameraReprjError::Create(
+              image_x, image_y, circle_dia, focal_length_x, focal_length_y, center_x, center_y, camera_mounting_pose);
+          problem_->AddResidualBlock(cost_function, NULL, extrinsics, target_pose_params, point.pb);
+        }
+        break;
+        case cost_functions::LinkCircleTargetCameraReprjErrorPK:
+        {
+          CostFunction* cost_function =
+              LinkCircleTargetCameraReprjErrorPK::Create(image_x, image_y, circle_dia, focal_length_x, focal_length_y,
+                                                         center_x, center_y, camera_mounting_pose, point);
+          problem_->AddResidualBlock(cost_function, NULL, extrinsics, target_pose_params);
+        }
+        break;
+        case cost_functions::LinkCameraCircleTargetReprjError:
+        {
+          CostFunction* cost_function = LinkCameraCircleTargetReprjError::Create(
+              image_x, image_y, circle_dia, focal_length_x, focal_length_y, center_x, center_y, camera_mounting_pose);
+          problem_->AddResidualBlock(cost_function, NULL, extrinsics, target_pose_params, point.pb);
+        }
+        break;
+        case cost_functions::LinkCameraCircleTargetReprjErrorPK:
+        {
+          CostFunction* cost_function =
+              LinkCameraCircleTargetReprjErrorPK::Create(image_x, image_y, circle_dia, focal_length_x, focal_length_y,
+                                                         center_x, center_y, camera_mounting_pose, point);
+          problem_->AddResidualBlock(cost_function, NULL, extrinsics, target_pose_params);
+          if (point_zero)
+          {
+            double residual[2];
+            double* params[2];
+            params[0] = &extrinsics[0];
+            params[1] = &target_pose_params[0];
+            cost_function->Evaluate(params, residual, NULL);
+            ROS_INFO("Initial residual %6.3lf %6.3lf ix,iy = %6.3lf %6.3lf px,py = %6.3lf %6.3lf", residual[0],
+                     residual[1], image_x, image_y, residual[0] + image_x, residual[0] + image_y);
+            point_zero = false;
+            LinkCameraCircleTargetReprjErrorPK testIt(image_x, image_y, circle_dia, focal_length_x, focal_length_y,
+                                                      center_x, center_y, camera_mounting_pose, point);
+            testIt.test_residual(extrinsics, target_pose_params, residual);
+          }
+        }
+        break;
+        case cost_functions::FixedCircleTargetCameraReprjErrorPK:
+        {
+          CostFunction* cost_function =
+              FixedCircleTargetCameraReprjErrorPK::Create(image_x, image_y, circle_dia, focal_length_x, focal_length_y,
+                                                          center_x, center_y, target_pose, camera_mounting_pose, point);
+          problem_->AddResidualBlock(cost_function, NULL, extrinsics);
+          if (point_zero)
+          {
+            double residual[2];
+            double* params[1];
+            showPose(extrinsics, "extrinsics");
+            params[0] = &extrinsics[0];
+            cost_function->Evaluate(params, residual, NULL);
+            ROS_ERROR("Initial residual %6.3lf %6.3lf ix,iy = %6.3lf %6.3lf px,py = %6.3lf %6.3lf", residual[0],
+                      residual[1], image_x, image_y, residual[0] + image_x, residual[0] + image_y);
+            point_zero = false;
+            FixedCircleTargetCameraReprjErrorPK testIt(image_x, image_y, circle_dia, focal_length_x, focal_length_y,
+                                                       center_x, center_y, target_pose, camera_mounting_pose, point);
+            testIt.test_residual(extrinsics, residual);
+          }
+        }
+        break;
+        case cost_functions::TriangulationError:
+        {
+          double x, y, z, ax, ay, az;
+          extractCameraExtrinsics(extrinsics, x, y, z, ax, ay, az);
+          Pose6d camera_pose(x, y, z, ax, ay, az);
+          CostFunction* cost_function = TriangulationError::Create(image_x, image_y, focal_length_x, focal_length_y,
+                                                                   center_x, center_y, camera_pose);
+          problem_->AddResidualBlock(cost_function, NULL, point.pb);
+        }
+        break;
+        default:
+        {
+          std::string cost_type_string = costType2String(ODP.cost_type_);
+          ROS_ERROR("No cost function of type %s", cost_type_string.c_str());
+        }
+        break;
+      }  // end of switch
+    }    // for each observation
+  }      // for each scene
+  ROS_INFO("total observations: %d ", total_observations_);
+
   // Make Ceres automatically detect the bundle structure. Note that the
   // standard solver, SPARSE_NORMAL_CHOLESKY, also works fine but it is slower
   // for standard bundle adjustment problems.
@@ -772,154 +677,171 @@ namespace industrial_extrinsic_cal
   options.max_num_iterations = 1000;
   ceres::Solve(options, problem_, &ceres_summary_);
 
-  if(ceres_summary_.termination_type != ceres::NO_CONVERGENCE ){
-      ROS_INFO("Problem Solved");
-      double error_per_observation = ceres_summary_.initial_cost/total_observations_;
-
-      return true;
-    }
-    else{
-      ROS_ERROR("Problem Not Solved termination type = %d success = %d", ceres_summary_.termination_type, ceres::USER_SUCCESS);
-    }
-
-
-    
-  }//end runOptimization
-
- bool CalibrationJob::computeCovariance(std::vector<CovarianceVariableRequest> &variables, std::string &covariance_file_name)
+  if (ceres_summary_.termination_type != ceres::NO_CONVERGENCE)
   {
-    FILE *fp;
-    if((fp= fopen(covariance_file_name.c_str(), "w") ) != NULL){
-      ceres::Covariance::Options covariance_options;
-      covariance_options.algorithm_type = ceres::DENSE_SVD;
-      ceres::Covariance covariance(covariance_options);
-      std::vector<const double*> covariance_blocks;
-      std::vector<int> block_sizes;
-      std::vector<std::string> block_names;
-      std::vector< std::pair< const double*, const double*> > covariance_pairs;
+    ROS_INFO("Problem Solved");
+    double error_per_observation = ceres_summary_.initial_cost / total_observations_;
 
-      BOOST_FOREACH(CovarianceVariableRequest req, variables){
-	P_BLOCK intrinsics, extrinsics, pose_params;
-	switch(req.request_type){
-	case covariance_requests::StaticCameraIntrinsicParams:
-	    intrinsics = ceres_blocks_.getStaticCameraParameterBlockIntrinsics(req.object_name.c_str());
-	    covariance_blocks.push_back(intrinsics);
-	    block_sizes.push_back(9);
-	    block_names.push_back(req.object_name.c_str());
-	    break;
-	case covariance_requests::StaticCameraExtrinsicParams:
-	  extrinsics = ceres_blocks_.getStaticCameraParameterBlockExtrinsics(req.object_name.c_str());
-	  covariance_blocks.push_back(extrinsics);
-	  block_sizes.push_back(6);
-	  block_names.push_back(req.object_name.c_str());
-	  break;
-	case covariance_requests::MovingCameraIntrinsicParams:
-	  intrinsics = ceres_blocks_.getMovingCameraParameterBlockIntrinsics(req.object_name.c_str());
-	  covariance_blocks.push_back(intrinsics);
-	  block_sizes.push_back(9);
-	  block_names.push_back(req.object_name.c_str());
-	  break;
-	case covariance_requests::MovingCameraExtrinsicParams:
-	  extrinsics = ceres_blocks_.getMovingCameraParameterBlockExtrinsics(req.object_name.c_str(), req.scene_id);
-	  covariance_blocks.push_back(extrinsics);
-	  block_sizes.push_back(6);
-	  block_names.push_back(req.object_name.c_str());
-	  break;
-	case covariance_requests::StaticTargetPoseParams:
-	  pose_params = ceres_blocks_.getStaticTargetPoseParameterBlock(req.object_name.c_str());
-	  covariance_blocks.push_back(pose_params);
-	  block_sizes.push_back(6);
-	  block_names.push_back(req.object_name.c_str());
-	  break;
-	case covariance_requests::MovingTargetPoseParams:
-	  pose_params = ceres_blocks_.getMovingTargetPoseParameterBlock(req.object_name.c_str(), req.scene_id);
-	  covariance_blocks.push_back(pose_params);
-	  block_sizes.push_back(6);
-	  block_names.push_back(req.object_name.c_str());
-	  break;
-	default:
-	  ROS_ERROR("unknown type of request");
-	  return(false);
-	  break;
-	}// end of switch for request type
-      }// end of for each request
+    return true;
+  }
+  else
+  {
+    ROS_ERROR("Problem Not Solved termination type = %d success = %d", ceres_summary_.termination_type,
+              ceres::USER_SUCCESS);
+  }
 
-      // create pairs from every combination of blocks in request
-      for(int i=0; i<(int)covariance_blocks.size(); i++){
-	for(int j=i; j<(int)covariance_blocks.size(); j++){
-	  covariance_pairs.push_back(std::make_pair(covariance_blocks[i],covariance_blocks[j]) );
-	}
+}  // end runOptimization
+
+bool CalibrationJob::computeCovariance(std::vector< CovarianceVariableRequest >& variables,
+                                       std::string& covariance_file_name)
+{
+  FILE* fp;
+  if ((fp = fopen(covariance_file_name.c_str(), "w")) != NULL)
+  {
+    ceres::Covariance::Options covariance_options;
+    covariance_options.algorithm_type = ceres::DENSE_SVD;
+    ceres::Covariance covariance(covariance_options);
+    std::vector< const double* > covariance_blocks;
+    std::vector< int > block_sizes;
+    std::vector< std::string > block_names;
+    std::vector< std::pair< const double*, const double* > > covariance_pairs;
+
+    BOOST_FOREACH (CovarianceVariableRequest req, variables)
+    {
+      P_BLOCK intrinsics, extrinsics, pose_params;
+      switch (req.request_type)
+      {
+        case covariance_requests::StaticCameraIntrinsicParams:
+          intrinsics = ceres_blocks_.getStaticCameraParameterBlockIntrinsics(req.object_name.c_str());
+          covariance_blocks.push_back(intrinsics);
+          block_sizes.push_back(9);
+          block_names.push_back(req.object_name.c_str());
+          break;
+        case covariance_requests::StaticCameraExtrinsicParams:
+          extrinsics = ceres_blocks_.getStaticCameraParameterBlockExtrinsics(req.object_name.c_str());
+          covariance_blocks.push_back(extrinsics);
+          block_sizes.push_back(6);
+          block_names.push_back(req.object_name.c_str());
+          break;
+        case covariance_requests::MovingCameraIntrinsicParams:
+          intrinsics = ceres_blocks_.getMovingCameraParameterBlockIntrinsics(req.object_name.c_str());
+          covariance_blocks.push_back(intrinsics);
+          block_sizes.push_back(9);
+          block_names.push_back(req.object_name.c_str());
+          break;
+        case covariance_requests::MovingCameraExtrinsicParams:
+          extrinsics = ceres_blocks_.getMovingCameraParameterBlockExtrinsics(req.object_name.c_str(), req.scene_id);
+          covariance_blocks.push_back(extrinsics);
+          block_sizes.push_back(6);
+          block_names.push_back(req.object_name.c_str());
+          break;
+        case covariance_requests::StaticTargetPoseParams:
+          pose_params = ceres_blocks_.getStaticTargetPoseParameterBlock(req.object_name.c_str());
+          covariance_blocks.push_back(pose_params);
+          block_sizes.push_back(6);
+          block_names.push_back(req.object_name.c_str());
+          break;
+        case covariance_requests::MovingTargetPoseParams:
+          pose_params = ceres_blocks_.getMovingTargetPoseParameterBlock(req.object_name.c_str(), req.scene_id);
+          covariance_blocks.push_back(pose_params);
+          block_sizes.push_back(6);
+          block_names.push_back(req.object_name.c_str());
+          break;
+        default:
+          ROS_ERROR("unknown type of request");
+          return (false);
+          break;
+      }  // end of switch for request type
+    }    // end of for each request
+
+    // create pairs from every combination of blocks in request
+    for (int i = 0; i < (int)covariance_blocks.size(); i++)
+    {
+      for (int j = i; j < (int)covariance_blocks.size(); j++)
+      {
+        covariance_pairs.push_back(std::make_pair(covariance_blocks[i], covariance_blocks[j]));
       }
-      covariance.Compute(covariance_pairs, problem_);
-
-      fprintf(fp,"covariance blocks:\n");
-      for(int i=0; i<(int)covariance_blocks.size(); i++){
-	for(int j=i; j<(int)covariance_blocks.size(); j++){
-	  fprintf(fp,"Cov[%s, %s]\n", block_names[i].c_str(), block_names[j].c_str());
-	  int N = block_sizes[i];
-	  int M = block_sizes[j];
-	  double ij_cov_block[N*M];
-	  covariance.GetCovarianceBlock(covariance_blocks[i], covariance_blocks[j], ij_cov_block);
-	  for(int q=0; q<N;i++){
-	    for(int k=0;k<M;k++){
-	      double sigma_i = sqrt(ij_cov_block[q*N+q]);
-	      double sigma_j = sqrt(ij_cov_block[k*N+k]);
-	      if(q==k){
-		fprintf(fp,"%6.3f ", sigma_i);
-	      }
-	      else{
-		fprintf(fp,"%6.3lf ", ij_cov_block[q*N + k]/(sigma_i * sigma_j));
-	      }
-	    }// end of k loop
-	    fprintf(fp,"\n");
-	  }// end of q loop
-	}// end of j loop
-      }// end of i loop
-      fclose(fp);
-    }// end of if file opens
-    else{
-      ROS_ERROR("could not open covariance file %s", covariance_file_name.c_str());
-      return(false);
     }
-    return(true);
-  } // end computeCovariance
+    covariance.Compute(covariance_pairs, problem_);
 
-  bool CalibrationJob::store(std::string filePath)
+    fprintf(fp, "covariance blocks:\n");
+    for (int i = 0; i < (int)covariance_blocks.size(); i++)
+    {
+      for (int j = i; j < (int)covariance_blocks.size(); j++)
+      {
+        fprintf(fp, "Cov[%s, %s]\n", block_names[i].c_str(), block_names[j].c_str());
+        int N = block_sizes[i];
+        int M = block_sizes[j];
+        double ij_cov_block[N * M];
+        covariance.GetCovarianceBlock(covariance_blocks[i], covariance_blocks[j], ij_cov_block);
+        for (int q = 0; q < N; i++)
+        {
+          for (int k = 0; k < M; k++)
+          {
+            double sigma_i = sqrt(ij_cov_block[q * N + q]);
+            double sigma_j = sqrt(ij_cov_block[k * N + k]);
+            if (q == k)
+            {
+              fprintf(fp, "%6.3f ", sigma_i);
+            }
+            else
+            {
+              fprintf(fp, "%6.3lf ", ij_cov_block[q * N + k] / (sigma_i * sigma_j));
+            }
+          }  // end of k loop
+          fprintf(fp, "\n");
+        }  // end of q loop
+      }    // end of j loop
+    }      // end of i loop
+    fclose(fp);
+  }  // end of if file opens
+  else
   {
-    bool rnt =  ceres_blocks_.writeAllStaticTransforms(filePath);
-    bool rtn = true;
-    return rtn;
+    ROS_ERROR("could not open covariance file %s", covariance_file_name.c_str());
+    return (false);
   }
+  return (true);
+}  // end computeCovariance
 
-  void CalibrationJob::show()
-  {
-    ceres_blocks_.pullTransforms(-1); // since we don't know which scene for any moving objects, only pull static transforms
-    ceres_blocks_.displayAllCamerasAndTargets();
-  }
-  void CalibrationJob::pullTransforms(int scene_id)
-  {
-    ceres_blocks_.pullTransforms( scene_id);
-  }
-  void CalibrationJob::pushTransforms()
-  {
-    ceres_blocks_.pushTransforms();
-  }
-  double CalibrationJob::finalCostPerObservation()
-  {
-    if(!solved_){
-      ROS_ERROR("Can't call costPerObservation prior to solving");
-      return(-1.0);
-    }
-    return(ceres_summary_.final_cost/total_observations_);
-  }
+bool CalibrationJob::store(std::string filePath)
+{
+  bool rnt = ceres_blocks_.writeAllStaticTransforms(filePath);
+  bool rtn = true;
+  return rtn;
+}
 
-  double CalibrationJob::initialCostPerObservation()
+void CalibrationJob::show()
+{
+  ceres_blocks_.pullTransforms(
+      -1);  // since we don't know which scene for any moving objects, only pull static transforms
+  ceres_blocks_.displayAllCamerasAndTargets();
+}
+void CalibrationJob::pullTransforms(int scene_id)
+{
+  ceres_blocks_.pullTransforms(scene_id);
+}
+void CalibrationJob::pushTransforms()
+{
+  ceres_blocks_.pushTransforms();
+}
+double CalibrationJob::finalCostPerObservation()
+{
+  if (!solved_)
   {
-    if(!solved_){
-      ROS_ERROR("Can't call costPerObservation prior to solving");
-      return(-1.0);
-    }
-    return(ceres_summary_.initial_cost/total_observations_);
+    ROS_ERROR("Can't call costPerObservation prior to solving");
+    return (-1.0);
   }
+  return (ceres_summary_.final_cost / total_observations_);
+}
 
-}//end namespace industrial_extrinsic_cal
+double CalibrationJob::initialCostPerObservation()
+{
+  if (!solved_)
+  {
+    ROS_ERROR("Can't call costPerObservation prior to solving");
+    return (-1.0);
+  }
+  return (ceres_summary_.initial_cost / total_observations_);
+}
+
+}  // end namespace industrial_extrinsic_cal

--- a/industrial_extrinsic_cal/src/caljob_yaml_parser.cpp
+++ b/industrial_extrinsic_cal/src/caljob_yaml_parser.cpp
@@ -15,9 +15,8 @@
 #include <industrial_extrinsic_cal/caljob_yaml_parser.h>
 #include <industrial_extrinsic_cal/yaml_utils.h>
 
-
-namespace industrial_extrinsic_cal {
-
+namespace industrial_extrinsic_cal
+{
 using std::ifstream;
 using std::string;
 using std::vector;
@@ -25,82 +24,98 @@ using boost::shared_ptr;
 using boost::make_shared;
 using YAML::Node;
 
-  bool parseCaljob(std::string &caljob_input_file, vector<ObservationScene>  &scene_list, string &reference_frame, CeresBlocks &blocks)
+bool parseCaljob(std::string& caljob_input_file, vector< ObservationScene >& scene_list, string& reference_frame,
+                 CeresBlocks& blocks)
+{
+  bool rtn = true;
+  try
   {
-    bool rtn=true;
-    try{
-      Node caljob_doc;
-      if(!yamlNodeFromFileName(caljob_input_file, caljob_doc)){
-	ROS_ERROR("Can't parse yaml file %s", caljob_input_file.c_str());
-      }
+    Node caljob_doc;
+    if (!yamlNodeFromFileName(caljob_input_file, caljob_doc))
+    {
+      ROS_ERROR("Can't parse yaml file %s", caljob_input_file.c_str());
+    }
 
-      // get reference frame       
-      if (!parseString(caljob_doc, "reference_frame", reference_frame)){
-	ROS_ERROR("must set caljob's reference frame");
-      }
-   
-      // read in all scenes
-      scene_list.clear();
-      const YAML::Node& scenes_node = parseNode(caljob_doc, "scenes");
-      for (unsigned int i = 0; i < scenes_node.size(); i++){
-	ObservationScene temp_scene = parseSingleScene(scenes_node[i], i, blocks);
-	temp_scene.setSceneId(i);
-	scene_list.push_back(temp_scene);
-      }
-      ROS_INFO_STREAM( (int) scene_list.size() << " scenes");
+    // get reference frame
+    if (!parseString(caljob_doc, "reference_frame", reference_frame))
+    {
+      ROS_ERROR("must set caljob's reference frame");
     }
-    catch (YAML::ParserException& e){
-      ROS_ERROR("Caljob parsing failure");
-      rtn = false;
+
+    // read in all scenes
+    scene_list.clear();
+    const YAML::Node& scenes_node = parseNode(caljob_doc, "scenes");
+    for (unsigned int i = 0; i < scenes_node.size(); i++)
+    {
+      ObservationScene temp_scene = parseSingleScene(scenes_node[i], i, blocks);
+      temp_scene.setSceneId(i);
+      scene_list.push_back(temp_scene);
     }
-    return(rtn);
+    ROS_INFO_STREAM((int)scene_list.size() << " scenes");
   }
-  ObservationScene parseSingleScene(const Node &node, int scene_id, CeresBlocks & blocks)
+  catch (YAML::ParserException& e)
   {
-    ObservationScene temp_scene;
-    try{
-      // parse the scene trigger
-      std::string trigger_name;
-      if(!parseString(node, "trigger", trigger_name)) ROS_ERROR("no trigger in scene");
-      boost::shared_ptr<Trigger> temp_trigger = parseTrigger(node, trigger_name);
-      temp_scene.setTrigger(temp_trigger);
-
-      // parse the observations
-      const YAML::Node& observation_node = parseNode(node, "observations");
-      for(int i=0; i<(int)observation_node.size();i++){
-	std::string camera_name;
-	std::string target_name;
-	std::string cost_type_string;
-	Cost_function cost_type;
-	shared_ptr<Camera> temp_cam = make_shared<Camera>();
-	shared_ptr<Target> temp_targ = make_shared<Target>();
-	Roi temp_roi;
-	if(!parseString(observation_node[i], "camera", camera_name)) ROS_ERROR("no camera_name in observation");
-	if(!parseString(observation_node[i], "target", target_name)) ROS_ERROR("no target in observation");
-	if(!parseString(observation_node[i], "cost_type", cost_type_string)) ROS_ERROR("no cost_type in observation");
-	cost_type = string2CostType(cost_type_string);
-	if(!parseInt(observation_node[i], "roi_x_min", temp_roi.x_min)) ROS_ERROR("need to define roi_x_min in observation");
-	if(!parseInt(observation_node[i], "roi_x_max", temp_roi.x_max)) ROS_ERROR("need to define roi_x_max in observation");
-	if(!parseInt(observation_node[i], "roi_y_min", temp_roi.y_min)) ROS_ERROR("need to define roi_y_min in observation");
-	if(!parseInt(observation_node[i], "roi_y_max", temp_roi.y_max)) ROS_ERROR("need to define roi_y_max in observation");
-	if((temp_cam = blocks.getCameraByName(camera_name)) == NULL){
-	  ROS_ERROR("Couldn't find camea %s",camera_name.c_str());
-	}
-	if((temp_targ = blocks.getTargetByName(target_name)) == NULL){;
-	  ROS_ERROR("Couldn't find target %s",target_name.c_str());
-	}
-	if(scene_id !=0 && temp_targ->is_moving_){ // if we have a moving target, we need to add it to the blocks
-	  blocks.addMovingTarget(temp_targ, scene_id);
-	  temp_targ =  blocks.getTargetByName(target_name, scene_id);
-	}
-	temp_scene.addCameraToScene(temp_cam);
-	temp_scene.populateObsCmdList(temp_cam, temp_targ, temp_roi, cost_type);
-      }
-    }
-    catch (YAML::ParserException& e){
-    }
-    return(temp_scene);
+    ROS_ERROR("Caljob parsing failure");
+    rtn = false;
   }
-  
+  return (rtn);
+}
+ObservationScene parseSingleScene(const Node& node, int scene_id, CeresBlocks& blocks)
+{
+  ObservationScene temp_scene;
+  try
+  {
+    // parse the scene trigger
+    std::string trigger_name;
+    if (!parseString(node, "trigger", trigger_name)) ROS_ERROR("no trigger in scene");
+    boost::shared_ptr< Trigger > temp_trigger = parseTrigger(node, trigger_name);
+    temp_scene.setTrigger(temp_trigger);
 
-}// end of industrial_extrinsic_cal namespace
+    // parse the observations
+    const YAML::Node& observation_node = parseNode(node, "observations");
+    for (int i = 0; i < (int)observation_node.size(); i++)
+    {
+      std::string camera_name;
+      std::string target_name;
+      std::string cost_type_string;
+      Cost_function cost_type;
+      shared_ptr< Camera > temp_cam = make_shared< Camera >();
+      shared_ptr< Target > temp_targ = make_shared< Target >();
+      Roi temp_roi;
+      if (!parseString(observation_node[i], "camera", camera_name)) ROS_ERROR("no camera_name in observation");
+      if (!parseString(observation_node[i], "target", target_name)) ROS_ERROR("no target in observation");
+      if (!parseString(observation_node[i], "cost_type", cost_type_string)) ROS_ERROR("no cost_type in observation");
+      cost_type = string2CostType(cost_type_string);
+      if (!parseInt(observation_node[i], "roi_x_min", temp_roi.x_min))
+        ROS_ERROR("need to define roi_x_min in observation");
+      if (!parseInt(observation_node[i], "roi_x_max", temp_roi.x_max))
+        ROS_ERROR("need to define roi_x_max in observation");
+      if (!parseInt(observation_node[i], "roi_y_min", temp_roi.y_min))
+        ROS_ERROR("need to define roi_y_min in observation");
+      if (!parseInt(observation_node[i], "roi_y_max", temp_roi.y_max))
+        ROS_ERROR("need to define roi_y_max in observation");
+      if ((temp_cam = blocks.getCameraByName(camera_name)) == NULL)
+      {
+        ROS_ERROR("Couldn't find camea %s", camera_name.c_str());
+      }
+      if ((temp_targ = blocks.getTargetByName(target_name)) == NULL)
+      {
+        ;
+        ROS_ERROR("Couldn't find target %s", target_name.c_str());
+      }
+      if (scene_id != 0 && temp_targ->is_moving_)
+      {  // if we have a moving target, we need to add it to the blocks
+        blocks.addMovingTarget(temp_targ, scene_id);
+        temp_targ = blocks.getTargetByName(target_name, scene_id);
+      }
+      temp_scene.addCameraToScene(temp_cam);
+      temp_scene.populateObsCmdList(temp_cam, temp_targ, temp_roi, cost_type);
+    }
+  }
+  catch (YAML::ParserException& e)
+  {
+  }
+  return (temp_scene);
+}
+
+}  // end of industrial_extrinsic_cal namespace

--- a/industrial_extrinsic_cal/src/camera_definition.cpp
+++ b/industrial_extrinsic_cal/src/camera_definition.cpp
@@ -16,12 +16,10 @@
  * limitations under the License.
  */
 
-
 #include <industrial_extrinsic_cal/camera_definition.h>
 
 namespace industrial_extrinsic_cal
 {
-
 using std::string;
 using boost::shared_ptr;
 using ceres::CostFunction;
@@ -31,8 +29,8 @@ Camera::Camera()
   is_moving_ = false;
 }
 
-Camera::Camera(string name, CameraParameters camera_parameters, bool is_moving) :
-    camera_name_(name), camera_parameters_(camera_parameters), is_moving_(is_moving)
+Camera::Camera(string name, CameraParameters camera_parameters, bool is_moving)
+  : camera_name_(name), camera_parameters_(camera_parameters), is_moving_(is_moving)
 {
 }
 
@@ -47,7 +45,8 @@ bool Camera::isMoving()
 void Camera::pushTransform()
 {
   Pose6d pose;
-  pose.setAngleAxis(camera_parameters_.angle_axis[0], camera_parameters_.angle_axis[1], camera_parameters_.angle_axis[2]);
+  pose.setAngleAxis(camera_parameters_.angle_axis[0], camera_parameters_.angle_axis[1],
+                    camera_parameters_.angle_axis[2]);
   pose.setOrigin(camera_parameters_.position[0], camera_parameters_.position[1], camera_parameters_.position[2]);
   transform_interface_->pushTransform(pose);
 }
@@ -57,32 +56,30 @@ void Camera::pullTransform()
   camera_parameters_.angle_axis[0] = pose.ax;
   camera_parameters_.angle_axis[1] = pose.ay;
   camera_parameters_.angle_axis[2] = pose.az;
-  camera_parameters_.position[0]    = pose.x;
-  camera_parameters_.position[1]    = pose.y;
-  camera_parameters_.position[2]    = pose.z;
+  camera_parameters_.position[0] = pose.x;
+  camera_parameters_.position[1] = pose.y;
+  camera_parameters_.position[2] = pose.z;
 }
-void Camera::setTransformInterface(boost::shared_ptr<TransformInterface> transform_interface)
+void Camera::setTransformInterface(boost::shared_ptr< TransformInterface > transform_interface)
 {
   transform_interface_ = transform_interface;
 }
-boost::shared_ptr<TransformInterface> Camera::getTransformInterface()
+boost::shared_ptr< TransformInterface > Camera::getTransformInterface()
 {
-  return(transform_interface_);
+  return (transform_interface_);
 }
-void Camera::setTIReferenceFrame(std::string & ref_frame)
+void Camera::setTIReferenceFrame(std::string& ref_frame)
 {
   transform_interface_->setReferenceFrame(ref_frame);
 }
 
-int Camera::getObservations(CameraObservations &camera_observations)
+int Camera::getObservations(CameraObservations& camera_observations)
 {
   camera_observations.clear();
   camera_observer_->getObservations(camera_observations);
-  for(int i=0; i<(int) camera_observations.size(); i++){// Add last pulled frame to observation's intermediate frame
-    camera_observations[i].intermediate_frame =  transform_interface_->getIntermediateFrame();
+  for (int i = 0; i < (int)camera_observations.size(); i++)
+  {  // Add last pulled frame to observation's intermediate frame
+    camera_observations[i].intermediate_frame = transform_interface_->getIntermediateFrame();
   }
 }
-}//end namespace industrial_extrinsic_cal
-
-
-
+}  // end namespace industrial_extrinsic_cal

--- a/industrial_extrinsic_cal/src/camera_yaml_parser.cpp
+++ b/industrial_extrinsic_cal/src/camera_yaml_parser.cpp
@@ -20,273 +20,312 @@ using std::vector;
 using boost::shared_ptr;
 using YAML::Node;
 
-namespace industrial_extrinsic_cal {
-
-  bool parseCameras(std::string &cameras_input_file,vector<shared_ptr<Camera> >& cameras)
+namespace industrial_extrinsic_cal
+{
+bool parseCameras(std::string& cameras_input_file, vector< shared_ptr< Camera > >& cameras)
+{
+  Node camera_doc;
+  bool rtn = true;
+  try
   {
     Node camera_doc;
-    bool rtn=true;
-    try{
-      Node camera_doc;
-      if(!yamlNodeFromFileName(cameras_input_file, camera_doc)){
-        ROS_ERROR("Can't parse yaml file %s",cameras_input_file.c_str());
-      }
-      cameras.clear();
-
-      // read in all static cameras
-      int n_static=0;
-      const YAML::Node& camera_parameters = parseNode(camera_doc, "static_cameras");
-      if(camera_parameters)
-      {
-        for (unsigned int i = 0; i < camera_parameters.size(); i++){
-          shared_ptr<Camera> temp_camera = parseSingleCamera(camera_parameters[i]);
-          cameras.push_back(temp_camera);
-          n_static++;
-        }
-      }
-
-      // read in all moving cameras
-      int n_moving=0;
-      const YAML::Node& camera_parameters2 = parseNode(camera_doc, "moving_cameras");
-      if(camera_parameters2)
-      {
-        for (unsigned int i = 0; i < camera_parameters2.size(); i++){
-          shared_ptr<Camera> temp_camera = parseSingleCamera(camera_parameters2[i]);
-          temp_camera->is_moving_ = true;
-          cameras.push_back(temp_camera);
-          n_moving++;
-        }
-      }
-
-      if(cameras.size() == 0)
-      {
-        ROS_ERROR_STREAM("No valid cameras found in file " << cameras_input_file.c_str());
-        return false;
-      }
-      ROS_INFO_STREAM((int) cameras.size() << " cameras " <<n_static <<" static " << n_moving << " moving");
+    if (!yamlNodeFromFileName(cameras_input_file, camera_doc))
+    {
+      ROS_ERROR("Can't parse yaml file %s", cameras_input_file.c_str());
     }
-    catch (YAML::ParserException& e){
-      ROS_ERROR_STREAM("Camera parsing failure " << e.what());
+    cameras.clear();
+
+    // read in all static cameras
+    int n_static = 0;
+    const YAML::Node& camera_parameters = parseNode(camera_doc, "static_cameras");
+    if (camera_parameters)
+    {
+      for (unsigned int i = 0; i < camera_parameters.size(); i++)
+      {
+        shared_ptr< Camera > temp_camera = parseSingleCamera(camera_parameters[i]);
+        cameras.push_back(temp_camera);
+        n_static++;
+      }
+    }
+
+    // read in all moving cameras
+    int n_moving = 0;
+    const YAML::Node& camera_parameters2 = parseNode(camera_doc, "moving_cameras");
+    if (camera_parameters2)
+    {
+      for (unsigned int i = 0; i < camera_parameters2.size(); i++)
+      {
+        shared_ptr< Camera > temp_camera = parseSingleCamera(camera_parameters2[i]);
+        temp_camera->is_moving_ = true;
+        cameras.push_back(temp_camera);
+        n_moving++;
+      }
+    }
+
+    if (cameras.size() == 0)
+    {
+      ROS_ERROR_STREAM("No valid cameras found in file " << cameras_input_file.c_str());
+      return false;
+    }
+    ROS_INFO_STREAM((int)cameras.size() << " cameras " << n_static << " static " << n_moving << " moving");
+  }
+  catch (YAML::ParserException& e)
+  {
+    ROS_ERROR_STREAM("Camera parsing failure " << e.what());
+    rtn = false;
+  }
+  return (rtn);
+}
+shared_ptr< Camera > parseSingleCamera(const Node& node)
+{
+  shared_ptr< Camera > temp_camera;
+  try
+  {
+    string temp_name, temp_topic, camera_optical_frame, camera_housing_frame, camera_mounting_frame, parent_frame;
+    string trigger_name, transform_interface;
+    CameraParameters temp_parameters;
+    if (!parseString(node, "camera_name", temp_name)) ROS_ERROR("Can't read camera_name");
+    if (!parseString(node, "trigger", trigger_name)) ROS_ERROR("Can't read trigger");
+    if (!parseString(node, "image_topic", temp_topic)) ROS_ERROR("Can't read image_topic");
+    if (!parseString(node, "camera_optical_frame", camera_optical_frame)) ROS_ERROR("Can't read camera_optical_frame");
+    if (!parseString(node, "transform_interface", transform_interface)) ROS_ERROR("Can't read transform_interface");
+
+    Pose6d pose;
+    bool transform_available = parsePose(node, pose);
+    if (transform_available)
+    {
+      temp_parameters.angle_axis[0] = pose.ax;
+      temp_parameters.angle_axis[1] = pose.ay;
+      temp_parameters.angle_axis[2] = pose.az;
+      temp_parameters.position[0] = pose.x;
+      temp_parameters.position[1] = pose.y;
+      temp_parameters.position[2] = pose.z;
+    }
+    ROSCameraObserver camera_observer(temp_topic, temp_name);
+    if (!camera_observer.pullCameraInfo(temp_parameters.focal_length_x, temp_parameters.focal_length_y,
+                                        temp_parameters.center_x, temp_parameters.center_y,
+                                        temp_parameters.distortion_k1, temp_parameters.distortion_k2,
+                                        temp_parameters.distortion_k3, temp_parameters.distortion_p1,
+                                        temp_parameters.distortion_p2, temp_parameters.width, temp_parameters.height))
+    {
+      ROS_WARN("Could not get camera info from topic, attempting to parse parameters from yaml file.");
+      if (!parseDouble(node, "focal_length_x", temp_parameters.focal_length_x)) ROS_ERROR("Can't read focal_length_x");
+      if (!parseDouble(node, "focal_length_y", temp_parameters.focal_length_y)) ROS_ERROR("Can't read focal_length_y");
+      if (!parseDouble(node, "center_x", temp_parameters.center_x)) ROS_ERROR("Can't read center_x");
+      if (!parseDouble(node, "center_y", temp_parameters.center_y)) ROS_ERROR("Can't read center_y");
+      if (!parseDouble(node, "distortion_k1", temp_parameters.distortion_k1)) ROS_ERROR("Can't read distortion_k1");
+      if (!parseDouble(node, "distortion_k2", temp_parameters.distortion_k2)) ROS_ERROR("Can't read distortion_k2");
+      if (!parseDouble(node, "distortion_k3", temp_parameters.distortion_k3)) ROS_ERROR("Can't read distortion_k2");
+      if (!parseDouble(node, "distortion_p1", temp_parameters.distortion_p1)) ROS_ERROR("Can't read distortion_p1");
+      if (!parseDouble(node, "distortion_p2", temp_parameters.distortion_p2)) ROS_ERROR("Can't read distortion_p2");
+      if (!parseInt(node, "image_height", temp_parameters.height)) ROS_ERROR("Can't read image_height");
+      if (!parseInt(node, "image_width", temp_parameters.width)) ROS_ERROR("Can't read image_width");
+    }
+
+    // create a shared camera and a shared transform interface
+    temp_camera = boost::make_shared< Camera >(temp_name, temp_parameters, false);
+    temp_camera->trigger_ = parseTrigger(node, trigger_name);
+    shared_ptr< TransformInterface > temp_ti =
+        parseTransformInterface(node, transform_interface, camera_optical_frame, pose);
+    temp_camera->setTransformInterface(temp_ti);  // install the transform interface
+    if (transform_available)
+    {
+      ros::Duration(0.25).sleep();  // wait for listeners to wake up
+      temp_camera->pushTransform();
+    }
+    else
+    {
+      temp_camera->pullTransform();
+    }
+    temp_camera->camera_observer_ = boost::make_shared< ROSCameraObserver >(temp_topic, temp_name);
+  }
+  catch (YAML::ParserException& e)
+  {
+    ROS_INFO_STREAM("Failed to read in moving cameras from yaml file ");
+    ROS_INFO_STREAM("camera name    = " << temp_camera->camera_name_.c_str());
+    ROS_INFO_STREAM("angle_axis_ax  = " << temp_camera->camera_parameters_.angle_axis[0]);
+    ROS_INFO_STREAM("angle_axis_ay  = " << temp_camera->camera_parameters_.angle_axis[1]);
+    ROS_INFO_STREAM("angle_axis_az  = " << temp_camera->camera_parameters_.angle_axis[2]);
+    ROS_INFO_STREAM("position_x     = " << temp_camera->camera_parameters_.position[0]);
+    ROS_INFO_STREAM("position_y     = " << temp_camera->camera_parameters_.position[1]);
+    ROS_INFO_STREAM("position_z     = " << temp_camera->camera_parameters_.position[2]);
+    ROS_INFO_STREAM("focal_length_x = " << temp_camera->camera_parameters_.focal_length_x);
+    ROS_INFO_STREAM("focal_length_y = " << temp_camera->camera_parameters_.focal_length_y);
+    ROS_INFO_STREAM("center_x       = " << temp_camera->camera_parameters_.center_x);
+    ROS_INFO_STREAM("center_y       = " << temp_camera->camera_parameters_.center_y);
+  }
+  return (temp_camera);
+}
+
+shared_ptr< Trigger > parseTrigger(const Node& node, string& name)
+{
+  shared_ptr< Trigger > temp_trigger;
+  std::string trig_param;
+  std::string trig_action_server;
+  std::string trig_action_msg;
+  // handle all the different trigger cases
+  if (name == string("NO_WAIT_TRIGGER"))
+  {
+    temp_trigger = boost::make_shared< NoWaitTrigger >();
+  }
+  else if (name == string("ROS_PARAM_TRIGGER"))
+  {
+    if (!parseString(node, "trig_param", trig_param)) ROS_ERROR("Can't read trig_param");
+    temp_trigger = boost::make_shared< ROSParamTrigger >(trig_param);
+  }
+  else if (name == string("ROS_ACTION_TRIGGER"))
+  {
+    if (!parseString(node, "trig_action_server", trig_action_server)) ROS_ERROR("Can't read trig_action_server");
+    if (!parseString(node, "trig_action_msg", trig_action_msg)) ROS_ERROR("Can't read trig_action_msg");
+    temp_trigger = boost::make_shared< ROSActionServerTrigger >(trig_action_server, trig_action_msg);
+  }
+  else if (name == string("ROS_ROBOT_JOINT_VALUES_ACTION_TRIGGER"))
+  {
+    if (!parseString(node, "trig_action_server", trig_action_server)) ROS_ERROR("Can't read trig_action_server");
+    std::vector< double > joint_values;
+    if (!parseVectorD(node, "joint_values", joint_values)) ROS_ERROR("Can't read joint_values");
+    if (joint_values.size() < 0)
+    {
+      ROS_ERROR("Couldn't read joint_values for ROS_ROBOT_JOINT_VALUES_ACTION_TRIGGER");
+    }
+    temp_trigger = boost::make_shared< ROSRobotJointValuesActionServerTrigger >(trig_action_server, joint_values);
+  }
+  else if (name == string("ROS_ROBOT_POSE_ACTION_TRIGGER"))
+  {
+    const YAML::Node& trig_node = parseNode(node, "trigger_parameters");
+    if (!parseString(trig_node[0], "trig_action_server", trig_action_server))
+      ROS_ERROR("Can't read trig_action_server");
+    Pose6d pose;
+    parsePose(trig_node, pose);
+    temp_trigger = boost::make_shared< ROSRobotPoseActionServerTrigger >(trig_action_server, pose);
+  }
+  else if (name == string("ROS_CAMERA_OBSERVER_TRIGGER"))
+  {
+    const YAML::Node& trig_node = parseNode(node, "trigger_parameters");
+    Roi roi;
+    std::string service_name;
+    std::string instructions;
+    std::string image_topic;
+    if (!parseString(trig_node[0], "service_name", service_name)) ROS_ERROR("Can't read service_name");
+    if (!parseString(trig_node[0], "instructions", instructions)) ROS_ERROR("Can't read instructions");
+    if (!parseString(trig_node[0], "image_topic", image_topic)) ROS_ERROR("Can't read image_topic");
+    if (!parseInt(trig_node[0], "roi_min_x", roi.x_min)) ROS_ERROR("Can't read roi_min_x");
+    if (!parseInt(trig_node[0], "roi_max_x", roi.x_max)) ROS_ERROR("Can't read roi_max_x");
+    if (!parseInt(trig_node[0], "roi_min_y", roi.y_min)) ROS_ERROR("Can't read roi_min_y");
+    if (!parseInt(trig_node[0], "roi_max_y", roi.y_max)) ROS_ERROR("Can't read roi_max_y");
+    temp_trigger = boost::make_shared< ROSCameraObserverTrigger >(service_name, instructions, image_topic, roi);
+  }
+  else
+  {
+    ROS_ERROR("No scene trigger of type %s", name.c_str());
+  }
+  return (temp_trigger);
+}
+
+shared_ptr< TransformInterface > parseTransformInterface(const Node& node, std::string& name, std::string& frame,
+                                                         Pose6d& pose)
+{
+  shared_ptr< TransformInterface > temp_ti;
+  std::string camera_housing_frame;
+  std::string camera_mounting_frame;
+  if (name == std::string("ros_lti"))
+  {  // this option makes no sense for a camera
+    temp_ti = boost::make_shared< ROSListenerTransInterface >(frame);
+  }
+  else if (name == std::string("ros_bti"))
+  {  // this option makes no sense for a camera
+    temp_ti = boost::make_shared< ROSBroadcastTransInterface >(frame);
+  }
+  else if (name == std::string("ros_camera_lti"))
+  {
+    temp_ti = boost::make_shared< ROSCameraListenerTransInterface >(frame);
+  }
+  else if (name == std::string("ros_camera_bti"))
+  {
+    temp_ti = boost::make_shared< ROSCameraBroadcastTransInterface >(frame);
+  }
+  else if (name == std::string("ros_camera_housing_lti"))
+  {
+    if (!parseString(node, "camera_housing_frame", camera_housing_frame)) ROS_ERROR("Can't read camera_housing_frame");
+    temp_ti = boost::make_shared< ROSCameraHousingListenerTInterface >(frame, camera_housing_frame);
+  }
+  else if (name == std::string("ros_camera_housing_bti"))
+  {
+    if (!parseString(node, "camera_housing_frame", camera_housing_frame)) ROS_ERROR("Can't read camera_housing_frame");
+    if (!parseString(node, "camera_mounting_frame", camera_mounting_frame))
+      ROS_ERROR("Can't read camera_mounting_frame");
+    temp_ti = boost::make_shared< ROSCameraHousingBroadcastTInterface >(frame, camera_housing_frame,
+                                                                        camera_mounting_frame, pose);
+  }
+  else if (name == std::string("ros_camera_housing_cti"))
+  {
+    if (!parseString(node, "camera_housing_frame", camera_housing_frame)) ROS_ERROR("Can't read camera_housing_frame");
+    if (!parseString(node, "camera_mounting_frame", camera_mounting_frame))
+      ROS_ERROR("Can't read camera_mounting_frame");
+    temp_ti = boost::make_shared< ROSCameraHousingCalTInterface >(frame, camera_housing_frame, camera_mounting_frame);
+  }
+  else if (name == std::string("ros_scti"))
+  {
+    if (!parseString(node, "parent_frame", camera_mounting_frame)) ROS_ERROR("Can't read parent_frame");
+    temp_ti = boost::make_shared< ROSSimpleCalTInterface >(frame, camera_mounting_frame);
+  }
+  else if (name == std::string("ros_camera_scti"))
+  {
+    if (!parseString(node, "parent_frame", camera_mounting_frame)) ROS_ERROR("Can't read parent_frame");
+    temp_ti = boost::make_shared< ROSSimpleCameraCalTInterface >(frame, camera_mounting_frame);
+  }
+  else if (name == std::string("default_ti"))
+  {
+    temp_ti = boost::make_shared< DefaultTransformInterface >();
+  }
+  else
+  {
+    ROS_ERROR("Unimplemented Transform Interface: %s", name.c_str());
+    temp_ti = boost::make_shared< DefaultTransformInterface >();
+  }
+  return (temp_ti);
+}
+
+bool parsePose(const Node& node, Pose6d& pose)
+{
+  bool rtn = true;
+  std::vector< double > temp_values;
+  if (parseVectorD(node, "xyz_quat_pose", temp_values))
+  {
+    if (temp_values.size() == 7)
+    {
+      pose.x = temp_values[0];
+      pose.y = temp_values[1];
+      pose.z = temp_values[2];
+      pose.setQuaternion(temp_values[3], temp_values[4], temp_values[5], temp_values[6]);
+    }  // got 7 values
+    else
+    {  // not 7 values
+      ROS_ERROR("did not read xyz_quat_pose correctly, %d values, 7 required", (int)temp_values.size());
+      rtn = false;
+    }  // right number of values
+  }    // "xyz_quat_pose" exists in yaml node
+  else if (parseVectorD(node, "xyz_aaxis_pose", temp_values))
+  {
+    if (temp_values.size() == 6)
+    {
+      pose.x = temp_values[0];
+      pose.y = temp_values[1];
+      pose.z = temp_values[2];
+      pose.setAngleAxis(temp_values[3], temp_values[4], temp_values[5]);
+    }  // got 6 values
+    else
+    {  // can't find xyz_aaxis_pose
+      ROS_ERROR("did not read xyz_aaxis_pose correctly, %d values, 6 required v[0] = %lf", (int)temp_values.size(),
+                temp_values[0]);
       rtn = false;
     }
-    return(rtn);
   }
-  shared_ptr<Camera> parseSingleCamera(const Node &node)
-  {
-    shared_ptr<Camera> temp_camera;
-    try{
-      string temp_name, temp_topic, camera_optical_frame, camera_housing_frame, camera_mounting_frame, parent_frame;
-      string trigger_name, transform_interface;
-      CameraParameters temp_parameters;
-      if(!parseString(node, "camera_name", temp_name)) ROS_ERROR("Can't read camera_name");
-      if(!parseString(node, "trigger", trigger_name)) ROS_ERROR("Can't read trigger");
-      if(!parseString(node, "image_topic", temp_topic)) ROS_ERROR("Can't read image_topic");
-      if(!parseString(node, "camera_optical_frame", camera_optical_frame)) ROS_ERROR("Can't read camera_optical_frame");
-      if(!parseString(node, "transform_interface", transform_interface)) ROS_ERROR("Can't read transform_interface");
+  else
+  {  // cant read xyz_aaxis either
+    rtn = false;
+  }
+  return rtn;
+}
 
-      Pose6d pose;
-      bool transform_available = parsePose(node, pose);
-      if(transform_available){
-	temp_parameters.angle_axis[0] = pose.ax;
-	temp_parameters.angle_axis[1] = pose.ay;
-	temp_parameters.angle_axis[2] = pose.az;
-	temp_parameters.position[0] = pose.x;
-	temp_parameters.position[1] = pose.y;
-	temp_parameters.position[2] = pose.z;
-      }
-      ROSCameraObserver camera_observer(temp_topic, temp_name);
-      if(!camera_observer.pullCameraInfo(temp_parameters.focal_length_x, temp_parameters.focal_length_y, temp_parameters.center_x,
-                                         temp_parameters.center_y, temp_parameters.distortion_k1, temp_parameters.distortion_k2,
-                                         temp_parameters.distortion_k3, temp_parameters.distortion_p1, temp_parameters.distortion_p2,
-                                         temp_parameters.width, temp_parameters.height))
-      {
-        ROS_WARN("Could not get camera info from topic, attempting to parse parameters from yaml file.");
-        if(!parseDouble(node, "focal_length_x", temp_parameters.focal_length_x)) ROS_ERROR("Can't read focal_length_x");
-        if(!parseDouble(node, "focal_length_y", temp_parameters.focal_length_y)) ROS_ERROR("Can't read focal_length_y");
-        if(!parseDouble(node, "center_x", temp_parameters.center_x)) ROS_ERROR("Can't read center_x");
-        if(!parseDouble(node, "center_y", temp_parameters.center_y)) ROS_ERROR("Can't read center_y");
-        if(!parseDouble(node, "distortion_k1", temp_parameters.distortion_k1)) ROS_ERROR("Can't read distortion_k1");
-        if(!parseDouble(node, "distortion_k2", temp_parameters.distortion_k2)) ROS_ERROR("Can't read distortion_k2");
-        if(!parseDouble(node, "distortion_k3", temp_parameters.distortion_k3)) ROS_ERROR("Can't read distortion_k2");
-        if(!parseDouble(node, "distortion_p1", temp_parameters.distortion_p1)) ROS_ERROR("Can't read distortion_p1");
-        if(!parseDouble(node, "distortion_p2", temp_parameters.distortion_p2)) ROS_ERROR("Can't read distortion_p2");
-        if(!parseInt(node, "image_height", temp_parameters.height)) ROS_ERROR("Can't read image_height");
-        if(!parseInt(node, "image_width", temp_parameters.width)) ROS_ERROR("Can't read image_width");
-      }
-    
-      // create a shared camera and a shared transform interface
-      temp_camera = boost::make_shared<Camera>(temp_name, temp_parameters, false);
-      temp_camera->trigger_ = parseTrigger(node, trigger_name);
-      shared_ptr<TransformInterface>  temp_ti = parseTransformInterface(node, transform_interface, camera_optical_frame, pose);
-      temp_camera->setTransformInterface(temp_ti);// install the transform interface 
-      if(transform_available){
-	ros::Duration(0.25).sleep(); // wait for listeners to wake up
-	temp_camera->pushTransform();
-      }
-      else{
-	temp_camera->pullTransform();
-      }
-      temp_camera->camera_observer_ = boost::make_shared<ROSCameraObserver>(temp_topic, temp_name);
-    }
-    catch (YAML::ParserException& e){
-      ROS_INFO_STREAM("Failed to read in moving cameras from yaml file ");
-      ROS_INFO_STREAM("camera name    = " << temp_camera->camera_name_.c_str());
-      ROS_INFO_STREAM("angle_axis_ax  = " << temp_camera->camera_parameters_.angle_axis[0]);
-      ROS_INFO_STREAM("angle_axis_ay  = " << temp_camera->camera_parameters_.angle_axis[1]);
-      ROS_INFO_STREAM("angle_axis_az  = " << temp_camera->camera_parameters_.angle_axis[2]);
-      ROS_INFO_STREAM("position_x     = " << temp_camera->camera_parameters_.position[0]);
-      ROS_INFO_STREAM("position_y     = " << temp_camera->camera_parameters_.position[1]);
-      ROS_INFO_STREAM("position_z     = " << temp_camera->camera_parameters_.position[2]);
-      ROS_INFO_STREAM("focal_length_x = " << temp_camera->camera_parameters_.focal_length_x);
-      ROS_INFO_STREAM("focal_length_y = " << temp_camera->camera_parameters_.focal_length_y);
-      ROS_INFO_STREAM("center_x       = " << temp_camera->camera_parameters_.center_x);
-      ROS_INFO_STREAM("center_y       = " << temp_camera->camera_parameters_.center_y);
-    }
-    return(temp_camera);
-  }
-  
-  shared_ptr<Trigger> parseTrigger(const Node &node, string &name)
-  {
-    shared_ptr<Trigger> temp_trigger;
-    std::string trig_param;
-    std::string trig_action_server;
-    std::string trig_action_msg;
-    // handle all the different trigger cases
-    if(name == string("NO_WAIT_TRIGGER")){
-      temp_trigger = boost::make_shared<NoWaitTrigger>();
-    }
-    else if(name == string("ROS_PARAM_TRIGGER")){
-      if(!parseString(node, "trig_param", trig_param)) ROS_ERROR("Can't read trig_param");
-      temp_trigger = boost::make_shared<ROSParamTrigger>(trig_param);
-    }
-    else if(name == string("ROS_ACTION_TRIGGER")){
-      if(!parseString(node, "trig_action_server", trig_action_server)) ROS_ERROR("Can't read trig_action_server");
-      if(!parseString(node, "trig_action_msg", trig_action_msg)) ROS_ERROR("Can't read trig_action_msg");
-      temp_trigger = boost::make_shared<ROSActionServerTrigger>(trig_action_server, trig_action_msg);
-    }
-    else if(name == string("ROS_ROBOT_JOINT_VALUES_ACTION_TRIGGER")){
-      if(!parseString(node, "trig_action_server", trig_action_server)) ROS_ERROR("Can't read trig_action_server");
-      std::vector<double>joint_values;
-      if(!parseVectorD(node, "joint_values", joint_values)) ROS_ERROR("Can't read joint_values");
-      if(joint_values.size()<0){
-	ROS_ERROR("Couldn't read joint_values for ROS_ROBOT_JOINT_VALUES_ACTION_TRIGGER");
-      }
-      temp_trigger = boost::make_shared<ROSRobotJointValuesActionServerTrigger>(trig_action_server, joint_values);
-    }
-    else if(name == string("ROS_ROBOT_POSE_ACTION_TRIGGER")){
-      const YAML::Node& trig_node = parseNode(node,"trigger_parameters");
-      if(!parseString(trig_node[0], "trig_action_server", trig_action_server)) ROS_ERROR("Can't read trig_action_server");
-      Pose6d pose;
-      parsePose(trig_node, pose);
-      temp_trigger = boost::make_shared<ROSRobotPoseActionServerTrigger>(trig_action_server, pose);
-    }
-    else if(name == string("ROS_CAMERA_OBSERVER_TRIGGER")){
-      const YAML::Node& trig_node = parseNode(node,"trigger_parameters");
-      Roi roi;
-      std::string service_name;
-      std::string instructions;
-      std::string image_topic;
-      if(!parseString(trig_node[0], "service_name", service_name)) ROS_ERROR("Can't read service_name");
-      if(!parseString(trig_node[0], "instructions", instructions)) ROS_ERROR("Can't read instructions");
-      if(!parseString(trig_node[0], "image_topic", image_topic)) ROS_ERROR("Can't read image_topic");
-      if(!parseInt(trig_node[0], "roi_min_x", roi.x_min)) ROS_ERROR("Can't read roi_min_x");
-      if(!parseInt(trig_node[0], "roi_max_x", roi.x_max)) ROS_ERROR("Can't read roi_max_x");
-      if(!parseInt(trig_node[0], "roi_min_y", roi.y_min)) ROS_ERROR("Can't read roi_min_y");
-      if(!parseInt(trig_node[0], "roi_max_y", roi.y_max)) ROS_ERROR("Can't read roi_max_y");
-      temp_trigger = boost::make_shared<ROSCameraObserverTrigger>(service_name, instructions, image_topic, roi);
-    }
-    else{
-      ROS_ERROR("No scene trigger of type %s", name.c_str());
-    }
-    return(temp_trigger);
-  }
-  
-  shared_ptr<TransformInterface> parseTransformInterface(const Node &node, std::string &name, std::string &frame, Pose6d &pose)
-  {
-    shared_ptr<TransformInterface> temp_ti;
-    std::string camera_housing_frame;
-    std::string camera_mounting_frame;
-    if(name == std::string("ros_lti")){ // this option makes no sense for a camera
-      temp_ti = boost::make_shared<ROSListenerTransInterface>(frame);
-    }
-    else if(name == std::string("ros_bti")){ // this option makes no sense for a camera
-      temp_ti = boost::make_shared<ROSBroadcastTransInterface>(frame);
-    }
-    else if(name == std::string("ros_camera_lti")){ 
-      temp_ti = boost::make_shared<ROSCameraListenerTransInterface>(frame);
-    }
-    else if(name == std::string("ros_camera_bti")){ 
-      temp_ti = boost::make_shared<ROSCameraBroadcastTransInterface>(frame);
-    }
-    else if(name == std::string("ros_camera_housing_lti")){ 
-      if(!parseString(node, "camera_housing_frame", camera_housing_frame)) ROS_ERROR("Can't read camera_housing_frame");
-      temp_ti = boost::make_shared<ROSCameraHousingListenerTInterface>(frame,camera_housing_frame);
-    }
-    else if(name == std::string("ros_camera_housing_bti")){ 
-      if(!parseString(node, "camera_housing_frame", camera_housing_frame)) ROS_ERROR("Can't read camera_housing_frame");
-      if(!parseString(node, "camera_mounting_frame", camera_mounting_frame)) ROS_ERROR("Can't read camera_mounting_frame");
-      temp_ti = boost::make_shared<ROSCameraHousingBroadcastTInterface>(frame,
-								 camera_housing_frame,
-								 camera_mounting_frame,
-								 pose);
-    }
-    else if(name == std::string("ros_camera_housing_cti")){ 
-      if(!parseString(node, "camera_housing_frame", camera_housing_frame)) ROS_ERROR("Can't read camera_housing_frame");
-      if(!parseString(node, "camera_mounting_frame", camera_mounting_frame)) ROS_ERROR("Can't read camera_mounting_frame");
-      temp_ti = boost::make_shared<ROSCameraHousingCalTInterface>(frame,
-							   camera_housing_frame,
-							   camera_mounting_frame);
-    }
-    else if(name == std::string("ros_scti")){ 
-      if(!parseString(node, "parent_frame", camera_mounting_frame)) ROS_ERROR("Can't read parent_frame");
-      temp_ti = boost::make_shared<ROSSimpleCalTInterface>(frame,  camera_mounting_frame);
-    }
-    else if(name == std::string("ros_camera_scti")){ 
-      if(!parseString(node, "parent_frame", camera_mounting_frame)) ROS_ERROR("Can't read parent_frame");
-      temp_ti = boost::make_shared<ROSSimpleCameraCalTInterface>(frame,  camera_mounting_frame);
-    }
-    else if(name == std::string("default_ti")){
-      temp_ti = boost::make_shared<DefaultTransformInterface>();
-    }
-    else{
-      ROS_ERROR("Unimplemented Transform Interface: %s",name.c_str());
-      temp_ti = boost::make_shared<DefaultTransformInterface>();
-    }
-    return(temp_ti);
-  }
-
-  bool parsePose(const Node &node, Pose6d &pose)
-  {
-    bool rtn = true;
-    std::vector<double> temp_values;
-    if(parseVectorD(node, "xyz_quat_pose", temp_values)){
-      if(temp_values.size() == 7){
-	pose.x = temp_values[0];
-	pose.y = temp_values[1];
-	pose.z = temp_values[2];
-	pose.setQuaternion(temp_values[3], temp_values[4], temp_values[5], temp_values[6]);
-      }// got 7 values
-      else{ // not 7 values
-	ROS_ERROR("did not read xyz_quat_pose correctly, %d values, 7 required", (int) temp_values.size());
-	rtn = false;
-      }// right number of values
-    }// "xyz_quat_pose" exists in yaml node
-    else if(parseVectorD(node, "xyz_aaxis_pose", temp_values)){
-      if(temp_values.size() == 6){     
-	pose.x = temp_values[0];
-	pose.y = temp_values[1];
-	pose.z = temp_values[2];
-	pose.setAngleAxis(temp_values[3], temp_values[4], temp_values[5]);
-      }// got 6 values
-      else{// can't find xyz_aaxis_pose
-	ROS_ERROR("did not read xyz_aaxis_pose correctly, %d values, 6 required v[0] = %lf", (int) temp_values.size(), temp_values[0]);
-	rtn = false;
-      }
-    }
-    else { // cant read xyz_aaxis either
-      rtn =false;
-    }
-    return rtn ;
-  }
-
-}// end of industrial_extrinsic_cal namespace
+}  // end of industrial_extrinsic_cal namespace

--- a/industrial_extrinsic_cal/src/camera_yaml_parser_indigo.cpp
+++ b/industrial_extrinsic_cal/src/camera_yaml_parser_indigo.cpp
@@ -20,194 +20,219 @@ using boost::shared_ptr;
 using boost::make_shared;
 using YAML::Node;
 
-namespace industrial_extrinsic_cal {
+namespace industrial_extrinsic_cal
+{
+void parseCameras(ifstream& cameras_input_file, vector< shared_ptr< Camera > >& cameras)
+{
+  Node camera_doc = YAML::LoadFile(cameras_input_file.c_str());
 
-  void parseCameras(ifstream &cameras_input_file,vector<shared_ptr<Camera> >& cameras)
+  // read in all static cameras
+  cameras.clear();
+  Node camera_parameters = camera_doc("static_cameras");
+  ROS_INFO_STREAM("Found " << camera_parameters.size() << " static cameras ");
+  for (unsigned int i = 0; i < camera_parameters.size(); i++)
   {
-    Node camera_doc = YAML::LoadFile(cameras_input_file.c_str());
-    
-    // read in all static cameras
-    cameras.clear();
-    Node camera_parameters = camera_doc("static_cameras");
-    ROS_INFO_STREAM("Found "<<camera_parameters.size()<<" static cameras ");
-    for (unsigned int i = 0; i < camera_parameters.size(); i++){
-      shared_ptr<Camera> temp_camera = parseSingleCamera(camera_parameters[i]);
-      cameras.push_back(temp_camera);
-    } // end if there are any cameras in file
+    shared_ptr< Camera > temp_camera = parseSingleCamera(camera_parameters[i]);
+    cameras.push_back(temp_camera);
+  }  // end if there are any cameras in file
 
-    // read in all moving cameras
-    camera_parameters = camera_doc("moving_cameras");
-    ROS_INFO_STREAM("Found "<<camera_parameters.size()<<" moving cameras ");
-    for (unsigned int i = 0; i < camera_parameters.size(); i++){
-      shared_ptr<Camera> temp_camera = parseSingleCamera(camera_parameters[i]);
-      temp_camera->is_moving_ = true;
-      cameras.push_back(temp_camera);
-    }
-    ROS_INFO_STREAM("Successfully read in " << (int) cameras.size() << " cameras");
+  // read in all moving cameras
+  camera_parameters = camera_doc("moving_cameras");
+  ROS_INFO_STREAM("Found " << camera_parameters.size() << " moving cameras ");
+  for (unsigned int i = 0; i < camera_parameters.size(); i++)
+  {
+    shared_ptr< Camera > temp_camera = parseSingleCamera(camera_parameters[i]);
+    temp_camera->is_moving_ = true;
+    cameras.push_back(temp_camera);
   }
+  ROS_INFO_STREAM("Successfully read in " << (int)cameras.size() << " cameras");
+}
 
-  shared_ptr<Camera> parseSingleCamera(const Node &node)
+shared_ptr< Camera > parseSingleCamera(const Node& node)
+{
+  shared_ptr< Camera > temp_camera;
+  try
   {
-    shared_ptr<Camera> temp_camera;
-    try{
-      string temp_name, temp_topic, camera_optical_frame, camera_housing_frame, camera_mounting_frame, parent_frame;
-      string trigger_name, transform_interface;
-      CameraParameters temp_parameters;
-      temp_name = node["camera_name"].as<std::string>();
-      trigger_name = node["trigger"].as<std::string>();
-      temp_topic = node["image_topic"].as<std::string>();
-      camera_optical_frame                = node["camera_optical_frame"].as<std::string>();
-      transform_interface                    = node["transform_interface"] .as<std::string()>();
-      temp_parameters.angle_axis[0]  = node["angle_axis_ax"].as<double>();
-      temp_parameters.angle_axis[1]  = node["angle_axis_ay"].as<double>();
-      temp_parameters.angle_axis[2]  = node["angle_axis_az"].as<double>();
-      temp_parameters.position[0]      = node["position_x"] .as<double>();
-      temp_parameters.position[1]      = node["position_y"] .as<double>();
-      temp_parameters.position[2]      = node["position_z"] .as<double>();
-      temp_parameters.focal_length_x = node["focal_length_x"] .as<double>();
-      temp_parameters.focal_length_y = node["focal_length_y"] .as<double>();
-      temp_parameters.center_x          = node["center_x"] .as<double>();
-      temp_parameters.center_y          = node["center_y"] .as<double>();
-      temp_parameters.distortion_k1   = node["distortion_k1"] .as<double>();
-      temp_parameters.distortion_k2  = node["distortion_k2"] .as<double>();
-      temp_parameters.distortion_k3  = node["distortion_k3"] .as<double>();
-      temp_parameters.distortion_p1  = node["distortion_p1"] .as<double>();
-      temp_parameters.distortion_p2  = node["distortion_p2"] .as<double>();
-      temp_parameters.height            = node["image_height"] .as<double>();
-      temp_parameters.width             = node["image_width"] .as<double>();
-      Pose6d pose(temp_parameters.position[0],temp_parameters.position[1],temp_parameters.position[2],
-		  temp_parameters.angle_axis[0],temp_parameters.angle_axis[1],temp_parameters.angle_axis[2]);
-    
-      // create a shared camera and a shared transform interface
-      temp_camera = make_shared<Camera>(temp_name, temp_parameters, false);
-      temp_camera->trigger_ = parseTrigger(node, trigger_name);
-      shared_ptr<TransformInterface>  temp_ti = parseTransformInterface(node, transform_interface, camera_optical_frame);
-      temp_camera->setTransformInterface(temp_ti);// install the transform interface 
-      temp_camera->camera_observer_ = make_shared<ROSCameraObserver>(temp_topic);
-    }
-    catch (YAML::ParserException& e){
-      ROS_INFO_STREAM("Failed to read in moving cameras from yaml file ");
-      ROS_INFO_STREAM("camera name    = " << temp_camera->camera_name_.c_str());
-      ROS_INFO_STREAM("angle_axis_ax  = " << temp_camera->camera_parameters_.angle_axis[0]);
-      ROS_INFO_STREAM("angle_axis_ay  = " << temp_camera->camera_parameters_.angle_axis[1]);
-      ROS_INFO_STREAM("angle_axis_az  = " << temp_camera->camera_parameters_.angle_axis[2]);
-      ROS_INFO_STREAM("position_x     = " << temp_camera->camera_parameters_.position[0]);
-      ROS_INFO_STREAM("position_y     = " << temp_camera->camera_parameters_.position[1]);
-      ROS_INFO_STREAM("position_z     = " << temp_camera->camera_parameters_.position[2]);
-      ROS_INFO_STREAM("focal_length_x = " << temp_camera->camera_parameters_.focal_length_x);
-      ROS_INFO_STREAM("focal_length_y = " << temp_camera->camera_parameters_.focal_length_y);
-      ROS_INFO_STREAM("center_x       = " << temp_camera->camera_parameters_.center_x);
-      ROS_INFO_STREAM("center_y       = " << temp_camera->camera_parameters_.center_y);
-    }
-    return(temp_camera);
-  }
-  
-  shared_ptr<Trigger> parseTrigger(const Node &node, string &name)
-  {
-    shared_ptr<Trigger> temp_trigger;
-    std::string trig_param;
-    std::string trig_action_server;
-    std::string trig_action_msg;
-    // handle all the different trigger cases
-    if(name == string("NO_WAIT_TRIGGER")){
-      temp_trigger = make_shared<NoWaitTrigger>();
-    }
-    else if(name == string("ROS_PARAM_TRIGGER")){
-      trig_param = node["trig_param"].at<std::string>();
-      temp_trigger = make_shared<ROSParamTrigger>(trig_param);
-    }
-    else if(name == string("ROS_ACTION_TRIGGER")){
-      trig_action_server = node["trig_action_server"] .at<std::string>();
-      trig_action_msg = node["trig_action_msg"] .at<std::string>();
-      temp_trigger = make_shared<ROSActionServerTrigger>(trig_action_server, trig_action_msg);
-    }
-    else if(name == string("ROS_ROBOT_JOINT_VALUES_ACTION_TRIGGER")){
-      trig_action_server = node["trig_action_server"] .at<std::string>();
-      std::vector<double>joint_values;
-      joint_values = node["joint_values"].at<double>();
-      if(joint_values.size()<0){
-	ROS_ERROR("Couldn't read joint_values for ROS_ROBOT_JOINT_VALUES_ACTION_TRIGGER");
-      }
-      temp_trigger = make_shared<ROSRobotJointValuesActionServerTrigger>(trig_action_server, joint_values);
-    }
-    else if(name == string("ROS_ROBOT_POSE_ACTION_TRIGGER")){
-      trig_action_server = node["trig_action_server"] .at<std::string>();
-      Pose6d pose = parsePose(node);
-      temp_trigger = make_shared<ROSRobotPoseActionServerTrigger>(trig_action_server, pose);
-    }
-    else{
-      ROS_ERROR("No scene trigger of type %s", name.c_str());
-    }
-    return(temp_trigger);
-  }
-  
-  shared_ptr<TransformInterface> parseTransformInterface(const Node &node, std::string &name, std::string &frame)
-  {
-    shared_ptr<TransformInterface> temp_ti;
-    std::string camera_housing_frame;
-    std::string camera_mounting_frame;
-    if(name == std::string("ros_lti")){ // this option makes no sense for a camera
-      temp_ti = make_shared<ROSListenerTransInterface>(frame);
-    }
-    else if(name == std::string("ros_bti")){ // this option makes no sense for a camera
-      Pose6d pose = parsePose(node);
-      temp_ti = make_shared<ROSBroadcastTransInterface>(frame, pose);
-    }
-    else if(name == std::string("ros_camera_lti")){ 
-      temp_ti = make_shared<ROSCameraListenerTransInterface>(frame);
-    }
-    else if(name == std::string("ros_camera_bti")){ 
-      Pose6d pose = parsePose(node);
-      temp_ti = make_shared<ROSCameraBroadcastTransInterface>(frame, pose);
-    }
-    else if(name == std::string("ros_camera_housing_lti")){ 
-      camera_housing_frame = node["camera_housing_frame"] .at<std::string>();
-      temp_ti = make_shared<ROSCameraHousingListenerTInterface>(frame,camera_housing_frame);
-    }
-    else if(name == std::string("ros_camera_housing_bti")){ 
-      Pose6d pose = parsePose(node);
-      camera_housing_frame; = node["camera_housing_frame"] .at<std::string>();
-      temp_ti = make_shared<ROSCameraHousingBroadcastTInterface>(frame,  pose);
-    }
-    else if(name == std::string("ros_camera_housing_cti")){ 
-      camera_housing_frame; = node["camera_housing_frame"] .at<std::string>();
-      camera_mounting_frame; = node["camera_mounting_frame"] .at<std::string>();
-      temp_ti = make_shared<ROSCameraHousingCalTInterface>(frame, 
-							   camera_housing_frame,
-							   camera_mounting_frame);
-    }
-    else if(name == std::string("ros_scti")){ 
-      camera_mounting_frame; = node["parent_frame"] .at<std::string>();
-      temp_ti = make_shared<ROSSimpleCalTInterface>(frame,  camera_mounting_frame);
-    }
-    else if(name == std::string("ros_camera_scti")){ 
-      camera_mounting_frame; = node["parent_frame"] .at<std::string>();
-      temp_ti = make_shared<ROSSimpleCameraCalTInterface>(frame,  camera_mounting_frame);
-    }
-    else if(name == std::string("default_ti")){
-      Pose6d pose = parsePose(node);
-      temp_ti = make_shared<DefaultTransformInterface>(pose);
-    }
-    else{
-      Pose6d pose;
-      ROS_ERROR("Unimplemented Transform Interface: %s",name.c_str());
-      temp_ti = make_shared<DefaultTransformInterface>(pose);
-    }
-    return(temp_ti);
-  }
+    string temp_name, temp_topic, camera_optical_frame, camera_housing_frame, camera_mounting_frame, parent_frame;
+    string trigger_name, transform_interface;
+    CameraParameters temp_parameters;
+    temp_name = node["camera_name"].as< std::string >();
+    trigger_name = node["trigger"].as< std::string >();
+    temp_topic = node["image_topic"].as< std::string >();
+    camera_optical_frame = node["camera_optical_frame"].as< std::string >();
+    transform_interface = node["transform_interface"].as< std::string() >();
+    temp_parameters.angle_axis[0] = node["angle_axis_ax"].as< double >();
+    temp_parameters.angle_axis[1] = node["angle_axis_ay"].as< double >();
+    temp_parameters.angle_axis[2] = node["angle_axis_az"].as< double >();
+    temp_parameters.position[0] = node["position_x"].as< double >();
+    temp_parameters.position[1] = node["position_y"].as< double >();
+    temp_parameters.position[2] = node["position_z"].as< double >();
+    temp_parameters.focal_length_x = node["focal_length_x"].as< double >();
+    temp_parameters.focal_length_y = node["focal_length_y"].as< double >();
+    temp_parameters.center_x = node["center_x"].as< double >();
+    temp_parameters.center_y = node["center_y"].as< double >();
+    temp_parameters.distortion_k1 = node["distortion_k1"].as< double >();
+    temp_parameters.distortion_k2 = node["distortion_k2"].as< double >();
+    temp_parameters.distortion_k3 = node["distortion_k3"].as< double >();
+    temp_parameters.distortion_p1 = node["distortion_p1"].as< double >();
+    temp_parameters.distortion_p2 = node["distortion_p2"].as< double >();
+    temp_parameters.height = node["image_height"].as< double >();
+    temp_parameters.width = node["image_width"].as< double >();
+    Pose6d pose(temp_parameters.position[0], temp_parameters.position[1], temp_parameters.position[2],
+                temp_parameters.angle_axis[0], temp_parameters.angle_axis[1], temp_parameters.angle_axis[2]);
 
-  Pose6d parsePose(const Node &node)
+    // create a shared camera and a shared transform interface
+    temp_camera = make_shared< Camera >(temp_name, temp_parameters, false);
+    temp_camera->trigger_ = parseTrigger(node, trigger_name);
+    shared_ptr< TransformInterface > temp_ti = parseTransformInterface(node, transform_interface, camera_optical_frame);
+    temp_camera->setTransformInterface(temp_ti);  // install the transform interface
+    temp_camera->camera_observer_ = make_shared< ROSCameraObserver >(temp_topic);
+  }
+  catch (YAML::ParserException& e)
+  {
+    ROS_INFO_STREAM("Failed to read in moving cameras from yaml file ");
+    ROS_INFO_STREAM("camera name    = " << temp_camera->camera_name_.c_str());
+    ROS_INFO_STREAM("angle_axis_ax  = " << temp_camera->camera_parameters_.angle_axis[0]);
+    ROS_INFO_STREAM("angle_axis_ay  = " << temp_camera->camera_parameters_.angle_axis[1]);
+    ROS_INFO_STREAM("angle_axis_az  = " << temp_camera->camera_parameters_.angle_axis[2]);
+    ROS_INFO_STREAM("position_x     = " << temp_camera->camera_parameters_.position[0]);
+    ROS_INFO_STREAM("position_y     = " << temp_camera->camera_parameters_.position[1]);
+    ROS_INFO_STREAM("position_z     = " << temp_camera->camera_parameters_.position[2]);
+    ROS_INFO_STREAM("focal_length_x = " << temp_camera->camera_parameters_.focal_length_x);
+    ROS_INFO_STREAM("focal_length_y = " << temp_camera->camera_parameters_.focal_length_y);
+    ROS_INFO_STREAM("center_x       = " << temp_camera->camera_parameters_.center_x);
+    ROS_INFO_STREAM("center_y       = " << temp_camera->camera_parameters_.center_y);
+  }
+  return (temp_camera);
+}
+
+shared_ptr< Trigger > parseTrigger(const Node& node, string& name)
+{
+  shared_ptr< Trigger > temp_trigger;
+  std::string trig_param;
+  std::string trig_action_server;
+  std::string trig_action_msg;
+  // handle all the different trigger cases
+  if (name == string("NO_WAIT_TRIGGER"))
+  {
+    temp_trigger = make_shared< NoWaitTrigger >();
+  }
+  else if (name == string("ROS_PARAM_TRIGGER"))
+  {
+    trig_param = node["trig_param"].at< std::string >();
+    temp_trigger = make_shared< ROSParamTrigger >(trig_param);
+  }
+  else if (name == string("ROS_ACTION_TRIGGER"))
+  {
+    trig_action_server = node["trig_action_server"].at< std::string >();
+    trig_action_msg = node["trig_action_msg"].at< std::string >();
+    temp_trigger = make_shared< ROSActionServerTrigger >(trig_action_server, trig_action_msg);
+  }
+  else if (name == string("ROS_ROBOT_JOINT_VALUES_ACTION_TRIGGER"))
+  {
+    trig_action_server = node["trig_action_server"].at< std::string >();
+    std::vector< double > joint_values;
+    joint_values = node["joint_values"].at< double >();
+    if (joint_values.size() < 0)
+    {
+      ROS_ERROR("Couldn't read joint_values for ROS_ROBOT_JOINT_VALUES_ACTION_TRIGGER");
+    }
+    temp_trigger = make_shared< ROSRobotJointValuesActionServerTrigger >(trig_action_server, joint_values);
+  }
+  else if (name == string("ROS_ROBOT_POSE_ACTION_TRIGGER"))
+  {
+    trig_action_server = node["trig_action_server"].at< std::string >();
+    Pose6d pose = parsePose(node);
+    temp_trigger = make_shared< ROSRobotPoseActionServerTrigger >(trig_action_server, pose);
+  }
+  else
+  {
+    ROS_ERROR("No scene trigger of type %s", name.c_str());
+  }
+  return (temp_trigger);
+}
+
+shared_ptr< TransformInterface > parseTransformInterface(const Node& node, std::string& name, std::string& frame)
+{
+  shared_ptr< TransformInterface > temp_ti;
+  std::string camera_housing_frame;
+  std::string camera_mounting_frame;
+  if (name == std::string("ros_lti"))
+  {  // this option makes no sense for a camera
+    temp_ti = make_shared< ROSListenerTransInterface >(frame);
+  }
+  else if (name == std::string("ros_bti"))
+  {  // this option makes no sense for a camera
+    Pose6d pose = parsePose(node);
+    temp_ti = make_shared< ROSBroadcastTransInterface >(frame, pose);
+  }
+  else if (name == std::string("ros_camera_lti"))
+  {
+    temp_ti = make_shared< ROSCameraListenerTransInterface >(frame);
+  }
+  else if (name == std::string("ros_camera_bti"))
+  {
+    Pose6d pose = parsePose(node);
+    temp_ti = make_shared< ROSCameraBroadcastTransInterface >(frame, pose);
+  }
+  else if (name == std::string("ros_camera_housing_lti"))
+  {
+    camera_housing_frame = node["camera_housing_frame"].at< std::string >();
+    temp_ti = make_shared< ROSCameraHousingListenerTInterface >(frame, camera_housing_frame);
+  }
+  else if (name == std::string("ros_camera_housing_bti"))
+  {
+    Pose6d pose = parsePose(node);
+    camera_housing_frame;
+    = node["camera_housing_frame"].at< std::string >();
+    temp_ti = make_shared< ROSCameraHousingBroadcastTInterface >(frame, pose);
+  }
+  else if (name == std::string("ros_camera_housing_cti"))
+  {
+    camera_housing_frame;
+    = node["camera_housing_frame"].at< std::string >();
+    camera_mounting_frame;
+    = node["camera_mounting_frame"].at< std::string >();
+    temp_ti = make_shared< ROSCameraHousingCalTInterface >(frame, camera_housing_frame, camera_mounting_frame);
+  }
+  else if (name == std::string("ros_scti"))
+  {
+    camera_mounting_frame;
+    = node["parent_frame"].at< std::string >();
+    temp_ti = make_shared< ROSSimpleCalTInterface >(frame, camera_mounting_frame);
+  }
+  else if (name == std::string("ros_camera_scti"))
+  {
+    camera_mounting_frame;
+    = node["parent_frame"].at< std::string >();
+    temp_ti = make_shared< ROSSimpleCameraCalTInterface >(frame, camera_mounting_frame);
+  }
+  else if (name == std::string("default_ti"))
+  {
+    Pose6d pose = parsePose(node);
+    temp_ti = make_shared< DefaultTransformInterface >(pose);
+  }
+  else
   {
     Pose6d pose;
-    pose.x =ode["pose"][0].at<double>();
-    pose.y =ode["pose"][1].at<double>();
-    pose.z =ode["pose"][2].at<double>();
-    double qx,qy,qz,qw;
-    qx =ode["pose"][3].at<double>();
-    qy =ode["pose"][4].at<double>();
-    qz =ode["pose"][5].at<double>();
-    qw =ode["pose"][6].at<double>();
-    pose.setQuaternion(qx, qy, qz, qw);
-    return(pose);
+    ROS_ERROR("Unimplemented Transform Interface: %s", name.c_str());
+    temp_ti = make_shared< DefaultTransformInterface >(pose);
   }
-}// end of industrial_extrinsic_cal namespace
+  return (temp_ti);
+}
+
+Pose6d parsePose(const Node& node)
+{
+  Pose6d pose;
+  pose.x = ode["pose"][0].at< double >();
+  pose.y = ode["pose"][1].at< double >();
+  pose.z = ode["pose"][2].at< double >();
+  double qx, qy, qz, qw;
+  qx = ode["pose"][3].at< double >();
+  qy = ode["pose"][4].at< double >();
+  qz = ode["pose"][5].at< double >();
+  qw = ode["pose"][6].at< double >();
+  pose.setQuaternion(qx, qy, qz, qw);
+  return (pose);
+}
+}  // end of industrial_extrinsic_cal namespace

--- a/industrial_extrinsic_cal/src/ceres_blocks.cpp
+++ b/industrial_extrinsic_cal/src/ceres_blocks.cpp
@@ -16,7 +16,6 @@
  * limitations under the License.
  */
 
-
 #include <industrial_extrinsic_cal/ceres_blocks.h>
 #include <boost/shared_ptr.hpp>
 
@@ -25,63 +24,60 @@ using boost::shared_ptr;
 
 namespace industrial_extrinsic_cal
 {
+void showPose(Pose6d pose, std::string message)
+{
+  tf::Matrix3x3 basis = pose.getBasis();
+  double ez_yaw, ey_pitch, ex_roll;
+  double qx, qy, qz, qw;
+  pose.getEulerZYX(ez_yaw, ey_pitch, ex_roll);
+  pose.getQuaternion(qx, qy, qz, qw);
+  ROS_INFO("%s =[\n %6.3lf  %6.3lf  %6.3lf  %6.3lf\n  %6.3lf  %6.3lf  %6.3lf  %6.3lf\n  %6.3lf  %6.3lf %6.3lf  "
+           "%6.3lf\n  %6.3lf  %6.3lf %6.3lf  %6.3lf];\n rpy= %lf %lf %lf\n quat= %6.3lf %6.3lf %6.3lf %6.3lf ",
+           message.c_str(), basis[0][0], basis[0][1], basis[0][2], pose.x, basis[1][0], basis[1][1], basis[1][2],
+           pose.y, basis[2][0], basis[2][1], basis[2][2], pose.z, 0.0, 0.0, 0.0, 1.0, ez_yaw, ey_pitch, ex_roll, qx, qy,
+           qz, qw);
+}
 
-  void  showPose(Pose6d pose, std::string message){
-    tf::Matrix3x3 basis = pose.getBasis();
-    double ez_yaw, ey_pitch, ex_roll;
-    double qx,qy,qz,qw;
-    pose.getEulerZYX(ez_yaw,ey_pitch,ex_roll);
-    pose.getQuaternion(qx, qy, qz, qw);
-    ROS_INFO("%s =[\n %6.3lf  %6.3lf  %6.3lf  %6.3lf\n  %6.3lf  %6.3lf  %6.3lf  %6.3lf\n  %6.3lf  %6.3lf %6.3lf  %6.3lf\n  %6.3lf  %6.3lf %6.3lf  %6.3lf];\n rpy= %lf %lf %lf\n quat= %6.3lf %6.3lf %6.3lf %6.3lf ",
-	     message.c_str(),
-	     basis[0][0],basis[0][1], basis[0][2], pose.x,
-	     basis[1][0],basis[1][1], basis[1][2], pose.y,
-	     basis[2][0],basis[2][1], basis[2][2], pose.z,
-	     0.0, 0.0, 0.0, 1.0,
-	     ez_yaw, ey_pitch, ex_roll,
-	     qx,qy,qz,qw);
-  }
-  
-void  showPose(P_BLOCK extrinsics, std::string message){
-    double ax,ay,az,px,py,pz;
-    ax  = extrinsics[0]; 
-    ay  = extrinsics[1]; 
-    az  = extrinsics[2]; 
-    px  = extrinsics[3]; 
-    py  = extrinsics[4]; 
-    pz  = extrinsics[5];
-    Pose6d pose(px,py,pz,ax,ay,az);
-    tf::Matrix3x3 basis = pose.getBasis();
-    double ez_yaw, ey_pitch, ex_roll;
-    double qx, qy, qz, qw;
-    pose.getEulerZYX(ez_yaw,ey_pitch,ex_roll);
-    pose.getQuaternion(qx, qy, qz, qw);
-    ROS_ERROR("%s =[\n %6.3lf  %6.3lf  %6.3lf  %6.3lf\n  %6.3lf  %6.3lf  %6.3lf  %6.3lf\n  %6.3lf  %6.3lf %6.3lf  %6.3lf\n  %6.3lf  %6.3lf %6.3lf  %6.3lf];\n rpy= %6.3lf %6.3lf %6.3lf\n quat= %6.3lf  %6.3lf  %6.3lf %6.3lf ",
-	      message.c_str(),
-	      basis[0][0],basis[0][1], basis[0][2],px,
-	      basis[1][0],basis[1][1], basis[1][2],py,
-	      basis[2][0],basis[2][1], basis[2][2],pz,
-	      0.0, 0.0, 0.0, 1.0,
-	      ez_yaw, ey_pitch, ex_roll,
-	      qx, qy, qz, qw);
-  }
+void showPose(P_BLOCK extrinsics, std::string message)
+{
+  double ax, ay, az, px, py, pz;
+  ax = extrinsics[0];
+  ay = extrinsics[1];
+  az = extrinsics[2];
+  px = extrinsics[3];
+  py = extrinsics[4];
+  pz = extrinsics[5];
+  Pose6d pose(px, py, pz, ax, ay, az);
+  tf::Matrix3x3 basis = pose.getBasis();
+  double ez_yaw, ey_pitch, ex_roll;
+  double qx, qy, qz, qw;
+  pose.getEulerZYX(ez_yaw, ey_pitch, ex_roll);
+  pose.getQuaternion(qx, qy, qz, qw);
+  ROS_ERROR("%s =[\n %6.3lf  %6.3lf  %6.3lf  %6.3lf\n  %6.3lf  %6.3lf  %6.3lf  %6.3lf\n  %6.3lf  %6.3lf %6.3lf  "
+            "%6.3lf\n  %6.3lf  %6.3lf %6.3lf  %6.3lf];\n rpy= %6.3lf %6.3lf %6.3lf\n quat= %6.3lf  %6.3lf  %6.3lf "
+            "%6.3lf ",
+            message.c_str(), basis[0][0], basis[0][1], basis[0][2], px, basis[1][0], basis[1][1], basis[1][2], py,
+            basis[2][0], basis[2][1], basis[2][2], pz, 0.0, 0.0, 0.0, 1.0, ez_yaw, ey_pitch, ex_roll, qx, qy, qz, qw);
+}
 
-  void  showIntrinsics(P_BLOCK intrinsics, bool with_distortion){
-    double fx,fy,cx,cy,k1,k2,k3,p1,p2;
-    fx  = intrinsics[0]; /** focal length x */
-    fy  = intrinsics[1]; /** focal length y */
-    cx  = intrinsics[2]; /** central point x */
-    cy  = intrinsics[3]; /** central point y */
-    ROS_INFO("fx = %lf fy=%lf cx=%lf cy=%lf", fx, fy, cx, cy);
-    if(with_distortion){
-      k1  = intrinsics[4]; /** distortion k1  */
-      k2  = intrinsics[5]; /** distortion k2  */
-      k3  = intrinsics[6]; /** distortion k3  */
-      p1  = intrinsics[7]; /** distortion p1  */
-      p2  = intrinsics[8]; /** distortion p2  */
-      ROS_INFO("k1 = %lf k2 = %lf k3 = %lf p1 = %lf p2 = %lf", k1, k2, k3, p1, p2);
-    }
+void showIntrinsics(P_BLOCK intrinsics, bool with_distortion)
+{
+  double fx, fy, cx, cy, k1, k2, k3, p1, p2;
+  fx = intrinsics[0]; /** focal length x */
+  fy = intrinsics[1]; /** focal length y */
+  cx = intrinsics[2]; /** central point x */
+  cy = intrinsics[3]; /** central point y */
+  ROS_INFO("fx = %lf fy=%lf cx=%lf cy=%lf", fx, fy, cx, cy);
+  if (with_distortion)
+  {
+    k1 = intrinsics[4]; /** distortion k1  */
+    k2 = intrinsics[5]; /** distortion k2  */
+    k3 = intrinsics[6]; /** distortion k3  */
+    p1 = intrinsics[7]; /** distortion p1  */
+    p2 = intrinsics[8]; /** distortion p2  */
+    ROS_INFO("k1 = %lf k2 = %lf k3 = %lf p1 = %lf p2 = %lf", k1, k2, k3, p1, p2);
   }
+}
 
 CeresBlocks::CeresBlocks()
 {
@@ -92,20 +88,20 @@ CeresBlocks::~CeresBlocks()
 }
 void CeresBlocks::clearCamerasTargets()
 {
-  //ROS_INFO_STREAM("Attempting to clear cameras and targets from ceresBlocks");
+  // ROS_INFO_STREAM("Attempting to clear cameras and targets from ceresBlocks");
   static_targets_.clear();
-  //ROS_INFO_STREAM("Moving Targets "<<moving_targets_.size());
+  // ROS_INFO_STREAM("Moving Targets "<<moving_targets_.size());
   moving_targets_.clear();
-  //ROS_INFO_STREAM("Static cameras "<<static_cameras_.size());
+  // ROS_INFO_STREAM("Static cameras "<<static_cameras_.size());
   static_cameras_.clear();
-  //ROS_INFO_STREAM("Moving cameras "<<moving_cameras_.size());
+  // ROS_INFO_STREAM("Moving cameras "<<moving_cameras_.size());
   moving_cameras_.clear();
-  //ROS_INFO_STREAM("Cameras and Targets cleared from CeresBlocks");
+  // ROS_INFO_STREAM("Cameras and Targets cleared from CeresBlocks");
 }
 P_BLOCK CeresBlocks::getStaticCameraParameterBlockIntrinsics(string camera_name)
 {
   // static cameras should have unique name
-  BOOST_FOREACH(shared_ptr<Camera> camera, static_cameras_)
+  BOOST_FOREACH (shared_ptr< Camera > camera, static_cameras_)
   {
     if (camera_name == camera->camera_name_)
     {
@@ -120,7 +116,7 @@ P_BLOCK CeresBlocks::getMovingCameraParameterBlockIntrinsics(string camera_name)
   // we use the intrinsic parameters from the first time the camera appears in the list
   // subsequent cameras with this name also have intrinsic parameters, but these are
   // never used as parameter blocks, only their extrinsics are used
-  BOOST_FOREACH(shared_ptr<MovingCamera> moving_camera, moving_cameras_)
+  BOOST_FOREACH (shared_ptr< MovingCamera > moving_camera, moving_cameras_)
   {
     if (camera_name == moving_camera->cam->camera_name_)
     {
@@ -133,7 +129,7 @@ P_BLOCK CeresBlocks::getMovingCameraParameterBlockIntrinsics(string camera_name)
 P_BLOCK CeresBlocks::getStaticCameraParameterBlockExtrinsics(string camera_name)
 {
   // static cameras should have unique name
-  BOOST_FOREACH(shared_ptr<Camera> camera, static_cameras_)
+  BOOST_FOREACH (shared_ptr< Camera > camera, static_cameras_)
   {
     if (camera_name == camera->camera_name_)
     {
@@ -143,11 +139,10 @@ P_BLOCK CeresBlocks::getStaticCameraParameterBlockExtrinsics(string camera_name)
   }
   ROS_ERROR("COULD NOT FIND STATIC CAMERA NAMED %s", camera_name.c_str());
   return (NULL);
-
 }
 P_BLOCK CeresBlocks::getMovingCameraParameterBlockExtrinsics(string camera_name, int scene_id)
 {
-  BOOST_FOREACH(shared_ptr<MovingCamera> camera, moving_cameras_)
+  BOOST_FOREACH (shared_ptr< MovingCamera > camera, moving_cameras_)
   {
     if (camera_name == camera->cam->camera_name_ && scene_id == camera->scene_id)
     {
@@ -156,11 +151,10 @@ P_BLOCK CeresBlocks::getMovingCameraParameterBlockExtrinsics(string camera_name,
     }
   }
   return (NULL);
-
 }
 P_BLOCK CeresBlocks::getStaticTargetPoseParameterBlock(string target_name)
 {
-  BOOST_FOREACH(shared_ptr<Target> target, static_targets_)
+  BOOST_FOREACH (shared_ptr< Target > target, static_targets_)
   {
     if (target_name == target->target_name_)
     {
@@ -172,7 +166,7 @@ P_BLOCK CeresBlocks::getStaticTargetPoseParameterBlock(string target_name)
 }
 P_BLOCK CeresBlocks::getStaticTargetPointParameterBlock(string target_name, int point_id)
 {
-  BOOST_FOREACH(shared_ptr<Target> target, static_targets_)
+  BOOST_FOREACH (shared_ptr< Target > target, static_targets_)
   {
     if (target_name == target->target_name_)
     {
@@ -184,7 +178,7 @@ P_BLOCK CeresBlocks::getStaticTargetPointParameterBlock(string target_name, int 
 }
 P_BLOCK CeresBlocks::getMovingTargetPoseParameterBlock(string target_name, int scene_id)
 {
-  BOOST_FOREACH(shared_ptr<MovingTarget> moving_target, moving_targets_)
+  BOOST_FOREACH (shared_ptr< MovingTarget > moving_target, moving_targets_)
   {
     if (target_name == moving_target->targ_->target_name_ && scene_id == moving_target->scene_id_)
     {
@@ -198,7 +192,7 @@ P_BLOCK CeresBlocks::getMovingTargetPointParameterBlock(string target_name, int 
 {
   // note scene_id unnecessary here since regarless of scene th point's location relative to
   // the target frame does not change
-  BOOST_FOREACH(shared_ptr<MovingTarget> moving_target, moving_targets_)
+  BOOST_FOREACH (shared_ptr< MovingTarget > moving_target, moving_targets_)
   {
     if (target_name == moving_target->targ_->target_name_)
     {
@@ -209,52 +203,53 @@ P_BLOCK CeresBlocks::getMovingTargetPointParameterBlock(string target_name, int 
   return (NULL);
 }
 
-bool CeresBlocks::addStaticCamera(shared_ptr<Camera> camera_to_add)
+bool CeresBlocks::addStaticCamera(shared_ptr< Camera > camera_to_add)
 {
-  BOOST_FOREACH(shared_ptr<Camera> cam, static_cameras_)
+  BOOST_FOREACH (shared_ptr< Camera > cam, static_cameras_)
   {
-    if (cam->camera_name_ == camera_to_add->camera_name_)
-      return (false); // camera already exists
+    if (cam->camera_name_ == camera_to_add->camera_name_) return (false);  // camera already exists
   }
   camera_to_add->setTIReferenceFrame(reference_frame_);
-  if(camera_to_add->isMoving()){
+  if (camera_to_add->isMoving())
+  {
     ROS_ERROR("trying to add a static camera that is moving");
   }
   static_cameras_.push_back(camera_to_add);
-  //ROS_INFO_STREAM("Camera added to static_cameras_");
+  // ROS_INFO_STREAM("Camera added to static_cameras_");
   return (true);
 }
-bool CeresBlocks::addStaticTarget(shared_ptr<Target> target_to_add)
+bool CeresBlocks::addStaticTarget(shared_ptr< Target > target_to_add)
 {
-  BOOST_FOREACH(shared_ptr<Target> targ, static_targets_)
+  BOOST_FOREACH (shared_ptr< Target > targ, static_targets_)
   {
     if (targ->target_name_ == target_to_add->target_name_)
-      {
-	return (false); // target already exists
-      }
+    {
+      return (false);  // target already exists
+    }
   }
   target_to_add->setTIReferenceFrame(reference_frame_);
-  if(target_to_add->is_moving_){
+  if (target_to_add->is_moving_)
+  {
     ROS_ERROR("trying to add a static target that is moving");
   }
   static_targets_.push_back(target_to_add);
 
   return (true);
 }
-bool CeresBlocks::addMovingCamera(shared_ptr<Camera> camera_to_add, int scene_id)
+bool CeresBlocks::addMovingCamera(shared_ptr< Camera > camera_to_add, int scene_id)
 {
-  BOOST_FOREACH(shared_ptr<MovingCamera> cam, moving_cameras_)
+  BOOST_FOREACH (shared_ptr< MovingCamera > cam, moving_cameras_)
   {
     if (cam->cam->camera_name_ == camera_to_add->camera_name_ && cam->scene_id == scene_id)
-      return (false); // camera already exists
+      return (false);  // camera already exists
   }
 
   // this next line allocates the memory for a moving camera
-  shared_ptr<MovingCamera> temp_moving_camera = boost::make_shared<MovingCamera>();
+  shared_ptr< MovingCamera > temp_moving_camera = boost::make_shared< MovingCamera >();
 
   // this next line allocates the memory for the actual camera
-  shared_ptr<Camera> temp_camera = boost::make_shared<Camera>(camera_to_add->camera_name_, camera_to_add->camera_parameters_,
-                                                       true);
+  shared_ptr< Camera > temp_camera =
+      boost::make_shared< Camera >(camera_to_add->camera_name_, camera_to_add->camera_parameters_, true);
 
   // set things not done by constructor using values from camera_to_add
   temp_camera->setTransformInterface(camera_to_add->getTransformInterface());
@@ -267,41 +262,45 @@ bool CeresBlocks::addMovingCamera(shared_ptr<Camera> camera_to_add, int scene_id
   moving_cameras_.push_back(temp_moving_camera);
   return (true);
 }
-bool CeresBlocks::addMovingTarget(shared_ptr<Target> target_to_add, int scene_id)
+bool CeresBlocks::addMovingTarget(shared_ptr< Target > target_to_add, int scene_id)
 {
-  BOOST_FOREACH(shared_ptr<MovingTarget> targ, moving_targets_)
+  BOOST_FOREACH (shared_ptr< MovingTarget > targ, moving_targets_)
   {
     if (targ->targ_->target_name_ == target_to_add->target_name_ && targ->scene_id_ == scene_id)
-      {
-	targ->targ_->pose_ = target_to_add->pose_; // update pose at least to account for intialization issue
-	return (false); // target already exists
-      }
+    {
+      targ->targ_->pose_ = target_to_add->pose_;  // update pose at least to account for intialization issue
+      return (false);                             // target already exists
+    }
   }
 
-  
-  // deep copy of target into moving target TODO test to see if using * or contents of notation can avoid all this direct copy
-  shared_ptr<MovingTarget> temp_moving_target = boost::make_shared<MovingTarget>();
-  temp_moving_target->targ_                         = boost::make_shared<Target>();
-  temp_moving_target->targ_->pose_            = target_to_add->pose_;
+  // deep copy of target into moving target TODO test to see if using * or contents of notation can avoid all this
+  // direct copy
+  shared_ptr< MovingTarget > temp_moving_target = boost::make_shared< MovingTarget >();
+  temp_moving_target->targ_ = boost::make_shared< Target >();
+  temp_moving_target->targ_->pose_ = target_to_add->pose_;
   temp_moving_target->targ_->num_points_ = target_to_add->num_points_;
-  temp_moving_target->targ_->pts_               = target_to_add->pts_;
-  temp_moving_target->targ_->is_moving_    = target_to_add->is_moving_;
+  temp_moving_target->targ_->pts_ = target_to_add->pts_;
+  temp_moving_target->targ_->is_moving_ = target_to_add->is_moving_;
   temp_moving_target->targ_->target_name_ = target_to_add->target_name_;
   temp_moving_target->targ_->target_frame_ = target_to_add->target_frame_;
-  temp_moving_target->targ_->target_type_   = target_to_add->target_type_;
-  temp_moving_target->scene_id_                   = scene_id;
-  if(temp_moving_target->targ_->target_type_ == 0){
+  temp_moving_target->targ_->target_type_ = target_to_add->target_type_;
+  temp_moving_target->scene_id_ = scene_id;
+  if (temp_moving_target->targ_->target_type_ == 0)
+  {
     temp_moving_target->targ_->checker_board_parameters_ = target_to_add->checker_board_parameters_;
   }
-  else if(temp_moving_target->targ_->target_type_ == 1 || temp_moving_target->targ_->target_type_ == 2 ){
+  else if (temp_moving_target->targ_->target_type_ == 1 || temp_moving_target->targ_->target_type_ == 2)
+  {
     temp_moving_target->targ_->circle_grid_parameters_ = target_to_add->circle_grid_parameters_;
   }
-  else{
+  else
+  {
     temp_moving_target->targ_->ar_target_parameters_ = target_to_add->ar_target_parameters_;
   }
   temp_moving_target->targ_->setTransformInterface(target_to_add->getTransformInterface());
-  boost::shared_ptr<TransformInterface> the_interface = target_to_add->getTransformInterface();
-  if(the_interface->isRefFrameInitialized()){
+  boost::shared_ptr< TransformInterface > the_interface = target_to_add->getTransformInterface();
+  if (the_interface->isRefFrameInitialized())
+  {
     std::string ref_frame;
     ref_frame = the_interface->getReferenceFrame();
     temp_moving_target->targ_->setTIReferenceFrame(ref_frame);
@@ -311,25 +310,25 @@ bool CeresBlocks::addMovingTarget(shared_ptr<Target> target_to_add, int scene_id
   return (true);
 }
 
-const boost::shared_ptr<Camera> CeresBlocks::getCameraByName(const std::string &camera_name)
+const boost::shared_ptr< Camera > CeresBlocks::getCameraByName(const std::string& camera_name)
 {
-  boost::shared_ptr<Camera> cam = boost::make_shared<Camera>();
-  //ROS_INFO_STREAM("Found "<<static_cameras_.size() <<" static cameras");
-  for (int i=0; i< static_cameras_.size() ; i++ )
+  boost::shared_ptr< Camera > cam = boost::make_shared< Camera >();
+  // ROS_INFO_STREAM("Found "<<static_cameras_.size() <<" static cameras");
+  for (int i = 0; i < static_cameras_.size(); i++)
   {
-    if (static_cameras_.at(i)->camera_name_==camera_name)
+    if (static_cameras_.at(i)->camera_name_ == camera_name)
     {
-      cam= static_cameras_.at(i);
-      ROS_DEBUG_STREAM("Found static camera with name: "<<static_cameras_.at(i)->camera_name_);
+      cam = static_cameras_.at(i);
+      ROS_DEBUG_STREAM("Found static camera with name: " << static_cameras_.at(i)->camera_name_);
     }
   }
-  //ROS_INFO_STREAM("Found "<<moving_cameras_.size() <<" moving cameras");
-  for (int i=0; i< moving_cameras_.size() ; i++ )
+  // ROS_INFO_STREAM("Found "<<moving_cameras_.size() <<" moving cameras");
+  for (int i = 0; i < moving_cameras_.size(); i++)
   {
-    if (moving_cameras_.at(i)->cam->camera_name_==camera_name)
+    if (moving_cameras_.at(i)->cam->camera_name_ == camera_name)
     {
-      cam= moving_cameras_.at(i)->cam;
-      ROS_DEBUG_STREAM("Found moving camera with name: "<<camera_name);
+      cam = moving_cameras_.at(i)->cam;
+      ROS_DEBUG_STREAM("Found moving camera with name: " << camera_name);
     }
   }
   if (!cam)
@@ -337,57 +336,52 @@ const boost::shared_ptr<Camera> CeresBlocks::getCameraByName(const std::string &
     ROS_ERROR("getCameraByName Failed for %s", camera_name.c_str());
   }
   return cam;
-  //return true;
+  // return true;
 }
 
-const boost::shared_ptr<Target> CeresBlocks::getTargetByName(const std::string &target_name, int scene_id)
+const boost::shared_ptr< Target > CeresBlocks::getTargetByName(const std::string& target_name, int scene_id)
 {
-  boost::shared_ptr<Target> target = boost::make_shared<Target>();
-  bool found=false;
-  //ROS_INFO_STREAM("Found "<<static_cameras_.size() <<" static cameras");
-  BOOST_FOREACH(shared_ptr<Target> targ, static_targets_)
+  boost::shared_ptr< Target > target = boost::make_shared< Target >();
+  bool found = false;
+  // ROS_INFO_STREAM("Found "<<static_cameras_.size() <<" static cameras");
+  BOOST_FOREACH (shared_ptr< Target > targ, static_targets_)
   {
-    if (targ->target_name_==target_name)
+    if (targ->target_name_ == target_name)
     {
-      target=targ;
+      target = targ;
       found = true;
-      ROS_DEBUG_STREAM("Found static target with name: "<<target_name);
+      ROS_DEBUG_STREAM("Found static target with name: " << target_name);
     }
   }
-  //ROS_INFO_STREAM("Found "<<moving_cameras_.size() <<" static cameras");
-  BOOST_FOREACH(shared_ptr<MovingTarget> mtarg, moving_targets_)
+  // ROS_INFO_STREAM("Found "<<moving_cameras_.size() <<" static cameras");
+  BOOST_FOREACH (shared_ptr< MovingTarget > mtarg, moving_targets_)
   {
-    if (mtarg->targ_->target_name_ ==target_name && mtarg->scene_id_ == scene_id)
+    if (mtarg->targ_->target_name_ == target_name && mtarg->scene_id_ == scene_id)
     {
       found = true;
-      target=mtarg->targ_;
-      ROS_DEBUG_STREAM("Found moving target with name: "<<target_name);
+      target = mtarg->targ_;
+      ROS_DEBUG_STREAM("Found moving target with name: " << target_name);
     }
   }
   if (!found)
   {
-    ROS_ERROR("getStaticTargetByName Failed for %s",target_name.c_str());
+    ROS_ERROR("getStaticTargetByName Failed for %s", target_name.c_str());
   }
   return target;
 }
 
-
- void CeresBlocks::displayStaticCameras()
+void CeresBlocks::displayStaticCameras()
 {
-
-  if(static_cameras_.size() !=0)   ROS_INFO("Static Cameras");
-  BOOST_FOREACH(shared_ptr<Camera> cam, static_cameras_)
-    {
-      Pose6d pose(cam->camera_parameters_.position[0],
-		  cam->camera_parameters_.position[1],
-		  cam->camera_parameters_.position[2],
-		  cam->camera_parameters_.angle_axis[0],
-		  cam->camera_parameters_.angle_axis[1],
-		  cam->camera_parameters_.angle_axis[2]);
-      Pose6d ipose = pose.getInverse();
-      showPose(ipose, cam->camera_name_);
-      showIntrinsics(cam->camera_parameters_.pb_intrinsics, true);
-    }
+  if (static_cameras_.size() != 0) ROS_INFO("Static Cameras");
+  BOOST_FOREACH (shared_ptr< Camera > cam, static_cameras_)
+  {
+    Pose6d pose(cam->camera_parameters_.position[0], cam->camera_parameters_.position[1],
+                cam->camera_parameters_.position[2], cam->camera_parameters_.angle_axis[0],
+                cam->camera_parameters_.angle_axis[1], cam->camera_parameters_.angle_axis[2]);
+    Pose6d ipose = pose.getInverse();
+    showPose(ipose, cam->camera_name_);
+    showIntrinsics(cam->camera_parameters_.pb_intrinsics, true);
+  }
 }
 void CeresBlocks::displayMovingCameras()
 {
@@ -397,44 +391,43 @@ void CeresBlocks::displayMovingCameras()
   double world_to_camera[3];
   double quat[4];
 
-  if(moving_cameras_.size() !=0) ROS_INFO("Moving Cameras");
-  BOOST_FOREACH(shared_ptr<MovingCamera> mcam, moving_cameras_)
+  if (moving_cameras_.size() != 0) ROS_INFO("Moving Cameras");
+  BOOST_FOREACH (shared_ptr< MovingCamera > mcam, moving_cameras_)
+  {
+    if (mcam->scene_id == 0)
     {
-      if(mcam->scene_id == 0){
-	Pose6d pose(mcam->cam->camera_parameters_.position[0],
-		    mcam->cam->camera_parameters_.position[1],
-		    mcam->cam->camera_parameters_.position[2],
-		    mcam->cam->camera_parameters_.angle_axis[0],
-		    mcam->cam->camera_parameters_.angle_axis[1],
-		    mcam->cam->camera_parameters_.angle_axis[2]);
-	Pose6d ipose = pose.getInverse();
-	showPose(ipose, mcam->cam->camera_name_);
-	P_BLOCK intrinsics = getMovingCameraParameterBlockIntrinsics(mcam->cam->camera_name_);
-	showIntrinsics(intrinsics, true);
-      }
+      Pose6d pose(mcam->cam->camera_parameters_.position[0], mcam->cam->camera_parameters_.position[1],
+                  mcam->cam->camera_parameters_.position[2], mcam->cam->camera_parameters_.angle_axis[0],
+                  mcam->cam->camera_parameters_.angle_axis[1], mcam->cam->camera_parameters_.angle_axis[2]);
+      Pose6d ipose = pose.getInverse();
+      showPose(ipose, mcam->cam->camera_name_);
+      P_BLOCK intrinsics = getMovingCameraParameterBlockIntrinsics(mcam->cam->camera_name_);
+      showIntrinsics(intrinsics, true);
     }
+  }
 }
 void CeresBlocks::displayStaticTargets()
 {
   double R[9];
 
-  if(static_targets_.size() !=0)   ROS_INFO("Static Targets:");
-  BOOST_FOREACH(shared_ptr<Target> targ, static_targets_)
-    {
-      showPose(targ->pose_, targ->target_name_);
-    }
+  if (static_targets_.size() != 0) ROS_INFO("Static Targets:");
+  BOOST_FOREACH (shared_ptr< Target > targ, static_targets_)
+  {
+    showPose(targ->pose_, targ->target_name_);
+  }
 }
 void CeresBlocks::displayMovingTargets()
 {
   double R[9];
 
-  if(moving_targets_.size() !=0)   ROS_INFO("Moving Targets:");
-  BOOST_FOREACH(shared_ptr<MovingTarget> mtarg, moving_targets_)
-    {
-      if(mtarg->scene_id_ == 0){	// only show first pose, not all 
-	showPose(mtarg->targ_->pose_, mtarg->targ_->target_name_);
-      }
+  if (moving_targets_.size() != 0) ROS_INFO("Moving Targets:");
+  BOOST_FOREACH (shared_ptr< MovingTarget > mtarg, moving_targets_)
+  {
+    if (mtarg->scene_id_ == 0)
+    {  // only show first pose, not all
+      showPose(mtarg->targ_->pose_, mtarg->targ_->target_name_);
     }
+  }
 }
 using std::string;
 using std::ofstream;
@@ -442,129 +435,131 @@ using std::endl;
 
 bool CeresBlocks::writeAllStaticTransforms(string filePath)
 {
-  std::ofstream outputFile(filePath.c_str(), std::ios::out);// | std::ios::app);
+  std::ofstream outputFile(filePath.c_str(), std::ios::out);  // | std::ios::app);
   if (outputFile.is_open())
-    {
-      ROS_INFO_STREAM("Storing results in: "<<filePath);
-    }
+  {
+    ROS_INFO_STREAM("Storing results in: " << filePath);
+  }
   else
-    {
-      ROS_ERROR_STREAM("Unable to open file:" <<filePath);
-      return false;
-    }//end if writing to file
+  {
+    ROS_ERROR_STREAM("Unable to open file:" << filePath);
+    return false;
+  }  // end if writing to file
   outputFile << "<launch>\n";
   outputFile << "# this file might be empty\n";
   outputFile << "# It might contain static transform publishers that were updated through calibration\n";
   outputFile << "# Often, transform interfaces use some other mechanism to update themselves\n";
   outputFile.close();
-  
+
   bool rtn = true;
-  BOOST_FOREACH(shared_ptr<Camera> cam, static_cameras_)
-    {
-      rtn = cam->transform_interface_->store(filePath);
-    }
-  BOOST_FOREACH(shared_ptr<MovingCamera> mcam, moving_cameras_)
-    {
-      rtn = mcam->cam->transform_interface_->store(filePath);
-    }
-  BOOST_FOREACH(shared_ptr<Target> targ, static_targets_)
-    {
-      rtn = targ->transform_interface_->store(filePath);
-    }
-  BOOST_FOREACH(shared_ptr<MovingTarget> mtarg, moving_targets_)
-    {
-      rtn = mtarg->targ_->transform_interface_->store(filePath);
-    }
-  
-  if(!rtn){
+  BOOST_FOREACH (shared_ptr< Camera > cam, static_cameras_)
+  {
+    rtn = cam->transform_interface_->store(filePath);
+  }
+  BOOST_FOREACH (shared_ptr< MovingCamera > mcam, moving_cameras_)
+  {
+    rtn = mcam->cam->transform_interface_->store(filePath);
+  }
+  BOOST_FOREACH (shared_ptr< Target > targ, static_targets_)
+  {
+    rtn = targ->transform_interface_->store(filePath);
+  }
+  BOOST_FOREACH (shared_ptr< MovingTarget > mtarg, moving_targets_)
+  {
+    rtn = mtarg->targ_->transform_interface_->store(filePath);
+  }
+
+  if (!rtn)
+  {
     ROS_ERROR("Couldn't write the static tranform publishers");
   }
   std::ofstream outputFileagain(filePath.c_str(), std::ios::app);
   if (!outputFileagain.is_open())
-    {
-      ROS_ERROR_STREAM("Unable to re-open file:" <<filePath);
-      return false;
-    }//end if writing to file
-  else{
+  {
+    ROS_ERROR_STREAM("Unable to re-open file:" << filePath);
+    return false;
+  }  // end if writing to file
+  else
+  {
     outputFileagain << "\n</launch> \n";
     outputFileagain.close();
   }
-  return(rtn);
+  return (rtn);
 }
 
 void CeresBlocks::pushTransforms()
 {
-  BOOST_FOREACH(shared_ptr<Camera> cam, static_cameras_)
-    {
-      cam->pushTransform();
+  BOOST_FOREACH (shared_ptr< Camera > cam, static_cameras_)
+  {
+    cam->pushTransform();
+  }
+  BOOST_FOREACH (shared_ptr< MovingCamera > mcam, moving_cameras_)
+  {
+    if (mcam->scene_id == 0)
+    {  // only push a moving camera's transform once, which is always scene 0
+      Pose6d pose;
+      pose.setAngleAxis(mcam->cam->camera_parameters_.angle_axis[0], mcam->cam->camera_parameters_.angle_axis[1],
+                        mcam->cam->camera_parameters_.angle_axis[2]);
+      pose.setOrigin(mcam->cam->camera_parameters_.position[0], mcam->cam->camera_parameters_.position[1],
+                     mcam->cam->camera_parameters_.position[2]);
+      mcam->cam->pushTransform();
     }
-  BOOST_FOREACH(shared_ptr<MovingCamera> mcam, moving_cameras_)
-    {
-      if(mcam->scene_id == 0){ // only push a moving camera's transform once, which is always scene 0
-	Pose6d pose;
-	pose.setAngleAxis(mcam->cam->camera_parameters_.angle_axis[0], 
-			  mcam->cam->camera_parameters_.angle_axis[1], 
-			  mcam->cam->camera_parameters_.angle_axis[2]);
-	pose.setOrigin(mcam->cam->camera_parameters_.position[0],
-		       mcam->cam->camera_parameters_.position[1],
-		       mcam->cam->camera_parameters_.position[2]);
-	mcam->cam->pushTransform();
-      }
+  }
+  BOOST_FOREACH (shared_ptr< Target > targ, static_targets_)
+  {
+    targ->pushTransform();
+  }
+  BOOST_FOREACH (shared_ptr< MovingTarget > mtarg, moving_targets_)
+  {
+    if (mtarg->scene_id_ == 0)
+    {  // only push a moving target once which is for the scene 0
+      mtarg->targ_->pushTransform();
     }
-  BOOST_FOREACH(shared_ptr<Target> targ, static_targets_)
-    {
-      targ->pushTransform();
-    }
-  BOOST_FOREACH(shared_ptr<MovingTarget> mtarg, moving_targets_)
-    {
-      if(mtarg->scene_id_ == 0){ // only push a moving target once which is for the scene 0
-	mtarg->targ_->pushTransform();
-      }
-    }
-
+  }
 }
 void CeresBlocks::pullTransforms(int scene_id)
 {
-  BOOST_FOREACH(shared_ptr<Camera> cam, static_cameras_)
-    {
-      cam->pullTransform();
+  BOOST_FOREACH (shared_ptr< Camera > cam, static_cameras_)
+  {
+    cam->pullTransform();
+  }
+  BOOST_FOREACH (shared_ptr< MovingCamera > mcam, moving_cameras_)
+  {
+    if (mcam->scene_id == scene_id)
+    {  // only pull transforms for cameras in current scene
+      mcam->cam->pullTransform();
     }
-  BOOST_FOREACH(shared_ptr<MovingCamera> mcam, moving_cameras_)
-    {
-      if(mcam->scene_id == scene_id){ // only pull transforms for cameras in current scene
-	mcam->cam->pullTransform();
-      }
+  }
+  BOOST_FOREACH (shared_ptr< Target > targ, static_targets_)
+  {
+    targ->pullTransform();
+  }
+  BOOST_FOREACH (shared_ptr< MovingTarget > mtarg, moving_targets_)
+  {
+    if (mtarg->scene_id_ == scene_id)
+    {  // only pull transforms for targets in current scene
+      mtarg->targ_->pullTransform();
     }
-  BOOST_FOREACH(shared_ptr<Target> targ, static_targets_)
-    {
-      targ->pullTransform();
-    }
-  BOOST_FOREACH(shared_ptr<MovingTarget> mtarg, moving_targets_)
-    {
-      if(mtarg->scene_id_ == scene_id){ // only pull transforms for targets in current scene
-	mtarg->targ_->pullTransform();
-      }
-    }
+  }
 }
 void CeresBlocks::setReferenceFrame(std::string ref_frame)
 {
   reference_frame_ = ref_frame;
-  BOOST_FOREACH(shared_ptr<Camera> cam, static_cameras_)
-    {
-      cam->setTIReferenceFrame(ref_frame);
-    }
-  BOOST_FOREACH(shared_ptr<MovingCamera> mcam, moving_cameras_)
-    {
-      mcam->cam->setTIReferenceFrame(ref_frame);
-    }
-  BOOST_FOREACH(shared_ptr<Target> targ, static_targets_)
-    {
-      targ->setTIReferenceFrame(ref_frame);
-    }
-  BOOST_FOREACH(shared_ptr<MovingTarget> mtarg, moving_targets_)
-    {
-      mtarg->targ_->setTIReferenceFrame(ref_frame);
-    }
+  BOOST_FOREACH (shared_ptr< Camera > cam, static_cameras_)
+  {
+    cam->setTIReferenceFrame(ref_frame);
+  }
+  BOOST_FOREACH (shared_ptr< MovingCamera > mcam, moving_cameras_)
+  {
+    mcam->cam->setTIReferenceFrame(ref_frame);
+  }
+  BOOST_FOREACH (shared_ptr< Target > targ, static_targets_)
+  {
+    targ->setTIReferenceFrame(ref_frame);
+  }
+  BOOST_FOREACH (shared_ptr< MovingTarget > mtarg, moving_targets_)
+  {
+    mtarg->targ_->setTIReferenceFrame(ref_frame);
+  }
 }
-}// end namespace industrial_extrinsic_cal
-
+}  // end namespace industrial_extrinsic_cal

--- a/industrial_extrinsic_cal/src/ceres_cost_utils_test.cpp
+++ b/industrial_extrinsic_cal/src/ceres_cost_utils_test.cpp
@@ -32,14 +32,14 @@ Observation projectPoint(CameraParameters C, Point3d P)
   /* transform point into camera frame */
   /* note, camera transform takes points from camera frame into world frame */
   double aa[3];
-  aa[0]=C.pb_extrinsics[0];
-  aa[0]=C.pb_extrinsics[1];
-  aa[0]=C.pb_extrinsics[2];
+  aa[0] = C.pb_extrinsics[0];
+  aa[0] = C.pb_extrinsics[1];
+  aa[0] = C.pb_extrinsics[2];
   ceres::AngleAxisRotatePoint(aa, pt, p);
 
-  p[0] +=C.pb_extrinsics[3];
-  p[1] +=C.pb_extrinsics[4];
-  p[2] +=C.pb_extrinsics[5];
+  p[0] += C.pb_extrinsics[3];
+  p[1] += C.pb_extrinsics[4];
+  p[2] += C.pb_extrinsics[5];
 
   double xp = p[0] / p[2];
   double yp = p[1] / p[2];
@@ -53,10 +53,10 @@ Observation projectPoint(CameraParameters C, Point3d P)
   double yp2 = yp * yp;
 
   /* apply the distortion coefficients to refine pixel location */
-  double xpp = xp + C.distortion_k1 * r2 * xp + C.distortion_k2 * r4 * xp +
-      C.distortion_k3 * r6 * xp + C.distortion_p2 * (r2 + 2 * xp2) + 2 * C.distortion_p1 * xp * yp;
-  double ypp = yp + C.distortion_k1 * r2 * yp + C.distortion_k2 * r4 * yp +
-      C.distortion_k3 * r6 * yp + C.distortion_p1 * (r2 + 2 * yp2) + 2 * C.distortion_p2 * xp * yp;
+  double xpp = xp + C.distortion_k1 * r2 * xp + C.distortion_k2 * r4 * xp + C.distortion_k3 * r6 * xp +
+               C.distortion_p2 * (r2 + 2 * xp2) + 2 * C.distortion_p1 * xp * yp;
+  double ypp = yp + C.distortion_k1 * r2 * yp + C.distortion_k2 * r4 * yp + C.distortion_k3 * r6 * yp +
+               C.distortion_p1 * (r2 + 2 * yp2) + 2 * C.distortion_p2 * xp * yp;
 
   /* perform projection using focal length and camera center into image plane */
   Observation O;
@@ -68,76 +68,76 @@ Observation projectPoint(CameraParameters C, Point3d P)
 
 struct CameraReprjErrorWithDistortion
 {
-  CameraReprjErrorWithDistortion(double ob_x, double ob_y) :
-      ox_(ob_x), oy_(ob_y)
+  CameraReprjErrorWithDistortion(double ob_x, double ob_y) : ox_(ob_x), oy_(ob_y)
   {
   }
 
-  template<typename T>
-    bool operator()(const T* const c_p1, /** extrinsic parameters */
-                    const T* c_p2, /** intrinsic parameters */
-                    const T* point, /** point being projected, yes this is has 3 parameters */
-                    T* resid) const
-    {
-      /** extract the variables from the camera parameters */
-      int q = 0; /** extrinsic block of parameters */
-      const T& x = c_p1[q++]; /**  angle_axis x for rotation of camera           */
-      const T& y = c_p1[q++]; /**  angle_axis y for rotation of camera */
-      const T& z = c_p1[q++]; /**  angle_axis z for rotation of camera */
-      const T& tx = c_p1[q++]; /**  translation of camera x */
-      const T& ty = c_p1[q++]; /**  translation of camera y */
-      const T& tz = c_p1[q++]; /**  translation of camera z */
+  template < typename T >
+  bool operator()(const T* const c_p1, /** extrinsic parameters */
+                  const T* c_p2,       /** intrinsic parameters */
+                  const T* point,      /** point being projected, yes this is has 3 parameters */
+                  T* resid) const
+  {
+    /** extract the variables from the camera parameters */
+    int q = 0;               /** extrinsic block of parameters */
+    const T& x = c_p1[q++];  /**  angle_axis x for rotation of camera           */
+    const T& y = c_p1[q++];  /**  angle_axis y for rotation of camera */
+    const T& z = c_p1[q++];  /**  angle_axis z for rotation of camera */
+    const T& tx = c_p1[q++]; /**  translation of camera x */
+    const T& ty = c_p1[q++]; /**  translation of camera y */
+    const T& tz = c_p1[q++]; /**  translation of camera z */
 
-      q = 0; /** intrinsic block of parameters */
-      const T& fx = c_p2[q++]; /**  focal length x */
-      const T& fy = c_p2[q++]; /**  focal length x */
-      const T& cx = c_p2[q++]; /**  center point x */
-      const T& cy = c_p2[q++]; /**  center point y */
-      const T& k1 = c_p2[q++]; /**  distortion coefficient on 2nd order terms */
-      const T& k2 = c_p2[q++]; /**  distortion coefficient on 4th order terms */
-      const T& k3 = c_p2[q++]; /**  distortion coefficient on 6th order terms */
-      const T& p1 = c_p2[q++]; /**  tangential distortion coefficient x */
-      const T& p2 = c_p2[q++]; /**  tangential distortion coefficient y */
+    q = 0;                   /** intrinsic block of parameters */
+    const T& fx = c_p2[q++]; /**  focal length x */
+    const T& fy = c_p2[q++]; /**  focal length x */
+    const T& cx = c_p2[q++]; /**  center point x */
+    const T& cy = c_p2[q++]; /**  center point y */
+    const T& k1 = c_p2[q++]; /**  distortion coefficient on 2nd order terms */
+    const T& k2 = c_p2[q++]; /**  distortion coefficient on 4th order terms */
+    const T& k3 = c_p2[q++]; /**  distortion coefficient on 6th order terms */
+    const T& p1 = c_p2[q++]; /**  tangential distortion coefficient x */
+    const T& p2 = c_p2[q++]; /**  tangential distortion coefficient y */
 
-      /** rotate and translate points into camera frame */
-      T aa[3];/** angle axis  */
-      T p[3]; /** point rotated */
-      aa[0] = x;
-      aa[1] = y;
-      aa[2] = z;
-      ceres::AngleAxisRotatePoint(aa, point, p);
+    /** rotate and translate points into camera frame */
+    T aa[3]; /** angle axis  */
+    T p[3];  /** point rotated */
+    aa[0] = x;
+    aa[1] = y;
+    aa[2] = z;
+    ceres::AngleAxisRotatePoint(aa, point, p);
 
-      /** apply camera translation */
-      T xp1 = p[0] + tx; /** point rotated and translated */
-      T yp1 = p[1] + ty;
-      T zp1 = p[2] + tz;
+    /** apply camera translation */
+    T xp1 = p[0] + tx; /** point rotated and translated */
+    T yp1 = p[1] + ty;
+    T zp1 = p[2] + tz;
 
-      /** scale into the image plane by distance away from camera */
-      T xp = xp1 / zp1;
-      T yp = yp1 / zp1;
+    /** scale into the image plane by distance away from camera */
+    T xp = xp1 / zp1;
+    T yp = yp1 / zp1;
 
-      /** calculate terms for polynomial distortion */
-      T r2 = xp * xp + yp * yp;
-      T r4 = r2 * r2;
-      T r6 = r2 * r4;
+    /** calculate terms for polynomial distortion */
+    T r2 = xp * xp + yp * yp;
+    T r4 = r2 * r2;
+    T r6 = r2 * r4;
 
-      T xp2 = xp * xp; /** temporary variables square of others */
-      T yp2 = yp * yp;
-      /*apply the distortion coefficients to refine pixel location */
-      T xpp = xp + k1 * r2 * xp + k2 * r4 * xp + k3 * r6 * xp + p2 * (r2 + T(2.0) * xp2) + T(2.0) * p1 * xp * yp;
-      T ypp = yp + k1 * r2 * yp + k2 * r4 * yp + k3 * r6 * yp + p1 * (r2 + T(2.0) * yp2) + T(2.0) * p2 * xp * yp;
-      /** perform projection using focal length and camera center into image plane */
-      resid[0] = fx * xpp + cx - T(ox_);
-      resid[1] = fy * ypp + cy - T(oy_);
+    T xp2 = xp * xp; /** temporary variables square of others */
+    T yp2 = yp * yp;
+    /*apply the distortion coefficients to refine pixel location */
+    T xpp = xp + k1 * r2 * xp + k2 * r4 * xp + k3 * r6 * xp + p2 * (r2 + T(2.0) * xp2) + T(2.0) * p1 * xp * yp;
+    T ypp = yp + k1 * r2 * yp + k2 * r4 * yp + k3 * r6 * yp + p1 * (r2 + T(2.0) * yp2) + T(2.0) * p2 * xp * yp;
+    /** perform projection using focal length and camera center into image plane */
+    resid[0] = fx * xpp + cx - T(ox_);
+    resid[1] = fy * ypp + cy - T(oy_);
 
-      return true;
-    } /** end of operator() */
+    return true;
+  } /** end of operator() */
 
   /** Factory to hide the construction of the CostFunction object from */
   /** the client code. */
   static ceres::CostFunction* Create(const double o_x, const double o_y)
   {
-    return (new ceres::AutoDiffCostFunction<CameraReprjErrorWithDistortion, 2, 6, 9, 3>(new CameraReprjErrorWithDistortion(o_x, o_y)));
+    return (new ceres::AutoDiffCostFunction< CameraReprjErrorWithDistortion, 2, 6, 9, 3 >(
+        new CameraReprjErrorWithDistortion(o_x, o_y)));
   }
   double ox_; /** observed x location of object in image */
   double oy_; /** observed y location of object in image */
@@ -145,61 +145,61 @@ struct CameraReprjErrorWithDistortion
 
 struct CameraReprjErrorNoDistortion
 {
-  CameraReprjErrorNoDistortion(double ob_x, double ob_y) :
-      ox_(ob_x), oy_(ob_y)
+  CameraReprjErrorNoDistortion(double ob_x, double ob_y) : ox_(ob_x), oy_(ob_y)
   {
   }
 
-  template<typename T>
-    bool operator()(const T* const c_p1, /** extrinsic parameters */
-                    const T* c_p2, /** intrinsic parameters */
-                    const T* point, /** point being projected, yes this is has 3 parameters */
-                    T* resid) const
-    {
-      /** extract the variables from the camera parameters */
-      int q = 0; /** extrinsic block of parameters */
-      const T& x = c_p1[q++]; /**  angle_axis x for rotation of camera		 */
-      const T& y = c_p1[q++]; /**  angle_axis y for rotation of camera */
-      const T& z = c_p1[q++]; /**  angle_axis z for rotation of camera */
-      const T& tx = c_p1[q++]; /**  translation of camera x */
-      const T& ty = c_p1[q++]; /**  translation of camera y */
-      const T& tz = c_p1[q++]; /**  translation of camera z */
+  template < typename T >
+  bool operator()(const T* const c_p1, /** extrinsic parameters */
+                  const T* c_p2,       /** intrinsic parameters */
+                  const T* point,      /** point being projected, yes this is has 3 parameters */
+                  T* resid) const
+  {
+    /** extract the variables from the camera parameters */
+    int q = 0;               /** extrinsic block of parameters */
+    const T& x = c_p1[q++];  /**  angle_axis x for rotation of camera		 */
+    const T& y = c_p1[q++];  /**  angle_axis y for rotation of camera */
+    const T& z = c_p1[q++];  /**  angle_axis z for rotation of camera */
+    const T& tx = c_p1[q++]; /**  translation of camera x */
+    const T& ty = c_p1[q++]; /**  translation of camera y */
+    const T& tz = c_p1[q++]; /**  translation of camera z */
 
-      q = 0; /** intrinsic block of parameters */
-      const T& fx = c_p2[q++]; /**  focal length x */
-      const T& fy = c_p2[q++]; /**  focal length x */
-      const T& cx = c_p2[q++]; /**  center point x */
-      const T& cy = c_p2[q++]; /**  center point y */
+    q = 0;                   /** intrinsic block of parameters */
+    const T& fx = c_p2[q++]; /**  focal length x */
+    const T& fy = c_p2[q++]; /**  focal length x */
+    const T& cx = c_p2[q++]; /**  center point x */
+    const T& cy = c_p2[q++]; /**  center point y */
 
-      /** rotate and translate points into camera frame */
-      T aa[3];/** angle axis  */
-      T p[3]; /** point rotated */
-      aa[0] = x;
-      aa[1] = y;
-      aa[2] = z;
-      ceres::AngleAxisRotatePoint(aa, point, p);
+    /** rotate and translate points into camera frame */
+    T aa[3]; /** angle axis  */
+    T p[3];  /** point rotated */
+    aa[0] = x;
+    aa[1] = y;
+    aa[2] = z;
+    ceres::AngleAxisRotatePoint(aa, point, p);
 
-      /** apply camera translation */
-      T xp1 = p[0] + tx; /** point rotated and translated */
-      T yp1 = p[1] + ty;
-      T zp1 = p[2] + tz;
+    /** apply camera translation */
+    T xp1 = p[0] + tx; /** point rotated and translated */
+    T yp1 = p[1] + ty;
+    T zp1 = p[2] + tz;
 
-      /** scale into the image plane by distance away from camera */
-      T xp = xp1 / zp1;
-      T yp = yp1 / zp1;
+    /** scale into the image plane by distance away from camera */
+    T xp = xp1 / zp1;
+    T yp = yp1 / zp1;
 
-      /** perform projection using focal length and camera center into image plane */
-      resid[0] = T(fx_) * xp + T(cx_) - T(ox_);
-      resid[1] = T(fy_) * yp + T(cy_) - T(oy_);
+    /** perform projection using focal length and camera center into image plane */
+    resid[0] = T(fx_) * xp + T(cx_) - T(ox_);
+    resid[1] = T(fy_) * yp + T(cy_) - T(oy_);
 
-      return true;
-    } /** end of operator() */
+    return true;
+  } /** end of operator() */
 
   /** Factory to hide the construction of the CostFunction object from */
   /** the client code. */
   static ceres::CostFunction* Create(const double o_x, const double o_y)
   {
-    return (new ceres::AutoDiffCostFunction<CameraReprjErrorNoDistortion, 2, 6, 4, 3>(new CameraReprjErrorNoDistortion(o_x, o_y)));
+    return (new ceres::AutoDiffCostFunction< CameraReprjErrorNoDistortion, 2, 6, 4, 3 >(
+        new CameraReprjErrorNoDistortion(o_x, o_y)));
   }
   double ox_; /** observed x location of object in image */
   double oy_; /** observed y location of object in image */
@@ -211,85 +211,83 @@ struct CameraReprjErrorNoDistortion
 
 struct TargetCameraReprjErrorNoDistortion
 {
-  TargetCameraReprjErrorNoDistortion(double ob_x, double ob_y) :
-      ox_(ob_x), oy_(ob_y)
+  TargetCameraReprjErrorNoDistortion(double ob_x, double ob_y) : ox_(ob_x), oy_(ob_y)
   {
   }
 
-  template<typename T>
-    bool operator()(const T* const c_p1, /** extrinsic parameters */
-                    const T* const c_p2, /** intrinsic parameters */
-                    const T* const c_p3, /** 6Dof transform of target points into world frame */
-                    const T* const point, /** point described in target frame that is being seen */
-                    T* resid) const
-    {
+  template < typename T >
+  bool operator()(const T* const c_p1,  /** extrinsic parameters */
+                  const T* const c_p2,  /** intrinsic parameters */
+                  const T* const c_p3,  /** 6Dof transform of target points into world frame */
+                  const T* const point, /** point described in target frame that is being seen */
+                  T* resid) const
+  {
+    /** extract the variables from parameter blocks  */
+    int q = 0;               /** extract extrinsic block of parameters */
+    const T& ax = c_p1[q++]; /**  angle_axis x for rotation of camera		 */
+    const T& ay = c_p1[q++]; /**  angle_axis y for rotation of camera */
+    const T& az = c_p1[q++]; /**  angle_axis z for rotation of camera */
+    const T& tx = c_p1[q++]; /**  translation of camera x */
+    const T& ty = c_p1[q++]; /**  translation of camera y */
+    const T& tz = c_p1[q++]; /**  translation of camera z */
 
-      /** extract the variables from parameter blocks  */
-      int q = 0; /** extract extrinsic block of parameters */
-      const T& ax = c_p1[q++]; /**  angle_axis x for rotation of camera		 */
-      const T& ay = c_p1[q++]; /**  angle_axis y for rotation of camera */
-      const T& az = c_p1[q++]; /**  angle_axis z for rotation of camera */
-      const T& tx = c_p1[q++]; /**  translation of camera x */
-      const T& ty = c_p1[q++]; /**  translation of camera y */
-      const T& tz = c_p1[q++]; /**  translation of camera z */
+    q = 0;                   /** extract intrinsic block of parameters */
+    const T& fx = c_p2[q++]; /**  focal length x */
+    const T& fy = c_p2[q++]; /**  focal length x */
+    const T& cx = c_p2[q++]; /**  center point x */
+    const T& cy = c_p2[q++]; /**  center point y */
 
-      q = 0; /** extract intrinsic block of parameters */
-      const T& fx = c_p2[q++]; /**  focal length x */
-      const T& fy = c_p2[q++]; /**  focal length x */
-      const T& cx = c_p2[q++]; /**  center point x */
-      const T& cy = c_p2[q++]; /**  center point y */
+    q = 0;                          /** extract target pose block of parameters */
+    const T& target_x = c_p3[q++];  /**  target's x location */
+    const T& target_y = c_p3[q++];  /**  target's y location */
+    const T& target_z = c_p3[q++];  /**  target's z location */
+    const T& target_ax = c_p3[q++]; /**  target's ax angle axis value */
+    const T& target_ay = c_p3[q++]; /**  target's ay angle axis value */
+    const T& target_az = c_p3[q++]; /**  target's az angle axis value */
 
-      q = 0; /** extract target pose block of parameters */
-      const T& target_x = c_p3[q++]; /**  target's x location */
-      const T& target_y = c_p3[q++]; /**  target's y location */
-      const T& target_z = c_p3[q++]; /**  target's z location */
-      const T& target_ax = c_p3[q++]; /**  target's ax angle axis value */
-      const T& target_ay = c_p3[q++]; /**  target's ay angle axis value */
-      const T& target_az = c_p3[q++]; /**  target's az angle axis value */
+    /** rotate and translate points into world frame */
+    T target_aa[3];       /** angle axis  */
+    T world_point_loc[3]; /** point rotated */
+    target_aa[0] = target_ax;
+    target_aa[1] = target_ay;
+    target_aa[2] = target_az;
+    ceres::AngleAxisRotatePoint(target_aa, point, world_point_loc);
 
-      /** rotate and translate points into world frame */
-      T target_aa[3];/** angle axis  */
-      T world_point_loc[3]; /** point rotated */
-      target_aa[0] = target_ax;
-      target_aa[1] = target_ay;
-      target_aa[2] = target_az;
-      ceres::AngleAxisRotatePoint(target_aa, point, world_point_loc);
+    /** apply target translation */
+    world_point_loc[0] = world_point_loc[0] + target_x;
+    world_point_loc[1] = world_point_loc[1] + target_y;
+    world_point_loc[2] = world_point_loc[2] + target_z;
 
-      /** apply target translation */
-      world_point_loc[0] = world_point_loc[0] + target_x;
-      world_point_loc[1] = world_point_loc[1] + target_y;
-      world_point_loc[2] = world_point_loc[2] + target_z;
+    /** rotate and translate points into camera frame */
+    /*  Note that camera transform is from world into camera frame, not vise versa */
+    T aa[3];               /** angle axis  */
+    T camera_point_loc[3]; /** point rotated */
+    aa[0] = ax;
+    aa[1] = ay;
+    aa[2] = az;
+    ceres::AngleAxisRotatePoint(aa, point, camera_point_loc);
 
-      /** rotate and translate points into camera frame */
-      /*  Note that camera transform is from world into camera frame, not vise versa */
-      T aa[3];/** angle axis  */
-      T camera_point_loc[3]; /** point rotated */
-      aa[0] = ax;
-      aa[1] = ay;
-      aa[2] = az;
-      ceres::AngleAxisRotatePoint(aa, point, camera_point_loc);
+    /** apply camera translation */
+    T xp1 = camera_point_loc[0] + tx; /** point rotated and translated */
+    T yp1 = camera_point_loc[1] + ty;
+    T zp1 = camera_point_loc[2] + tz;
 
-      /** apply camera translation */
-      T xp1 = camera_point_loc[0] + tx; /** point rotated and translated */
-      T yp1 = camera_point_loc[1] + ty;
-      T zp1 = camera_point_loc[2] + tz;
+    /** scale into the image plane by distance away from camera */
+    T xp = xp1 / zp1;
+    T yp = yp1 / zp1;
 
-      /** scale into the image plane by distance away from camera */
-      T xp = xp1 / zp1;
-      T yp = yp1 / zp1;
+    /** perform projection using focal length and camera center into image plane */
+    resid[0] = fx * xp + cx - T(ox_);
+    resid[1] = fy * yp + cy - T(oy_);
 
-      /** perform projection using focal length and camera center into image plane */
-      resid[0] = fx * xp + cx - T(ox_);
-      resid[1] = fy * yp + cy - T(oy_);
-
-      return true;
-    } /** end of operator() */
+    return true;
+  } /** end of operator() */
 
   /** Factory to hide the construction of the CostFunction object from */
   /** the client code. */
   static ceres::CostFunction* Create(const double o_x, const double o_y)
   {
-    return (new ceres::AutoDiffCostFunction<TargetCameraReprjErrorNoDistortion, 2, 6, 4, 6, 3>(
+    return (new ceres::AutoDiffCostFunction< TargetCameraReprjErrorNoDistortion, 2, 6, 4, 6, 3 >(
         new CameraReprjError(o_x, o_y)));
   }
   double ox_; /** observed x location of object in image */
@@ -298,96 +296,95 @@ struct TargetCameraReprjErrorNoDistortion
 
 struct TargetCameraReprjErrorProjModelAsClassVars
 {
-  TargetCameraReprjErrorProjModelAsClassVars(double ob_x, double ob_y, double fx, double fy, double cx, double cy) :
-      ox_(ob_x), oy_(ob_y), fx_(fx), fy_(fy), cx_(cx), cy_(cy)
+  TargetCameraReprjErrorProjModelAsClassVars(double ob_x, double ob_y, double fx, double fy, double cx, double cy)
+    : ox_(ob_x), oy_(ob_y), fx_(fx), fy_(fy), cx_(cx), cy_(cy)
   {
   }
 
-  template<typename T>
-    bool operator()(const T* const c_p1, /** extrinsic parameters */
-                    const T* const c_p2, /** 6Dof transform of target points into world frame */
-                    const T* const point, /** point described in target frame that is being seen */
-                    T* resid) const
-    {
+  template < typename T >
+  bool operator()(const T* const c_p1,  /** extrinsic parameters */
+                  const T* const c_p2,  /** 6Dof transform of target points into world frame */
+                  const T* const point, /** point described in target frame that is being seen */
+                  T* resid) const
+  {
+    /** extract the variables from parameter blocks  */
+    int q = 0;               /** extract extrinsic block of parameters */
+    const T& ax = c_p1[q++]; /**  angle_axis x for rotation of camera		 */
+    const T& ay = c_p1[q++]; /**  angle_axis y for rotation of camera */
+    const T& az = c_p1[q++]; /**  angle_axis z for rotation of camera */
+    const T& tx = c_p1[q++]; /**  translation of camera x */
+    const T& ty = c_p1[q++]; /**  translation of camera y */
+    const T& tz = c_p1[q++]; /**  translation of camera z */
 
-      /** extract the variables from parameter blocks  */
-      int q = 0; /** extract extrinsic block of parameters */
-      const T& ax = c_p1[q++]; /**  angle_axis x for rotation of camera		 */
-      const T& ay = c_p1[q++]; /**  angle_axis y for rotation of camera */
-      const T& az = c_p1[q++]; /**  angle_axis z for rotation of camera */
-      const T& tx = c_p1[q++]; /**  translation of camera x */
-      const T& ty = c_p1[q++]; /**  translation of camera y */
-      const T& tz = c_p1[q++]; /**  translation of camera z */
+    q = 0;                          /** extract target pose block of parameters */
+    const T& target_x = c_p2[q++];  /**  target's x location */
+    const T& target_y = c_p2[q++];  /**  target's y location */
+    const T& target_z = c_p2[q++];  /**  target's z location */
+    const T& target_ax = c_p2[q++]; /**  target's ax angle axis value */
+    const T& target_ay = c_p2[q++]; /**  target's ay angle axis value */
+    const T& target_az = c_p2[q++]; /**  target's az angle axis value */
 
-      q = 0; /** extract target pose block of parameters */
-      const T& target_x = c_p2[q++]; /**  target's x location */
-      const T& target_y = c_p2[q++]; /**  target's y location */
-      const T& target_z = c_p2[q++]; /**  target's z location */
-      const T& target_ax = c_p2[q++]; /**  target's ax angle axis value */
-      const T& target_ay = c_p2[q++]; /**  target's ay angle axis value */
-      const T& target_az = c_p2[q++]; /**  target's az angle axis value */
+    /** rotate and translate points into world frame */
+    // create a vector from the location of the point in the target's frame
+    T point[3];
+    point[0] = pnt_x_;
+    point[1] = pnt_y_;
+    point[2] = pnt_z_;
 
-      /** rotate and translate points into world frame */
-      // create a vector from the location of the point in the target's frame
-      T point[3];
-      point[0] = pnt_x_;
-      point[1] = pnt_y_;
-      point[2] = pnt_z_;
+    /** rotate and translate points into world frame */
+    T target_aa[3];       /** angle axis  */
+    T world_point_loc[3]; /** point rotated */
+    target_aa[0] = target_ax;
+    target_aa[1] = target_ay;
+    target_aa[2] = target_az;
+    ceres::AngleAxisRotatePoint(target_aa, point, world_point_loc);
 
-      /** rotate and translate points into world frame */
-      T target_aa[3];/** angle axis  */
-      T world_point_loc[3]; /** point rotated */
-      target_aa[0] = target_ax;
-      target_aa[1] = target_ay;
-      target_aa[2] = target_az;
-      ceres::AngleAxisRotatePoint(target_aa, point, world_point_loc);
+    /** apply target translation */
+    world_point_loc[0] = world_point_loc[0] + target_x;
+    world_point_loc[1] = world_point_loc[1] + target_y;
+    world_point_loc[2] = world_point_loc[2] + target_z;
 
-      /** apply target translation */
-      world_point_loc[0] = world_point_loc[0] + target_x;
-      world_point_loc[1] = world_point_loc[1] + target_y;
-      world_point_loc[2] = world_point_loc[2] + target_z;
+    /** rotate and translate points into camera frame */
+    /*  Note that camera transform is from world into camera frame, not vise versa */
+    T aa[3];               /** angle axis  */
+    T camera_point_loc[3]; /** point rotated */
+    aa[0] = ax;
+    aa[1] = ay;
+    aa[2] = az;
+    ceres::AngleAxisRotatePoint(aa, point, camera_point_loc);
 
-      /** rotate and translate points into camera frame */
-      /*  Note that camera transform is from world into camera frame, not vise versa */
-      T aa[3];/** angle axis  */
-      T camera_point_loc[3]; /** point rotated */
-      aa[0] = ax;
-      aa[1] = ay;
-      aa[2] = az;
-      ceres::AngleAxisRotatePoint(aa, point, camera_point_loc);
+    /** apply camera translation */
+    T xp1 = camera_point_loc[0] + tx; /** point rotated and translated */
+    T yp1 = camera_point_loc[1] + ty;
+    T zp1 = camera_point_loc[2] + tz;
 
-      /** apply camera translation */
-      T xp1 = camera_point_loc[0] + tx; /** point rotated and translated */
-      T yp1 = camera_point_loc[1] + ty;
-      T zp1 = camera_point_loc[2] + tz;
+    /** scale into the image plane by distance away from camera */
+    T xp = xp1 / zp1;
+    T yp = yp1 / zp1;
 
-      /** scale into the image plane by distance away from camera */
-      T xp = xp1 / zp1;
-      T yp = yp1 / zp1;
+    /** perform projection using focal length and camera center into image plane */
+    resid[0] = T(fx_) * xp + T(cx_) - T(ox_);
+    resid[1] = T(fy_) * yp + T(cy_) - T(oy_);
 
-      /** perform projection using focal length and camera center into image plane */
-      resid[0] = T(fx_) * xp + T(cx_) - T(ox_);
-      resid[1] = T(fy_) * yp + T(cy_) - T(oy_);
-
-      return true;
-    } /** end of operator() */
+    return true;
+  } /** end of operator() */
 
   /** Factory to hide the construction of the CostFunction object from */
   /** the client code. */
   static ceres::CostFunction* Create(const double o_x, const double o_y, double fx, double fy, double cx, double cy)
   {
-    return (new ceres::AutoDiffCostFunction<TargetCameraReprjErrorProjModelAsClassVars, 2, 6, 6, 3>(
+    return (new ceres::AutoDiffCostFunction< TargetCameraReprjErrorProjModelAsClassVars, 2, 6, 6, 3 >(
         new CameraReprjError(o_x, o_y, fx, fy, cx, cy)));
   }
-  double ox_; /** observed x location of object in image */
-  double oy_; /** observed y location of object in image */
-  double fx_; /** focal length in x pixels */
-  double fy_; /** focal length in x pixels */
-  double cx_; /** optical center x */
-  double cy_; /** optical center y */
-  double pnt_x_;/*!< known location of point in target's reference frame x */
-  double pnt_y_;/*!< known location of point in target's reference frame y */
-  double pnt_z_;/*!< known location of point in target's reference frame z */
+  double ox_;    /** observed x location of object in image */
+  double oy_;    /** observed y location of object in image */
+  double fx_;    /** focal length in x pixels */
+  double fy_;    /** focal length in x pixels */
+  double cx_;    /** optical center x */
+  double cy_;    /** optical center y */
+  double pnt_x_; /*!< known location of point in target's reference frame x */
+  double pnt_y_; /*!< known location of point in target's reference frame y */
+  double pnt_z_; /*!< known location of point in target's reference frame z */
 };
 
 void printQTasH(double qx, double qy, double qz, double qw, double tx, double ty, double tz)
@@ -469,4 +466,4 @@ void printCameraParameters(CameraParameters C, std::string words)
   printf("p1 = %8.3lf p2 = %8.3lf\n", C.p1, C.p2);
   printf("cx = %8.3lf cy = %8.3lf\n", C.cx, C.cy);
 }
-} // end of namespace
+}  // end of namespace

--- a/industrial_extrinsic_cal/src/ceres_costs_utils.cpp
+++ b/industrial_extrinsic_cal/src/ceres_costs_utils.cpp
@@ -20,72 +20,85 @@
 
 namespace industrial_extrinsic_cal
 {
-  /*! @brief converts a string to a cost type 
-   *   @param cost_type_str The cost type string 
-   *   @returns The cost function type from the enumeration
-   */
-  Cost_function string2CostType(std::string &cost_type_str)
-  {
-    if(cost_type_str == "CameraReprjErrorWithDistortion") return(cost_functions::CameraReprjErrorWithDistortion);
-    if(cost_type_str == "CameraReprjErrorWithDistortionPK") return(cost_functions::CameraReprjErrorWithDistortionPK);
-    if(cost_type_str == "CameraReprjError") return(cost_functions::CameraReprjError);
-    if(cost_type_str == "CameraReprjErrorPK") return(cost_functions::CameraReprjErrorPK);
-    if(cost_type_str == "TriangulationErrro") return(cost_functions::TriangulationError);
-    if(cost_type_str == "TargetCameraReprjError") return(cost_functions::TargetCameraReprjError);
-    if(cost_type_str == "TargetCameraReprjErrorPK") return(cost_functions::TargetCameraReprjErrorPK);
-    if(cost_type_str == "LinkTargetCameraReprjError") return(cost_functions::LinkTargetCameraReprjError);
-    if(cost_type_str == "LinkTargetCameraReprjErrorPK") return(cost_functions::LinkTargetCameraReprjErrorPK);
-    if(cost_type_str == "PosedTargetCameraReprjErrorPK") return(cost_functions::PosedTargetCameraReprjErrorPK);
-    if(cost_type_str == "LinkCameraTargetReprjError") return(cost_functions::LinkCameraTargetReprjError);
-    if(cost_type_str == "LinkCameraTargetReprjErrorPK") return(cost_functions::LinkCameraTargetReprjErrorPK);
-    if(cost_type_str == "CircleCameraReprjErrorWithDistortion") return(cost_functions::CircleCameraReprjErrorWithDistortion);
-    if(cost_type_str == "CircleCameraReprjErrorWithDistortionPK") return(cost_functions::CircleCameraReprjErrorWithDistortionPK);
-    if(cost_type_str == "CircleCameraReprjError") return(cost_functions::CircleCameraReprjError);
-    if(cost_type_str == "CircleCameraReprjErrorPK") return(cost_functions::CircleCameraReprjErrorPK);
-    if(cost_type_str == "CircleTargetCameraReprjErrorWithDistortion") return(cost_functions::CircleTargetCameraReprjErrorWithDistortion);
-    if(cost_type_str == "CircleTargetCameraReprjErrorWithDistortionPK") return(cost_functions::CircleTargetCameraReprjErrorWithDistortionPK);
-    if(cost_type_str == "FixedCircleTargetCameraReprjErrorWithDistortionPK") return(cost_functions::FixedCircleTargetCameraReprjErrorWithDistortionPK);
-    if(cost_type_str == "SimpleCircleTargetCameraReprjErrorWithDistortionPK") return(cost_functions::SimpleCircleTargetCameraReprjErrorWithDistortionPK);
-    if(cost_type_str == "CircleTargetCameraReprjError") return(cost_functions::CircleTargetCameraReprjError);
-    if(cost_type_str == "CircleTargetCameraReprjErrorPK") return(cost_functions::CircleTargetCameraReprjErrorPK);
-    if(cost_type_str == "LinkCircleTargetCameraReprjError") return(cost_functions::LinkCircleTargetCameraReprjError);
-    if(cost_type_str == "LinkCircleTargetCameraReprjErrorPK") return(cost_functions::LinkCircleTargetCameraReprjErrorPK);
-    if(cost_type_str == "LinkCameraCircleTargetReprjError") return(cost_functions::LinkCameraCircleTargetReprjError);
-    if(cost_type_str == "LinkCameraCircleTargetReprjErrorPK") return(cost_functions::LinkCameraCircleTargetReprjErrorPK);
-    if(cost_type_str == "FixedCircleTargetCameraReprjErrorPK") return(cost_functions::FixedCircleTargetCameraReprjErrorPK);
-    return(cost_functions::NullCostType);
-  }
+/*! @brief converts a string to a cost type
+ *   @param cost_type_str The cost type string
+ *   @returns The cost function type from the enumeration
+ */
+Cost_function string2CostType(std::string& cost_type_str)
+{
+  if (cost_type_str == "CameraReprjErrorWithDistortion") return (cost_functions::CameraReprjErrorWithDistortion);
+  if (cost_type_str == "CameraReprjErrorWithDistortionPK") return (cost_functions::CameraReprjErrorWithDistortionPK);
+  if (cost_type_str == "CameraReprjError") return (cost_functions::CameraReprjError);
+  if (cost_type_str == "CameraReprjErrorPK") return (cost_functions::CameraReprjErrorPK);
+  if (cost_type_str == "TriangulationErrro") return (cost_functions::TriangulationError);
+  if (cost_type_str == "TargetCameraReprjError") return (cost_functions::TargetCameraReprjError);
+  if (cost_type_str == "TargetCameraReprjErrorPK") return (cost_functions::TargetCameraReprjErrorPK);
+  if (cost_type_str == "LinkTargetCameraReprjError") return (cost_functions::LinkTargetCameraReprjError);
+  if (cost_type_str == "LinkTargetCameraReprjErrorPK") return (cost_functions::LinkTargetCameraReprjErrorPK);
+  if (cost_type_str == "PosedTargetCameraReprjErrorPK") return (cost_functions::PosedTargetCameraReprjErrorPK);
+  if (cost_type_str == "LinkCameraTargetReprjError") return (cost_functions::LinkCameraTargetReprjError);
+  if (cost_type_str == "LinkCameraTargetReprjErrorPK") return (cost_functions::LinkCameraTargetReprjErrorPK);
+  if (cost_type_str == "CircleCameraReprjErrorWithDistortion")
+    return (cost_functions::CircleCameraReprjErrorWithDistortion);
+  if (cost_type_str == "CircleCameraReprjErrorWithDistortionPK")
+    return (cost_functions::CircleCameraReprjErrorWithDistortionPK);
+  if (cost_type_str == "CircleCameraReprjError") return (cost_functions::CircleCameraReprjError);
+  if (cost_type_str == "CircleCameraReprjErrorPK") return (cost_functions::CircleCameraReprjErrorPK);
+  if (cost_type_str == "CircleTargetCameraReprjErrorWithDistortion")
+    return (cost_functions::CircleTargetCameraReprjErrorWithDistortion);
+  if (cost_type_str == "CircleTargetCameraReprjErrorWithDistortionPK")
+    return (cost_functions::CircleTargetCameraReprjErrorWithDistortionPK);
+  if (cost_type_str == "FixedCircleTargetCameraReprjErrorWithDistortionPK")
+    return (cost_functions::FixedCircleTargetCameraReprjErrorWithDistortionPK);
+  if (cost_type_str == "SimpleCircleTargetCameraReprjErrorWithDistortionPK")
+    return (cost_functions::SimpleCircleTargetCameraReprjErrorWithDistortionPK);
+  if (cost_type_str == "CircleTargetCameraReprjError") return (cost_functions::CircleTargetCameraReprjError);
+  if (cost_type_str == "CircleTargetCameraReprjErrorPK") return (cost_functions::CircleTargetCameraReprjErrorPK);
+  if (cost_type_str == "LinkCircleTargetCameraReprjError") return (cost_functions::LinkCircleTargetCameraReprjError);
+  if (cost_type_str == "LinkCircleTargetCameraReprjErrorPK")
+    return (cost_functions::LinkCircleTargetCameraReprjErrorPK);
+  if (cost_type_str == "LinkCameraCircleTargetReprjError") return (cost_functions::LinkCameraCircleTargetReprjError);
+  if (cost_type_str == "LinkCameraCircleTargetReprjErrorPK")
+    return (cost_functions::LinkCameraCircleTargetReprjErrorPK);
+  if (cost_type_str == "FixedCircleTargetCameraReprjErrorPK")
+    return (cost_functions::FixedCircleTargetCameraReprjErrorPK);
+  return (cost_functions::NullCostType);
+}
 
-  /*! @brief converts a cost type to a string
-   *   @param cost_type The cost type 
-   *   @returns The cost function type as a string
-   */
-  std::string costType2String(Cost_function cost_type)
-  {
-    if(cost_type == cost_functions::CameraReprjErrorWithDistortion) return("CameraReprjErrorWithDistortion");
-    if(cost_type == cost_functions::CameraReprjErrorWithDistortionPK) return("CameraReprjErrorWithDistortionPK");
-    if(cost_type == cost_functions::CameraReprjError) return("CameraReprjError");
-    if(cost_type == cost_functions::CameraReprjErrorPK) return("CameraReprjErrorPK");
-    if(cost_type == cost_functions::TargetCameraReprjError) return("TargetCameraReprjError");
-    if(cost_type == cost_functions::TargetCameraReprjErrorPK) return("TargetCameraReprjErrorPK");
-    if(cost_type == cost_functions::LinkTargetCameraReprjError) return("LinkTargetCameraReprjError");
-    if(cost_type == cost_functions::LinkTargetCameraReprjErrorPK) return("LinkTargetCameraReprjErrorPK");
-    if(cost_type == cost_functions::PosedTargetCameraReprjErrorPK) return("PosedTargetCameraReprjErrorPK");
-    if(cost_type == cost_functions::LinkCameraTargetReprjError) return("LinkCameraTargetReprjError");
-    if(cost_type == cost_functions::LinkCameraTargetReprjErrorPK) return("LinkCameraTargetReprjErrorPK");
-    if(cost_type == cost_functions::CircleCameraReprjErrorWithDistortion) return("CircleCameraReprjErrorWithDistortion");
-    if(cost_type == cost_functions::CircleCameraReprjErrorWithDistortionPK) return("CircleCameraReprjErrorWithDistortionPK");
-    if(cost_type == cost_functions::CircleCameraReprjError) return("CircleCameraReprjError");
-    if(cost_type == cost_functions::CircleCameraReprjErrorPK) return("CircleCameraReprjErrorPK");
-    if(cost_type == cost_functions::CircleTargetCameraReprjErrorWithDistortion) return("CircleTargetCameraReprjErrorWithDistortion");
-    if(cost_type == cost_functions::CircleTargetCameraReprjErrorWithDistortionPK) return("CircleTargetCameraReprjErrorWithDistortionPK");
-    if(cost_type == cost_functions::CircleTargetCameraReprjError) return("CircleTargetCameraReprjError");
-    if(cost_type == cost_functions::CircleTargetCameraReprjErrorPK) return("CircleTargetCameraReprjErrorPK");
-    if(cost_type == cost_functions::LinkCircleTargetCameraReprjError) return("LinkCircleTargetCameraReprjError");
-    if(cost_type == cost_functions::LinkCircleTargetCameraReprjErrorPK) return("LinkCircleTargetCameraReprjErrorPK");
-    if(cost_type == cost_functions::LinkCameraCircleTargetReprjError) return("LinkCameraCircleTargetReprjError");
-    if(cost_type == cost_functions::LinkCameraCircleTargetReprjErrorPK) return("LinkCameraCircleTargetReprjErrorPK");
-    if(cost_type == cost_functions::FixedCircleTargetCameraReprjErrorPK) return("FixedCircleTargetCameraReprjErrorPK");
-    return("NullCostType");
-  }
-}// end of namespace
+/*! @brief converts a cost type to a string
+ *   @param cost_type The cost type
+ *   @returns The cost function type as a string
+ */
+std::string costType2String(Cost_function cost_type)
+{
+  if (cost_type == cost_functions::CameraReprjErrorWithDistortion) return ("CameraReprjErrorWithDistortion");
+  if (cost_type == cost_functions::CameraReprjErrorWithDistortionPK) return ("CameraReprjErrorWithDistortionPK");
+  if (cost_type == cost_functions::CameraReprjError) return ("CameraReprjError");
+  if (cost_type == cost_functions::CameraReprjErrorPK) return ("CameraReprjErrorPK");
+  if (cost_type == cost_functions::TargetCameraReprjError) return ("TargetCameraReprjError");
+  if (cost_type == cost_functions::TargetCameraReprjErrorPK) return ("TargetCameraReprjErrorPK");
+  if (cost_type == cost_functions::LinkTargetCameraReprjError) return ("LinkTargetCameraReprjError");
+  if (cost_type == cost_functions::LinkTargetCameraReprjErrorPK) return ("LinkTargetCameraReprjErrorPK");
+  if (cost_type == cost_functions::PosedTargetCameraReprjErrorPK) return ("PosedTargetCameraReprjErrorPK");
+  if (cost_type == cost_functions::LinkCameraTargetReprjError) return ("LinkCameraTargetReprjError");
+  if (cost_type == cost_functions::LinkCameraTargetReprjErrorPK) return ("LinkCameraTargetReprjErrorPK");
+  if (cost_type == cost_functions::CircleCameraReprjErrorWithDistortion)
+    return ("CircleCameraReprjErrorWithDistortion");
+  if (cost_type == cost_functions::CircleCameraReprjErrorWithDistortionPK)
+    return ("CircleCameraReprjErrorWithDistortionPK");
+  if (cost_type == cost_functions::CircleCameraReprjError) return ("CircleCameraReprjError");
+  if (cost_type == cost_functions::CircleCameraReprjErrorPK) return ("CircleCameraReprjErrorPK");
+  if (cost_type == cost_functions::CircleTargetCameraReprjErrorWithDistortion)
+    return ("CircleTargetCameraReprjErrorWithDistortion");
+  if (cost_type == cost_functions::CircleTargetCameraReprjErrorWithDistortionPK)
+    return ("CircleTargetCameraReprjErrorWithDistortionPK");
+  if (cost_type == cost_functions::CircleTargetCameraReprjError) return ("CircleTargetCameraReprjError");
+  if (cost_type == cost_functions::CircleTargetCameraReprjErrorPK) return ("CircleTargetCameraReprjErrorPK");
+  if (cost_type == cost_functions::LinkCircleTargetCameraReprjError) return ("LinkCircleTargetCameraReprjError");
+  if (cost_type == cost_functions::LinkCircleTargetCameraReprjErrorPK) return ("LinkCircleTargetCameraReprjErrorPK");
+  if (cost_type == cost_functions::LinkCameraCircleTargetReprjError) return ("LinkCameraCircleTargetReprjError");
+  if (cost_type == cost_functions::LinkCameraCircleTargetReprjErrorPK) return ("LinkCameraCircleTargetReprjErrorPK");
+  if (cost_type == cost_functions::FixedCircleTargetCameraReprjErrorPK) return ("FixedCircleTargetCameraReprjErrorPK");
+  return ("NullCostType");
+}
+}  // end of namespace

--- a/industrial_extrinsic_cal/src/circle_detector.cpp
+++ b/industrial_extrinsic_cal/src/circle_detector.cpp
@@ -43,7 +43,7 @@
 
 /********************************************************************************************
 **   Slight Modification of OpenCV function to use ellipse fitting rather than center of mass of contour ****
-**  to provide the location of the circle                                                                                               ****
+**  to provide the location of the circle ****
 ********************************************************************************************/
 
 #include "opencv2/features2d.hpp"
@@ -62,44 +62,40 @@
 
 #include "opencv2/opencv.hpp"
 
-
-
 #include <industrial_extrinsic_cal/circle_detector.hpp>
 #include <iterator>
 
 //#define DEBUG_CIRCLE_DETECTOR
 
 #ifdef DEBUG_CIRCLE_DETECTOR
-#  include "opencv2/opencv_modules.hpp"
-#  ifdef HAVE_OPENCV_HIGHGUI
-#    include "opencv2/highgui/highgui.hpp"
-#  else
-#    undef DEBUG_CIRCLE_DETECTOR
-#  endif
+#include "opencv2/opencv_modules.hpp"
+#ifdef HAVE_OPENCV_HIGHGUI
+#include "opencv2/highgui/highgui.hpp"
+#else
+#undef DEBUG_CIRCLE_DETECTOR
+#endif
 #endif
 
 namespace cv
 {
-
 class CV_EXPORTS_W CircleDetectorImpl : public CircleDetector
 {
 public:
+  explicit CircleDetectorImpl(const CircleDetector::Params& parameters = CircleDetector::Params());
 
-  explicit CircleDetectorImpl(const CircleDetector::Params &parameters = CircleDetector::Params());
-
-  virtual void read( const FileNode& fn );
-  virtual void write( FileStorage& fs ) const;
+  virtual void read(const FileNode& fn);
+  virtual void write(FileStorage& fs) const;
 
 protected:
   struct CV_EXPORTS Center
   {
-      Point2d location;
-      double radius;
-      double confidence;
+    Point2d location;
+    double radius;
+    double confidence;
   };
 
-  virtual void detect( InputArray image, std::vector<KeyPoint>& keypoints, InputArray mask=noArray() );
-  virtual void findCircles(InputArray image, InputArray binaryImage, std::vector<Center> &centers) const;
+  virtual void detect(InputArray image, std::vector< KeyPoint >& keypoints, InputArray mask = noArray());
+  virtual void findCircles(InputArray image, InputArray binaryImage, std::vector< Center >& centers) const;
 
   Params params;
 };
@@ -109,232 +105,224 @@ protected:
 */
 CircleDetector::Params::Params()
 {
-	thresholdStep = 10;
-	minThreshold = 50;
-	maxThreshold = 220;
-	minRepeatability = 2;
-	minDistBetweenCircles = 10;
-        minRadiusDiff = 10;
+  thresholdStep = 10;
+  minThreshold = 50;
+  maxThreshold = 220;
+  minRepeatability = 2;
+  minDistBetweenCircles = 10;
+  minRadiusDiff = 10;
 
-	filterByColor = true;
-	circleColor = 0;
+  filterByColor = true;
+  circleColor = 0;
 
-	filterByArea = true;
-	minArea = 25;
-	maxArea = 5000;
+  filterByArea = true;
+  minArea = 25;
+  maxArea = 5000;
 
-	filterByCircularity = false;
-	minCircularity = 0.8f;
-	maxCircularity = std::numeric_limits<float>::max();
+  filterByCircularity = false;
+  minCircularity = 0.8f;
+  maxCircularity = std::numeric_limits< float >::max();
 
-	filterByInertia = true;
-	minInertiaRatio = 0.1f;
-	maxInertiaRatio = std::numeric_limits<float>::max();
+  filterByInertia = true;
+  minInertiaRatio = 0.1f;
+  maxInertiaRatio = std::numeric_limits< float >::max();
 
-	filterByConvexity = true;
-	minConvexity = 0.95f;
-	maxConvexity = std::numeric_limits<float>::max();
+  filterByConvexity = true;
+  minConvexity = 0.95f;
+  maxConvexity = std::numeric_limits< float >::max();
 }
 
-void CircleDetector::Params::read(const cv::FileNode& fn )
+void CircleDetector::Params::read(const cv::FileNode& fn)
 {
-    thresholdStep = fn["thresholdStep"];
-    minThreshold = fn["minThreshold"];
-    maxThreshold = fn["maxThreshold"];
+  thresholdStep = fn["thresholdStep"];
+  minThreshold = fn["minThreshold"];
+  maxThreshold = fn["maxThreshold"];
 
-    minRepeatability = (size_t)(int)fn["minRepeatability"];
-    minDistBetweenCircles = fn["minDistBetweenCircles"];
+  minRepeatability = (size_t)(int)fn["minRepeatability"];
+  minDistBetweenCircles = fn["minDistBetweenCircles"];
 
-    filterByColor = (int)fn["filterByColor"] != 0 ? true : false;
-    circleColor = (uchar)(int)fn["circleColor"];
+  filterByColor = (int)fn["filterByColor"] != 0 ? true : false;
+  circleColor = (uchar)(int)fn["circleColor"];
 
-    filterByArea = (int)fn["filterByArea"] != 0 ? true : false;
-    minArea = fn["minArea"];
-    maxArea = fn["maxArea"];
+  filterByArea = (int)fn["filterByArea"] != 0 ? true : false;
+  minArea = fn["minArea"];
+  maxArea = fn["maxArea"];
 
-    filterByCircularity = (int)fn["filterByCircularity"] != 0 ? true : false;
-    minCircularity = fn["minCircularity"];
-    maxCircularity = fn["maxCircularity"];
+  filterByCircularity = (int)fn["filterByCircularity"] != 0 ? true : false;
+  minCircularity = fn["minCircularity"];
+  maxCircularity = fn["maxCircularity"];
 
-    filterByInertia = (int)fn["filterByInertia"] != 0 ? true : false;
-    minInertiaRatio = fn["minInertiaRatio"];
-    maxInertiaRatio = fn["maxInertiaRatio"];
+  filterByInertia = (int)fn["filterByInertia"] != 0 ? true : false;
+  minInertiaRatio = fn["minInertiaRatio"];
+  maxInertiaRatio = fn["maxInertiaRatio"];
 
-    filterByConvexity = (int)fn["filterByConvexity"] != 0 ? true : false;
-    minConvexity = fn["minConvexity"];
-    maxConvexity = fn["maxConvexity"];
+  filterByConvexity = (int)fn["filterByConvexity"] != 0 ? true : false;
+  minConvexity = fn["minConvexity"];
+  maxConvexity = fn["maxConvexity"];
 }
 
 void CircleDetector::Params::write(cv::FileStorage& fs) const
 {
-    fs << "thresholdStep" << thresholdStep;
-    fs << "minThreshold" << minThreshold;
-    fs << "maxThreshold" << maxThreshold;
+  fs << "thresholdStep" << thresholdStep;
+  fs << "minThreshold" << minThreshold;
+  fs << "maxThreshold" << maxThreshold;
 
-    fs << "minRepeatability" << (int)minRepeatability;
-    fs << "minDistBetweenCircles" << minDistBetweenCircles;
+  fs << "minRepeatability" << (int)minRepeatability;
+  fs << "minDistBetweenCircles" << minDistBetweenCircles;
 
-    fs << "filterByColor" << (int)filterByColor;
-    fs << "circleColor" << (int)circleColor;
+  fs << "filterByColor" << (int)filterByColor;
+  fs << "circleColor" << (int)circleColor;
 
-    fs << "filterByArea" << (int)filterByArea;
-    fs << "minArea" << minArea;
-    fs << "maxArea" << maxArea;
+  fs << "filterByArea" << (int)filterByArea;
+  fs << "minArea" << minArea;
+  fs << "maxArea" << maxArea;
 
-    fs << "filterByCircularity" << (int)filterByCircularity;
-    fs << "minCircularity" << minCircularity;
-    fs << "maxCircularity" << maxCircularity;
+  fs << "filterByCircularity" << (int)filterByCircularity;
+  fs << "minCircularity" << minCircularity;
+  fs << "maxCircularity" << maxCircularity;
 
-    fs << "filterByInertia" << (int)filterByInertia;
-    fs << "minInertiaRatio" << minInertiaRatio;
-    fs << "maxInertiaRatio" << maxInertiaRatio;
+  fs << "filterByInertia" << (int)filterByInertia;
+  fs << "minInertiaRatio" << minInertiaRatio;
+  fs << "maxInertiaRatio" << maxInertiaRatio;
 
-    fs << "filterByConvexity" << (int)filterByConvexity;
-    fs << "minConvexity" << minConvexity;
-    fs << "maxConvexity" << maxConvexity;
+  fs << "filterByConvexity" << (int)filterByConvexity;
+  fs << "minConvexity" << minConvexity;
+  fs << "maxConvexity" << maxConvexity;
 }
 
-CircleDetectorImpl::CircleDetectorImpl(const CircleDetector::Params &parameters) :
-params(parameters)
+CircleDetectorImpl::CircleDetectorImpl(const CircleDetector::Params& parameters) : params(parameters)
 {
 }
 
-void CircleDetectorImpl::read( const cv::FileNode& fn )
+void CircleDetectorImpl::read(const cv::FileNode& fn)
 {
-    params.read(fn);
+  params.read(fn);
 }
 
-void CircleDetectorImpl::write( cv::FileStorage& fs ) const
+void CircleDetectorImpl::write(cv::FileStorage& fs) const
 {
   writeFormat(fs);
   params.write(fs);
 }
 
-void CircleDetectorImpl::findCircles(InputArray _image, InputArray _binaryImage, std::vector<Center> &centers) const
+void CircleDetectorImpl::findCircles(InputArray _image, InputArray _binaryImage, std::vector< Center >& centers) const
 {
   //  CV_INSTRUMENT_REGION()
 
-  Mat image       = _image.getMat(); // Oh so much  cleaner this way :(
+  Mat image = _image.getMat();  // Oh so much  cleaner this way :(
   Mat binaryImage = _binaryImage.getMat();
-  
+
   (void)image;
   centers.clear();
 
-  vector < vector<Point> > contours;
+  vector< vector< Point > > contours;
   Mat tmpBinaryImage = binaryImage.clone();
   findContours(tmpBinaryImage, contours, CV_RETR_LIST, CV_CHAIN_APPROX_NONE);
-  
+
   // loop on all contours
   for (size_t contourIdx = 0; contourIdx < contours.size(); contourIdx++)
+  {
+    // each if statement may eliminate a contour through the continue function
+    // some if statements may also set the confidence whose default is 1.0
+    Center center;
+    center.confidence = 1;
+    Moments moms = moments(Mat(contours[contourIdx]));
+    if (params.filterByArea)
     {
-      // each if statement may eliminate a contour through the continue function
-      // some if statements may also set the confidence whose default is 1.0
-      Center center;
-      center.confidence = 1;
-      Moments moms = moments(Mat(contours[contourIdx]));
-      if (params.filterByArea)
-	{
-	  double area = moms.m00;
-	  if (area < params.minArea || area >= params.maxArea)
-	    continue;
-	}
-      
-      if (params.filterByCircularity)
-	{
-	  double area = moms.m00;
-	  double perimeter = arcLength(Mat(contours[contourIdx]), true);
-	  double ratio = 4 * CV_PI * area / (perimeter * perimeter);
-	  if (ratio < params.minCircularity || ratio >= params.maxCircularity)
-	    continue;
-	}
-      
-      if (params.filterByInertia)
-	{
-	  double denominator = sqrt(pow(2 * moms.mu11, 2) + pow(moms.mu20 - moms.mu02, 2));
-	  const double eps = 1e-2;
-	  double ratio;
-	  if (denominator > eps)
-	    {
-	      double cosmin = (moms.mu20 - moms.mu02) / denominator;
-	      double sinmin = 2 * moms.mu11 / denominator;
-	      double cosmax = -cosmin;
-	      double sinmax = -sinmin;
-	      
-	      double imin = 0.5 * (moms.mu20 + moms.mu02) - 0.5 * (moms.mu20 - moms.mu02) * cosmin - moms.mu11 * sinmin;
-	      double imax = 0.5 * (moms.mu20 + moms.mu02) - 0.5 * (moms.mu20 - moms.mu02) * cosmax - moms.mu11 * sinmax;
-	      ratio = imin / imax;
-	    }
-	  else
-	    {
-	      ratio = 1;
-	    }
-	  
-	  if (ratio < params.minInertiaRatio || ratio >= params.maxInertiaRatio)
-	    continue;
-	  
-	  center.confidence = ratio * ratio;
-	}
-      
-      if (params.filterByConvexity)
-	{
-	  vector < Point > hull;
-	  convexHull(Mat(contours[contourIdx]), hull);
-	  double area = contourArea(Mat(contours[contourIdx]));
-	  double hullArea = contourArea(Mat(hull));
-	  double ratio = area / hullArea;
-	  if (ratio < params.minConvexity || ratio >= params.maxConvexity)
-	    continue;
-	}
-      Mat pointsf;
-      Mat(contours[contourIdx]).convertTo(pointsf, CV_32F);
-      if(pointsf.rows<5) continue;
-      RotatedRect box = fitEllipse(pointsf);
-      
-      
-      // find center
-      //center.location = Point2d(moms.m10 / moms.m00, moms.m01 / moms.m00);
-      center.location = box.center;
-      
-      
-      // one more filter by color of central pixel
-      if (params.filterByColor)
-	{
-	  if (binaryImage.at<uchar> (cvRound(center.location.y), cvRound(center.location.x)) != params.circleColor)
-	    continue;
-	}
-      
-      //compute circle radius
-      //	{
-      //	vector<double> dists;
-      //	for (size_t pointIdx = 0; pointIdx < contours[contourIdx].size(); pointIdx++)
-      //	{
-      //		Point2d pt = contours[contourIdx][pointIdx];
-      //		dists.push_back(norm(center.location - pt));
-      //	}
-      //	std::sort(dists.begin(), dists.end());
-      //	center.radius = (dists[(dists.size() - 1) / 2] + dists[dists.size() / 2]) / 2.;
-      //}
-      center.radius = (box.size.height+box.size.width)/4.0;
-      centers.push_back(center);
-      
-#ifdef DEBUG_CIRCLE_DETECTOR
-      //    circle( keypointsImage, center.location, 1, Scalar(0,0,255), 1 );
-#endif
+      double area = moms.m00;
+      if (area < params.minArea || area >= params.maxArea) continue;
     }
+
+    if (params.filterByCircularity)
+    {
+      double area = moms.m00;
+      double perimeter = arcLength(Mat(contours[contourIdx]), true);
+      double ratio = 4 * CV_PI * area / (perimeter * perimeter);
+      if (ratio < params.minCircularity || ratio >= params.maxCircularity) continue;
+    }
+
+    if (params.filterByInertia)
+    {
+      double denominator = sqrt(pow(2 * moms.mu11, 2) + pow(moms.mu20 - moms.mu02, 2));
+      const double eps = 1e-2;
+      double ratio;
+      if (denominator > eps)
+      {
+        double cosmin = (moms.mu20 - moms.mu02) / denominator;
+        double sinmin = 2 * moms.mu11 / denominator;
+        double cosmax = -cosmin;
+        double sinmax = -sinmin;
+
+        double imin = 0.5 * (moms.mu20 + moms.mu02) - 0.5 * (moms.mu20 - moms.mu02) * cosmin - moms.mu11 * sinmin;
+        double imax = 0.5 * (moms.mu20 + moms.mu02) - 0.5 * (moms.mu20 - moms.mu02) * cosmax - moms.mu11 * sinmax;
+        ratio = imin / imax;
+      }
+      else
+      {
+        ratio = 1;
+      }
+
+      if (ratio < params.minInertiaRatio || ratio >= params.maxInertiaRatio) continue;
+
+      center.confidence = ratio * ratio;
+    }
+
+    if (params.filterByConvexity)
+    {
+      vector< Point > hull;
+      convexHull(Mat(contours[contourIdx]), hull);
+      double area = contourArea(Mat(contours[contourIdx]));
+      double hullArea = contourArea(Mat(hull));
+      double ratio = area / hullArea;
+      if (ratio < params.minConvexity || ratio >= params.maxConvexity) continue;
+    }
+    Mat pointsf;
+    Mat(contours[contourIdx]).convertTo(pointsf, CV_32F);
+    if (pointsf.rows < 5) continue;
+    RotatedRect box = fitEllipse(pointsf);
+
+    // find center
+    // center.location = Point2d(moms.m10 / moms.m00, moms.m01 / moms.m00);
+    center.location = box.center;
+
+    // one more filter by color of central pixel
+    if (params.filterByColor)
+    {
+      if (binaryImage.at< uchar >(cvRound(center.location.y), cvRound(center.location.x)) != params.circleColor)
+        continue;
+    }
+
+    // compute circle radius
+    //	{
+    //	vector<double> dists;
+    //	for (size_t pointIdx = 0; pointIdx < contours[contourIdx].size(); pointIdx++)
+    //	{
+    //		Point2d pt = contours[contourIdx][pointIdx];
+    //		dists.push_back(norm(center.location - pt));
+    //	}
+    //	std::sort(dists.begin(), dists.end());
+    //	center.radius = (dists[(dists.size() - 1) / 2] + dists[dists.size() / 2]) / 2.;
+    //}
+    center.radius = (box.size.height + box.size.width) / 4.0;
+    centers.push_back(center);
+
 #ifdef DEBUG_CIRCLE_DETECTOR
-  //  imshow("bk", keypointsImage );
-  //  waitKey();
+//    circle( keypointsImage, center.location, 1, Scalar(0,0,255), 1 );
+#endif
+  }
+#ifdef DEBUG_CIRCLE_DETECTOR
+//  imshow("bk", keypointsImage );
+//  waitKey();
 #endif
 }
 
-void CircleDetectorImpl::detect( InputArray _image, std::vector<KeyPoint>& keypoints, InputArray mask )
+void CircleDetectorImpl::detect(InputArray _image, std::vector< KeyPoint >& keypoints, InputArray mask)
 {
-
   Mat image = _image.getMat();
-  
+
   //  CV_INSTRUMENT_REGION()
-    
-  //TODO: support mask
+
+  // TODO: support mask
   keypoints.clear();
   Mat grayscaleImage;
   if (image.channels() == 3)
@@ -342,94 +330,94 @@ void CircleDetectorImpl::detect( InputArray _image, std::vector<KeyPoint>& keypo
   else
     grayscaleImage = image;
 
-  vector < vector<Center> > centers;
+  vector< vector< Center > > centers;
   for (double thresh = params.minThreshold; thresh < params.maxThreshold; thresh += params.thresholdStep)
+  {
+    Mat binarizedImage;
+    threshold(grayscaleImage, binarizedImage, thresh, 255, THRESH_BINARY);
+
+#ifdef DEBUG_CIRCLE_DETECTOR
+//    Mat keypointsImage;
+//    cvtColor( binarizedImage, keypointsImage, CV_GRAY2RGB );
+#endif
+
+    vector< Center > curCenters;
+    findCircles(grayscaleImage, binarizedImage, curCenters);
+    vector< vector< Center > > newCenters;
+    for (size_t i = 0; i < curCenters.size(); i++)
     {
-      Mat binarizedImage;
-      threshold(grayscaleImage, binarizedImage, thresh, 255, THRESH_BINARY);
-
 #ifdef DEBUG_CIRCLE_DETECTOR
-      //    Mat keypointsImage;
-      //    cvtColor( binarizedImage, keypointsImage, CV_GRAY2RGB );
+//      circle(keypointsImage, curCenters[i].location, curCenters[i].radius, Scalar(0,0,255),-1);
 #endif
 
-      vector < Center > curCenters;
-      findCircles(grayscaleImage, binarizedImage, curCenters);
-      vector < vector<Center> > newCenters;
-      for (size_t i = 0; i < curCenters.size(); i++)
-	{
-#ifdef DEBUG_CIRCLE_DETECTOR
-	  //      circle(keypointsImage, curCenters[i].location, curCenters[i].radius, Scalar(0,0,255),-1);
-#endif
+      bool isNew = true;
+      for (size_t j = 0; j < centers.size(); j++)
+      {
+        double dist = norm(centers[j][centers[j].size() / 2].location - curCenters[i].location);
+        //				isNew = dist >= params.minDistBetweenCircles && dist >= centers[j][ centers[j].size() / 2 ].radius &&
+        //dist >= curCenters[i].radius;
+        double rad_diff = fabs(centers[j][centers[j].size() / 2].radius - curCenters[i].radius);
+        isNew = dist >= params.minDistBetweenCircles || rad_diff >= params.minRadiusDiff;
+        if (!isNew)
+        {
+          centers[j].push_back(curCenters[i]);
 
-	  bool isNew = true;
-	  for (size_t j = 0; j < centers.size(); j++)
-	    {
-	      double dist = norm(centers[j][ centers[j].size() / 2 ].location - curCenters[i].location);
-	      //				isNew = dist >= params.minDistBetweenCircles && dist >= centers[j][ centers[j].size() / 2 ].radius && dist >= curCenters[i].radius;
-	      double rad_diff = fabs(centers[j][ centers[j].size() / 2 ].radius - curCenters[i].radius);
-	      isNew = dist >= params.minDistBetweenCircles || rad_diff >= params.minRadiusDiff;
-	      if (!isNew)
-		{
-		  centers[j].push_back(curCenters[i]);
+          size_t k = centers[j].size() - 1;
+          while (k > 0 && centers[j][k].radius < centers[j][k - 1].radius)
+          {
+            centers[j][k] = centers[j][k - 1];
+            k--;
+          }
+          centers[j][k] = curCenters[i];
 
-		  size_t k = centers[j].size() - 1;
-		  while( k > 0 && centers[j][k].radius < centers[j][k-1].radius )
-		    {
-		      centers[j][k] = centers[j][k-1];
-		      k--;
-		    }
-		  centers[j][k] = curCenters[i];
-
-		  break;
-		}
-	    }
-	  if (isNew)
-	    {
-	      newCenters.push_back(vector<Center> (1, curCenters[i]));
-	      //centers.push_back(vector<Center> (1, curCenters[i]));
-	    }
-	}
-      std::copy(newCenters.begin(), newCenters.end(), std::back_inserter(centers));
-
-#ifdef DEBUG_CIRCLE_DETECTOR
-      //    imshow("binarized", keypointsImage );
-      //waitKey();
-#endif
+          break;
+        }
+      }
+      if (isNew)
+      {
+        newCenters.push_back(vector< Center >(1, curCenters[i]));
+        // centers.push_back(vector<Center> (1, curCenters[i]));
+      }
     }
+    std::copy(newCenters.begin(), newCenters.end(), std::back_inserter(centers));
+
+#ifdef DEBUG_CIRCLE_DETECTOR
+//    imshow("binarized", keypointsImage );
+// waitKey();
+#endif
+  }
 
   for (size_t i = 0; i < centers.size(); i++)
+  {
+    if (centers[i].size() < params.minRepeatability) continue;
+    Point2d sumPoint(0, 0);
+    double normalizer = 0;
+    for (size_t j = 0; j < centers[i].size(); j++)
     {
-      if (centers[i].size() < params.minRepeatability)
-	continue;
-      Point2d sumPoint(0, 0);
-      double normalizer = 0;
-      for (size_t j = 0; j < centers[i].size(); j++)
-	{
-	  sumPoint += centers[i][j].confidence * centers[i][j].location;
-	  normalizer += centers[i][j].confidence;
-	}
-      sumPoint *= (1. / normalizer);
-      KeyPoint kpt(sumPoint, (float)(centers[i][centers[i].size() / 2].radius*2.0));
-      keypoints.push_back(kpt);
+      sumPoint += centers[i][j].confidence * centers[i][j].location;
+      normalizer += centers[i][j].confidence;
     }
+    sumPoint *= (1. / normalizer);
+    KeyPoint kpt(sumPoint, (float)(centers[i][centers[i].size() / 2].radius * 2.0));
+    keypoints.push_back(kpt);
+  }
 
 #ifdef DEBUG_CIRCLE_DETECTOR
   namedWindow("keypoints", CV_WINDOW_NORMAL);
   Mat outImg = image.clone();
-  for(size_t i=0; i<keypoints.size(); i++)
-    {
-      circle(outImg, keypoints[i].pt, keypoints[i].size, Scalar(255, 0, 255), -1);
-    }
-  //drawKeypoints(image, keypoints, outImg);
+  for (size_t i = 0; i < keypoints.size(); i++)
+  {
+    circle(outImg, keypoints[i].pt, keypoints[i].size, Scalar(255, 0, 255), -1);
+  }
+  // drawKeypoints(image, keypoints, outImg);
   imshow("keypoints", outImg);
   waitKey();
 #endif
 }
 
- Ptr<CircleDetector> CircleDetector::create(const CircleDetector::Params& params)
+Ptr< CircleDetector > CircleDetector::create(const CircleDetector::Params& params)
 {
-    return makePtr<CircleDetectorImpl>(params);
+  return makePtr< CircleDetectorImpl >(params);
 }
 
-}// end  namespace cv
+}  // end  namespace cv

--- a/industrial_extrinsic_cal/src/nodes/calibration_service.cpp
+++ b/industrial_extrinsic_cal/src/nodes/calibration_service.cpp
@@ -29,11 +29,11 @@ using industrial_extrinsic_cal::CovarianceVariableRequest;
 class CalibrationServiceNode
 {
 public:
+  typedef actionlib::SimpleActionServer< industrial_extrinsic_cal::calibrationAction > CalibrationActionServer;
 
-  typedef actionlib::SimpleActionServer<industrial_extrinsic_cal::calibrationAction> CalibrationActionServer;
-
-  explicit CalibrationServiceNode(const ros::NodeHandle& nh):
-    nh_(nh),  action_server_(nh_,"run_calibration",boost::bind(&CalibrationServiceNode::actionCallback, this, _1), false)
+  explicit CalibrationServiceNode(const ros::NodeHandle& nh)
+    : nh_(nh)
+    , action_server_(nh_, "run_calibration", boost::bind(&CalibrationServiceNode::actionCallback, this, _1), false)
   {
     calibrated_ = false;
     std::string nn = ros::this_node::getName();
@@ -42,7 +42,7 @@ public:
     std::string target_file;
     std::string caljob_file;
     std::string yaml_file_path = ros::package::getPath("industrial_extrinsic_cal") + "/yaml/";
-    bool post_proc_on=false;
+    bool post_proc_on = false;
     std::string observation_data_file;
     priv_nh.getParam("yaml_file_path", yaml_file_path);
     priv_nh.getParam("camera_file", camera_file);
@@ -50,103 +50,108 @@ public:
     priv_nh.getParam("cal_job_file", caljob_file);
     priv_nh.getParam("post_proc_on", post_proc_on);
     priv_nh.getParam("observation_data_file", observation_data_file);
-    if(!priv_nh.getParam("results_file", results_file_)){
+    if (!priv_nh.getParam("results_file", results_file_))
+    {
       results_file_ = yaml_file_path + "results.launch";
     }
-    ROS_INFO("yaml_file_path: %s",yaml_file_path.c_str());
-    ROS_INFO("camera_file: %s",camera_file.c_str());
-    ROS_INFO("target_file: %s",target_file.c_str());
-    ROS_INFO("cal_job_file: %s",caljob_file.c_str());
-    ROS_INFO("results_file: %s",results_file_.c_str());
-    
-    cal_job_ = new industrial_extrinsic_cal::CalibrationJob(yaml_file_path + camera_file,
-							    yaml_file_path + target_file,
-							    yaml_file_path + caljob_file);
-  
-    if(post_proc_on) cal_job_->postProcessingOn(observation_data_file);
+    ROS_INFO("yaml_file_path: %s", yaml_file_path.c_str());
+    ROS_INFO("camera_file: %s", camera_file.c_str());
+    ROS_INFO("target_file: %s", target_file.c_str());
+    ROS_INFO("cal_job_file: %s", caljob_file.c_str());
+    ROS_INFO("results_file: %s", results_file_.c_str());
+
+    cal_job_ = new industrial_extrinsic_cal::CalibrationJob(yaml_file_path + camera_file, yaml_file_path + target_file,
+                                                            yaml_file_path + caljob_file);
+
+    if (post_proc_on) cal_job_->postProcessingOn(observation_data_file);
     if (cal_job_->load())
-      {
-	ROS_INFO_STREAM("Calibration job (cal_job, target and camera) yaml parameters loaded.");
-      }
+    {
+      ROS_INFO_STREAM("Calibration job (cal_job, target and camera) yaml parameters loaded.");
+    }
     action_server_.start();
   };
 
   ~CalibrationServiceNode()
   {
-    delete( cal_job_);
+    delete (cal_job_);
   }
   bool callback(industrial_extrinsic_cal::calibrate::Request& req, industrial_extrinsic_cal::calibrate::Response& resp);
   bool actionCallback(const industrial_extrinsic_cal::calibrationGoalConstPtr& goal);
-  bool is_calibrated(){return(calibrated_);};
-  bool covarianceCallback(industrial_extrinsic_cal::covariance::Request & req, industrial_extrinsic_cal::covariance::Response & res);
+  bool is_calibrated()
+  {
+    return (calibrated_);
+  };
+  bool covarianceCallback(industrial_extrinsic_cal::covariance::Request& req,
+                          industrial_extrinsic_cal::covariance::Response& res);
 
 private:
   ros::NodeHandle nh_;
   bool calibrated_;
-  industrial_extrinsic_cal::CalibrationJob * cal_job_;
+  industrial_extrinsic_cal::CalibrationJob* cal_job_;
   CalibrationActionServer action_server_;
   std::string results_file_;
 };
 
-bool CalibrationServiceNode::covarianceCallback(industrial_extrinsic_cal::covariance::Request & req, industrial_extrinsic_cal::covariance::Response & res)
+bool CalibrationServiceNode::covarianceCallback(industrial_extrinsic_cal::covariance::Request& req,
+                                                industrial_extrinsic_cal::covariance::Response& res)
 {
-  std::vector<CovarianceVariableRequest> requests;
-  CovarianceVariableRequest request1,request2;
+  std::vector< CovarianceVariableRequest > requests;
+  CovarianceVariableRequest request1, request2;
 
   request1.request_type = industrial_extrinsic_cal::intToCovRequest(req.request_type1);
   request1.object_name = req.block_name1;
-  request1.scene_id       = req.scene_id1;
+  request1.scene_id = req.scene_id1;
   requests.push_back(request1);
 
-  request2.request_type =  industrial_extrinsic_cal::intToCovRequest(req.request_type2); 
+  request2.request_type = industrial_extrinsic_cal::intToCovRequest(req.request_type2);
   request2.object_name = req.block_name2;
-  request2.scene_id       = req.scene_id2;
+  request2.scene_id = req.scene_id2;
   requests.push_back(request2);
   std::string file_name = req.file_name;
   bool ret = cal_job_->computeCovariance(requests, file_name);
   // set results and return
-  res.result = 1; // just a placeholder
-  return(ret);
+  res.result = 1;  // just a placeholder
+  return (ret);
 }
 
-bool CalibrationServiceNode::callback(industrial_extrinsic_cal::calibrate::Request& req, industrial_extrinsic_cal::calibrate::Response& res)
+bool CalibrationServiceNode::callback(industrial_extrinsic_cal::calibrate::Request& req,
+                                      industrial_extrinsic_cal::calibrate::Response& res)
 {
-  
-// Display initial state
+  // Display initial state
   ROS_INFO("State prior to optimization");
   cal_job_->show();
-  
+
   // Run observations and subsequent optimization
   ROS_INFO("RUNNING");
   if (cal_job_->run())
+  {
+    res.cost_per_observation = cal_job_->finalCostPerObservation();
+    ROS_INFO("Calibration Sucessful. Initial cost per observation = %lf final cost per observation %lf",
+             cal_job_->initialCostPerObservation(), cal_job_->finalCostPerObservation());
+    if (cal_job_->finalCostPerObservation() <= req.allowable_cost_per_observation)
     {
-      res.cost_per_observation = cal_job_->finalCostPerObservation();
-      ROS_INFO("Calibration Sucessful. Initial cost per observation = %lf final cost per observation %lf", 
-		      cal_job_->initialCostPerObservation(), 
-		      cal_job_->finalCostPerObservation());
-      if(cal_job_->finalCostPerObservation() <= req.allowable_cost_per_observation){
-	calibrated_ = true;
-	if (!cal_job_->store(results_file_))
-	  {
-	    ROS_ERROR_STREAM(" Trouble storing calibration job optimization results ");
-	  }
-      }
-      else{
-	ROS_ERROR("Calibration ran successfully, but error was larger than allowed by caller");
-	calibrated_ = false;
+      calibrated_ = true;
+      if (!cal_job_->store(results_file_))
+      {
+        ROS_ERROR_STREAM(" Trouble storing calibration job optimization results ");
       }
     }
+    else
+    {
+      ROS_ERROR("Calibration ran successfully, but error was larger than allowed by caller");
+      calibrated_ = false;
+    }
+  }
   else
-    {
-      ROS_INFO_STREAM("Calibration job failed");
-      return(false);
-    }
-  
+  {
+    ROS_INFO_STREAM("Calibration job failed");
+    return (false);
+  }
+
   // Show Results
   cal_job_->show();
-  
-  return(calibrated_);
 
+  return (calibrated_);
 }
 
 bool CalibrationServiceNode::actionCallback(const industrial_extrinsic_cal::calibrationGoalConstPtr& goal)
@@ -154,26 +159,25 @@ bool CalibrationServiceNode::actionCallback(const industrial_extrinsic_cal::cali
   industrial_extrinsic_cal::calibrate::Request request;
   industrial_extrinsic_cal::calibrate::Response response;
   request.allowable_cost_per_observation = goal->allowable_cost_per_observation;
-  if(callback(request, response)){
+  if (callback(request, response))
+  {
     action_server_.setSucceeded();
-    return(true);
+    return (true);
   }
   action_server_.setAborted();
-  return(false);
+  return (false);
 }
 
-
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
   ros::init(argc, argv, "calibration_service_node");
   ros::NodeHandle nh;
   CalibrationServiceNode cal_service_node(nh);
 
-  ros::ServiceServer cal_service=nh.advertiseService("calibration_service", &CalibrationServiceNode::callback, &cal_service_node);
-  ros::ServiceServer cov_service=nh.advertiseService("covariance_service", &CalibrationServiceNode::covarianceCallback, &cal_service_node);
+  ros::ServiceServer cal_service =
+      nh.advertiseService("calibration_service", &CalibrationServiceNode::callback, &cal_service_node);
+  ros::ServiceServer cov_service =
+      nh.advertiseService("covariance_service", &CalibrationServiceNode::covarianceCallback, &cal_service_node);
 
   ros::spin();
-    
 }
-
-

--- a/industrial_extrinsic_cal/src/nodes/camera_observer_scene_trigger.cpp
+++ b/industrial_extrinsic_cal/src/nodes/camera_observer_scene_trigger.cpp
@@ -24,18 +24,19 @@
 #include <industrial_extrinsic_cal/user_accept.h>
 #include <industrial_extrinsic_cal/ros_camera_observer.h>
 #include <industrial_extrinsic_cal/basic_types.h>
-#include <industrial_extrinsic_cal/ceres_costs_utils.h> 
+#include <industrial_extrinsic_cal/ceres_costs_utils.h>
 
-class CameraObserverTrigger 
+class CameraObserverTrigger
 {
 public:
   CameraObserverTrigger(ros::NodeHandle nh);
-  ~CameraObserverTrigger()  {  } ;
-  bool executeCallBack( industrial_extrinsic_cal::camera_observer_trigger::Request &req, 
-			industrial_extrinsic_cal::camera_observer_trigger::Response &res);
+  ~CameraObserverTrigger(){};
+  bool executeCallBack(industrial_extrinsic_cal::camera_observer_trigger::Request& req,
+                       industrial_extrinsic_cal::camera_observer_trigger::Response& res);
 
-  bool userAcceptCallBack( industrial_extrinsic_cal::user_accept::Request &req, 
-			industrial_extrinsic_cal::user_accept::Response &res);
+  bool userAcceptCallBack(industrial_extrinsic_cal::user_accept::Request& req,
+                          industrial_extrinsic_cal::user_accept::Response& res);
+
 private:
   ros::NodeHandle nh_;
   ros::ServiceServer trigger_server_;
@@ -48,58 +49,67 @@ private:
 
 CameraObserverTrigger::CameraObserverTrigger(ros::NodeHandle nh)
 {
-  
   nh_ = nh;
   ros::NodeHandle pnh("~");
-  if(!pnh.getParam( "target_type", target_type_)){
+  if (!pnh.getParam("target_type", target_type_))
+  {
     ROS_ERROR("Must set target_type");
   }
-  if(!pnh.getParam( "target_type", target_type_)){
+  if (!pnh.getParam("target_type", target_type_))
+  {
     ROS_ERROR("Must set target_type");
   }
-  
-  if(target_type_ == 3 || target_type_ == 4){
+
+  if (target_type_ == 3 || target_type_ == 4)
+  {
     // neither AR_TAGs nor balls targets need rows or columns
   }
-  else{
-    if(!pnh.getParam("pattern_rows", pattern_rows_)){
+  else
+  {
+    if (!pnh.getParam("pattern_rows", pattern_rows_))
+    {
       ROS_ERROR("Must set pattern_rows");
     }
-    if(!pnh.getParam("pattern_cols", pattern_cols_)){
+    if (!pnh.getParam("pattern_cols", pattern_cols_))
+    {
       ROS_ERROR("Must set pattern_rows");
     }
   }
-  trigger_server_ = nh_.advertiseService( "ObserverTrigger", &CameraObserverTrigger::executeCallBack, this);
-  accept_server_ = nh_.advertiseService( "UserAccept", &CameraObserverTrigger::userAcceptCallBack, this);
+  trigger_server_ = nh_.advertiseService("ObserverTrigger", &CameraObserverTrigger::executeCallBack, this);
+  accept_server_ = nh_.advertiseService("UserAccept", &CameraObserverTrigger::userAcceptCallBack, this);
 }
 
-bool CameraObserverTrigger::executeCallBack( industrial_extrinsic_cal::camera_observer_trigger::Request &req,
-				             industrial_extrinsic_cal::camera_observer_trigger::Response &res)
+bool CameraObserverTrigger::executeCallBack(industrial_extrinsic_cal::camera_observer_trigger::Request& req,
+                                            industrial_extrinsic_cal::camera_observer_trigger::Response& res)
 {
   ros::NodeHandle nh;
   int number_of_required_observations;
   industrial_extrinsic_cal::CameraObservations camera_observations;
-  
-  ROS_ERROR("%s",req.instructions.c_str());
+
+  ROS_ERROR("%s", req.instructions.c_str());
 
   industrial_extrinsic_cal::ROSCameraObserver camera_observer(req.image_topic);
   camera_observer.clearObservations();
   camera_observer.clearTargets();
-  boost::shared_ptr<industrial_extrinsic_cal::Target> target = boost::make_shared<industrial_extrinsic_cal::Target>();
+  boost::shared_ptr< industrial_extrinsic_cal::Target > target =
+      boost::make_shared< industrial_extrinsic_cal::Target >();
   target->target_name_ = "junk";
   target->target_frame_ = "whocares";
-  target->target_type_ =  target_type_;
-  if(target_type_<3){ // neither ARTag nor Balls targets need these parameters
+  target->target_type_ = target_type_;
+  if (target_type_ < 3)
+  {  // neither ARTag nor Balls targets need these parameters
     target->circle_grid_parameters_.pattern_rows = pattern_rows_;
     target->circle_grid_parameters_.pattern_cols = pattern_cols_;
-    target->circle_grid_parameters_.circle_diameter = 1.0; // don't care here
-    target->circle_grid_parameters_.is_symmetric = true; 
-    number_of_required_observations = pattern_rows_*pattern_cols_;
+    target->circle_grid_parameters_.circle_diameter = 1.0;  // don't care here
+    target->circle_grid_parameters_.is_symmetric = true;
+    number_of_required_observations = pattern_rows_ * pattern_cols_;
   }
-  if(target_type_ == 4){
+  if (target_type_ == 4)
+  {
     number_of_required_observations = 3;
   }
-  if(target_type_ == 3){
+  if (target_type_ == 3)
+  {
     ROS_ERROR("AR_TAG does not work in this application");
   }
   industrial_extrinsic_cal::Roi roi;
@@ -109,24 +119,25 @@ bool CameraObserverTrigger::executeCallBack( industrial_extrinsic_cal::camera_ob
   roi.y_max = req.roi_max_y;
 
   industrial_extrinsic_cal::Cost_function cost_type;
-  
+
   camera_observer.clearTargets();
   camera_observer.addTarget(target, roi, cost_type);
   user_accepted_ = false;
   int num_observations = 0;
-  while(num_observations != number_of_required_observations || !user_accepted_)
-    {
-      camera_observer.clearObservations();
-      camera_observer.triggerCamera();
-      while (!camera_observer.observationsDone()) ;
-      camera_observer.getObservations(camera_observations);
-      num_observations = (int) camera_observations.size();
-      ROS_DEBUG("camera observer found %d observations", (int) camera_observations.size());
-    }
-  return(true);
+  while (num_observations != number_of_required_observations || !user_accepted_)
+  {
+    camera_observer.clearObservations();
+    camera_observer.triggerCamera();
+    while (!camera_observer.observationsDone())
+      ;
+    camera_observer.getObservations(camera_observations);
+    num_observations = (int)camera_observations.size();
+    ROS_DEBUG("camera observer found %d observations", (int)camera_observations.size());
+  }
+  return (true);
 }
-bool CameraObserverTrigger::userAcceptCallBack( industrial_extrinsic_cal::user_accept::Request &req,
-						industrial_extrinsic_cal::user_accept::Response &res)
+bool CameraObserverTrigger::userAcceptCallBack(industrial_extrinsic_cal::user_accept::Request& req,
+                                               industrial_extrinsic_cal::user_accept::Response& res)
 {
   user_accepted_ = true;
 }
@@ -136,7 +147,7 @@ int main(int argc, char** argv)
   ros::init(argc, argv, "trigger_server");
   ros::NodeHandle node_handle;
   CameraObserverTrigger COT(node_handle);
-  ros::AsyncSpinner spinner(2); // use 2 threads, one for each service callback
+  ros::AsyncSpinner spinner(2);  // use 2 threads, one for each service callback
   spinner.start();
   ros::waitForShutdown();
   return 0;

--- a/industrial_extrinsic_cal/src/nodes/manual_calt_adjuster.cpp
+++ b/industrial_extrinsic_cal/src/nodes/manual_calt_adjuster.cpp
@@ -20,158 +20,174 @@
 #include <iostream>
 #include <fstream>
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
   ros::init(argc, argv, "manual_calt_adjuster");
   ros::NodeHandle nh, pnh("~");
-  ros::ServiceClient get_client; /**< a client for calling the service to get the joint values associated with the transform */
-  ros::ServiceClient set_client; /**< a client for calling the service to set the joint values associated with the transform */
-  ros::ServiceClient store_client; /**< a client for calling the service to store the joint values associated with the transform */
-  industrial_extrinsic_cal::get_mutable_joint_states::Request get_request; /**< request when transform is part of a mutable set */
-  industrial_extrinsic_cal::get_mutable_joint_states::Response get_response; /**< response when transform is part of a mutable set */
-  industrial_extrinsic_cal::set_mutable_joint_states::Request set_request; /**< request when transform is part of a mutable set */
-  industrial_extrinsic_cal::set_mutable_joint_states::Response set_response; /**< response when transform is part of a mutable set */
-  industrial_extrinsic_cal::store_mutable_joint_states::Request store_request; /**< request to store when  part of a mutable set */
-  industrial_extrinsic_cal::store_mutable_joint_states::Response  store_response;/**< response to store when  part of a mutable set */
+  ros::ServiceClient get_client;   /**< a client for calling the service to get the joint values associated with the
+                                      transform */
+  ros::ServiceClient set_client;   /**< a client for calling the service to set the joint values associated with the
+                                      transform */
+  ros::ServiceClient store_client; /**< a client for calling the service to store the joint values associated with the
+                                      transform */
+  industrial_extrinsic_cal::get_mutable_joint_states::Request get_request;     /**< request when transform is part of a
+                                                                                  mutable set */
+  industrial_extrinsic_cal::get_mutable_joint_states::Response get_response;   /**< response when transform is part of a
+                                                                                  mutable set */
+  industrial_extrinsic_cal::set_mutable_joint_states::Request set_request;     /**< request when transform is part of a
+                                                                                  mutable set */
+  industrial_extrinsic_cal::set_mutable_joint_states::Response set_response;   /**< response when transform is part of a
+                                                                                  mutable set */
+  industrial_extrinsic_cal::store_mutable_joint_states::Request store_request; /**< request to store when  part of a
+                                                                                  mutable set */
+  industrial_extrinsic_cal::store_mutable_joint_states::Response
+      store_response; /**< response to store when  part of a mutable set */
 
-  get_client    = nh.serviceClient<industrial_extrinsic_cal::get_mutable_joint_states>("get_mutable_joint_states");
-  set_client    = nh.serviceClient<industrial_extrinsic_cal::set_mutable_joint_states>("set_mutable_joint_states");
-  store_client = nh.serviceClient<industrial_extrinsic_cal::store_mutable_joint_states>("store_mutable_joint_states");
+  get_client = nh.serviceClient< industrial_extrinsic_cal::get_mutable_joint_states >("get_mutable_joint_states");
+  set_client = nh.serviceClient< industrial_extrinsic_cal::set_mutable_joint_states >("set_mutable_joint_states");
+  store_client = nh.serviceClient< industrial_extrinsic_cal::store_mutable_joint_states >("store_mutable_joint_states");
 
   std::string base_name;
   double delta_t, delta_d;
-  std::vector<double> joint_values;
-  if(argc == 4){
+  std::vector< double > joint_values;
+  if (argc == 4)
+  {
     base_name = argv[1];
-    sscanf(argv[2],"%lf", &delta_t);
-    sscanf(argv[3],"%lf", &delta_d);
+    sscanf(argv[2], "%lf", &delta_t);
+    sscanf(argv[3], "%lf", &delta_d);
   }
-  else{
+  else
+  {
     ROS_ERROR(" usage manual_calt_adjuster base_name delta_theta delta_distance ");
     exit(0);
   }
-  get_request.joint_names.push_back(base_name+"_x_joint");
-  get_request.joint_names.push_back(base_name+"_y_joint");
-  get_request.joint_names.push_back(base_name+"_z_joint");
-  get_request.joint_names.push_back(base_name+"_yaw_joint");
-  get_request.joint_names.push_back(base_name+"_pitch_joint");
-  get_request.joint_names.push_back(base_name+"_roll_joint");
+  get_request.joint_names.push_back(base_name + "_x_joint");
+  get_request.joint_names.push_back(base_name + "_y_joint");
+  get_request.joint_names.push_back(base_name + "_z_joint");
+  get_request.joint_names.push_back(base_name + "_yaw_joint");
+  get_request.joint_names.push_back(base_name + "_pitch_joint");
+  get_request.joint_names.push_back(base_name + "_roll_joint");
 
-  while(!get_client.call(get_request,get_response)){
+  while (!get_client.call(get_request, get_response))
+  {
     sleep(1);
     ROS_INFO("Waiting for mutable joint state publisher to come up");
   }
-  if(get_response.joint_values.size() < 6){  
-    ROS_ERROR("could not get the requested joint values from the mutable joint state publisher base_name: %s",base_name.c_str());
+  if (get_response.joint_values.size() < 6)
+  {
+    ROS_ERROR("could not get the requested joint values from the mutable joint state publisher base_name: %s",
+              base_name.c_str());
   }
-  for(int i=0;i<(int) get_response.joint_values.size();i++){
+  for (int i = 0; i < (int)get_response.joint_values.size(); i++)
+  {
     joint_values.push_back(get_response.joint_values[i]);
   }
 
-  set_request.joint_names.push_back(base_name+"_x_joint");
-  set_request.joint_names.push_back(base_name+"_y_joint");
-  set_request.joint_names.push_back(base_name+"_z_joint");
-  set_request.joint_names.push_back(base_name+"_yaw_joint");
-  set_request.joint_names.push_back(base_name+"_pitch_joint");
-  set_request.joint_names.push_back(base_name+"_roll_joint");
-  system ("/bin/stty raw");
+  set_request.joint_names.push_back(base_name + "_x_joint");
+  set_request.joint_names.push_back(base_name + "_y_joint");
+  set_request.joint_names.push_back(base_name + "_z_joint");
+  set_request.joint_names.push_back(base_name + "_yaw_joint");
+  set_request.joint_names.push_back(base_name + "_pitch_joint");
+  set_request.joint_names.push_back(base_name + "_roll_joint");
+  system("/bin/stty raw");
   ros::Rate loop_rate(10);
   char c;
-  while(ros::ok() && c !='q'){
+  while (ros::ok() && c != 'q')
+  {
     c = 'n';
     c = getc(stdin);
     set_request.joint_values.clear();
     set_request.joint_names.clear();
     switch (c)
-      {
+    {
       case 'x':
-	joint_values[0] -= delta_d;
-	set_request.joint_values.push_back(joint_values[0]);
-	set_request.joint_names.push_back(base_name+"_x_joint");
-	set_client.call(set_request,set_response);
-	break;
+        joint_values[0] -= delta_d;
+        set_request.joint_values.push_back(joint_values[0]);
+        set_request.joint_names.push_back(base_name + "_x_joint");
+        set_client.call(set_request, set_response);
+        break;
       case 'X':
-	joint_values[0] += delta_d;
-	set_request.joint_names.push_back(base_name+"_x_joint");
-	set_request.joint_values.push_back(joint_values[0]);
-	set_client.call(set_request,set_response);
-	break;
+        joint_values[0] += delta_d;
+        set_request.joint_names.push_back(base_name + "_x_joint");
+        set_request.joint_values.push_back(joint_values[0]);
+        set_client.call(set_request, set_response);
+        break;
       case 'y':
-	joint_values[1] -= delta_d;
-	set_request.joint_names.push_back(base_name+"_y_joint");
-	set_request.joint_values.push_back(joint_values[1]);
-	set_client.call(set_request,set_response);
-	break;
+        joint_values[1] -= delta_d;
+        set_request.joint_names.push_back(base_name + "_y_joint");
+        set_request.joint_values.push_back(joint_values[1]);
+        set_client.call(set_request, set_response);
+        break;
       case 'Y':
-	joint_values[1] += delta_d;
-	set_request.joint_names.push_back(base_name+"_y_joint");
-	set_request.joint_values.push_back(joint_values[1]);
-	set_client.call(set_request,set_response);
-	break;
+        joint_values[1] += delta_d;
+        set_request.joint_names.push_back(base_name + "_y_joint");
+        set_request.joint_values.push_back(joint_values[1]);
+        set_client.call(set_request, set_response);
+        break;
       case 'z':
-	joint_values[2] -= delta_d;
-	set_request.joint_names.push_back(base_name+"_z_joint");
-	set_request.joint_values.push_back(joint_values[2]);
-	set_client.call(set_request,set_response);
-	break;
+        joint_values[2] -= delta_d;
+        set_request.joint_names.push_back(base_name + "_z_joint");
+        set_request.joint_values.push_back(joint_values[2]);
+        set_client.call(set_request, set_response);
+        break;
       case 'Z':
-	joint_values[2] += delta_d;
-	set_request.joint_names.push_back(base_name+"_z_joint");
-	set_request.joint_values.push_back(joint_values[2]);
-	set_client.call(set_request,set_response);
-	break;
+        joint_values[2] += delta_d;
+        set_request.joint_names.push_back(base_name + "_z_joint");
+        set_request.joint_values.push_back(joint_values[2]);
+        set_client.call(set_request, set_response);
+        break;
       case 'w':
-	joint_values[3] -= delta_t;
-	set_request.joint_names.push_back(base_name+"_yaw_joint");
-	set_request.joint_values.push_back(joint_values[3]);
-	set_client.call(set_request,set_response);
-	break;
+        joint_values[3] -= delta_t;
+        set_request.joint_names.push_back(base_name + "_yaw_joint");
+        set_request.joint_values.push_back(joint_values[3]);
+        set_client.call(set_request, set_response);
+        break;
       case 'W':
-	joint_values[3] += delta_t;
-	set_request.joint_names.push_back(base_name+"_yaw_joint");
-	set_request.joint_values.push_back(joint_values[3]);
-	set_client.call(set_request,set_response);
-	break;
+        joint_values[3] += delta_t;
+        set_request.joint_names.push_back(base_name + "_yaw_joint");
+        set_request.joint_values.push_back(joint_values[3]);
+        set_client.call(set_request, set_response);
+        break;
       case 'p':
-	joint_values[4] -= delta_t;
-	set_request.joint_names.push_back(base_name+"_pitch_joint");
-	set_request.joint_values.push_back(joint_values[4]);
-	set_client.call(set_request,set_response);
-	break;
+        joint_values[4] -= delta_t;
+        set_request.joint_names.push_back(base_name + "_pitch_joint");
+        set_request.joint_values.push_back(joint_values[4]);
+        set_client.call(set_request, set_response);
+        break;
       case 'P':
-	joint_values[4] += delta_t;
-	set_request.joint_names.push_back(base_name+"_pitch_joint");
-	set_request.joint_values.push_back(joint_values[4]);
-	set_client.call(set_request,set_response);
-	break;
+        joint_values[4] += delta_t;
+        set_request.joint_names.push_back(base_name + "_pitch_joint");
+        set_request.joint_values.push_back(joint_values[4]);
+        set_client.call(set_request, set_response);
+        break;
       case 'r':
-	joint_values[5] -= delta_t;
-	set_request.joint_names.push_back(base_name+"_roll_joint");
-	set_request.joint_values.push_back(joint_values[5]);
-	set_client.call(set_request,set_response);
-	break;
+        joint_values[5] -= delta_t;
+        set_request.joint_names.push_back(base_name + "_roll_joint");
+        set_request.joint_values.push_back(joint_values[5]);
+        set_client.call(set_request, set_response);
+        break;
       case 'R':
-	joint_values[5] += delta_t;
-	set_request.joint_names.push_back(base_name+"_roll_joint");
-	set_request.joint_values.push_back(joint_values[5]);
-	set_client.call(set_request,set_response);
-	break;
+        joint_values[5] += delta_t;
+        set_request.joint_names.push_back(base_name + "_roll_joint");
+        set_request.joint_values.push_back(joint_values[5]);
+        set_client.call(set_request, set_response);
+        break;
       case '-':
-	delta_d = delta_d*.95;
-	delta_t = delta_t*.95;
-	break;
+        delta_d = delta_d * .95;
+        delta_t = delta_t * .95;
+        break;
       case '+':
-	delta_d = delta_d*1.05;
-	delta_t = delta_t*1.05;
-	break;
+        delta_d = delta_d * 1.05;
+        delta_t = delta_t * 1.05;
+        break;
       case 's':
-	store_client.call(store_request, store_response);
-	break;
+        store_client.call(store_request, store_response);
+        break;
       default:
-	break;
-      }	// end switch
-      ros::spinOnce();
-      loop_rate.sleep();
-  }// end while ok
-  system ("/bin/stty cooked");
+        break;
+    }  // end switch
+    ros::spinOnce();
+    loop_rate.sleep();
+  }  // end while ok
+  system("/bin/stty cooked");
 }

--- a/industrial_extrinsic_cal/src/nodes/mono_ex_cal.cpp
+++ b/industrial_extrinsic_cal/src/nodes/mono_ex_cal.cpp
@@ -5,9 +5,9 @@
 #include <iostream>
 typedef struct
 {
-  int p_id; // point's id
-  double x; // image x
-  double y; // image y
+  int p_id;  // point's id
+  double x;  // image x
+  double y;  // image y
 } observation;
 
 typedef struct
@@ -20,7 +20,7 @@ typedef struct
       double y;
       double z;
     };
-    double PB[3]; // parameter block
+    double PB[3];  // parameter block
   };
 } point;
 
@@ -30,13 +30,13 @@ typedef struct
   {
     struct
     {
-      double PB_extrinsics[6]; // parameter block for intrinsics
-      double PB_intrinsics[9]; // parameter block for extrinsics
+      double PB_extrinsics[6];  // parameter block for intrinsics
+      double PB_intrinsics[9];  // parameter block for extrinsics
     };
     struct
     {
-      double aa[3]; // angle axis data
-      double pos[3]; // position data
+      double aa[3];   // angle axis data
+      double pos[3];  // position data
       double fx;
       double fy;
       double cx;
@@ -86,10 +86,10 @@ observation project_point(Camera C, point P)
   double r4 = r2 * r2;
   double r6 = r2 * r4;
 
-  double xp2 = xp * xp; // temporary variables square of others
+  double xp2 = xp * xp;  // temporary variables square of others
   double yp2 = yp * yp;
 
-  //apply the distortion coefficients to refine pixel location
+  // apply the distortion coefficients to refine pixel location
   double xpp = xp + C.k1 * r2 * xp + C.k2 * r4 * xp + C.k3 * r6 * xp + C.p2 * (r2 + 2 * xp2) + 2 * C.p1 * xp * yp;
   double ypp = yp + C.k1 * r2 * yp + C.k2 * r4 * yp + C.k3 * r6 * yp + C.p1 * (r2 + 2 * yp2) + 2 * C.p2 * xp * yp;
 
@@ -103,84 +103,82 @@ observation project_point(Camera C, point P)
 
 struct Camera_reprj_error
 {
-  Camera_reprj_error(double ob_x, double ob_y) :
-      Ox(ob_x), Oy(ob_y)
+  Camera_reprj_error(double ob_x, double ob_y) : Ox(ob_x), Oy(ob_y)
   {
   }
 
-  template<typename T>
-    bool operator()(const T* const c_p1, // extrinsic parameters
-        const T* c_p2, // intrinsic parameters
-        const T* point, // point being projected, yes this is has 3 parameters
-        T* resid) const
-    {
-      // extract the variables from the camera parameters
-      int q = 0; // extrinsic block of parameters
-      const T& x = c_p1[q++]; //  angle_axis x for rotation of camera		
-      const T& y = c_p1[q++]; //  angle_axis y for rotation of camera
-      const T& z = c_p1[q++]; //  angle_axis z for rotation of camera
-      const T& tx = c_p1[q++]; //  translation of camera x
-      const T& ty = c_p1[q++]; //  translation of camera y
-      const T& tz = c_p1[q++]; //  translation of camera z
+  template < typename T >
+  bool operator()(const T* const c_p1,  // extrinsic parameters
+                  const T* c_p2,        // intrinsic parameters
+                  const T* point,       // point being projected, yes this is has 3 parameters
+                  T* resid) const
+  {
+    // extract the variables from the camera parameters
+    int q = 0;                // extrinsic block of parameters
+    const T& x = c_p1[q++];   //  angle_axis x for rotation of camera
+    const T& y = c_p1[q++];   //  angle_axis y for rotation of camera
+    const T& z = c_p1[q++];   //  angle_axis z for rotation of camera
+    const T& tx = c_p1[q++];  //  translation of camera x
+    const T& ty = c_p1[q++];  //  translation of camera y
+    const T& tz = c_p1[q++];  //  translation of camera z
 
-      q = 0; // intrinsic block of parameters
-      const T& fx = c_p2[q++]; //  focal length x
-      const T& fy = c_p2[q++]; //  focal length x
-      const T& cx = c_p2[q++]; //  center point x
-      const T& cy = c_p2[q++]; //  center point y
-      const T& k1 = c_p2[q++]; //  distortion coefficient on 2nd order terms
-      const T& k2 = c_p2[q++]; //  distortion coefficient on 4th order terms
-      const T& k3 = c_p2[q++]; //  distortion coefficient on 6th order terms
-      const T& p1 = c_p2[q++]; //  tangential distortion coefficient x
-      const T& p2 = c_p2[q++]; //  tangential distortion coefficient y
+    q = 0;                    // intrinsic block of parameters
+    const T& fx = c_p2[q++];  //  focal length x
+    const T& fy = c_p2[q++];  //  focal length x
+    const T& cx = c_p2[q++];  //  center point x
+    const T& cy = c_p2[q++];  //  center point y
+    const T& k1 = c_p2[q++];  //  distortion coefficient on 2nd order terms
+    const T& k2 = c_p2[q++];  //  distortion coefficient on 4th order terms
+    const T& k3 = c_p2[q++];  //  distortion coefficient on 6th order terms
+    const T& p1 = c_p2[q++];  //  tangential distortion coefficient x
+    const T& p2 = c_p2[q++];  //  tangential distortion coefficient y
 
-      // rotate and translate points into camera frame
-      T aa[3]; // angle axis 
-      T p[3]; // point rotated
-      aa[0] = x;
-      aa[1] = y;
-      aa[2] = z;
-      ceres::AngleAxisRotatePoint(aa, point, p);
+    // rotate and translate points into camera frame
+    T aa[3];  // angle axis
+    T p[3];   // point rotated
+    aa[0] = x;
+    aa[1] = y;
+    aa[2] = z;
+    ceres::AngleAxisRotatePoint(aa, point, p);
 
-      // apply camera translation
-      T xp1 = p[0] + tx; // point rotated and translated
-      T yp1 = p[1] + ty;
-      T zp1 = p[2] + tz;
+    // apply camera translation
+    T xp1 = p[0] + tx;  // point rotated and translated
+    T yp1 = p[1] + ty;
+    T zp1 = p[2] + tz;
 
-      // scale into the image plane by distance away from camera
-      T xp = xp1 / zp1;
-      T yp = yp1 / zp1;
+    // scale into the image plane by distance away from camera
+    T xp = xp1 / zp1;
+    T yp = yp1 / zp1;
 
-      // calculate terms for polynomial distortion
-      T r2 = xp * xp + yp * yp;
-      T r4 = r2 * r2;
-      T r6 = r2 * r4;
+    // calculate terms for polynomial distortion
+    T r2 = xp * xp + yp * yp;
+    T r4 = r2 * r2;
+    T r6 = r2 * r4;
 
-      T xp2 = xp * xp; // temporary variables square of others
-      T yp2 = yp * yp;
-      //apply the distortion coefficients to refine pixel location
-      T xpp = xp + k1 * r2 * xp + k2 * r4 * xp + k3 * r6 * xp + p2 * (r2 + T(2.0) * xp2) + T(2.0) * p1 * xp * yp;
-      T ypp = yp + k1 * r2 * yp + k2 * r4 * yp + k3 * r6 * yp + p1 * (r2 + T(2.0) * yp2) + T(2.0) * p2 * xp * yp;
-      // perform projection using focal length and camera center into image plane
-      resid[0] = fx * xpp + cx - Ox;
-      resid[1] = fy * ypp + cy - Oy;
+    T xp2 = xp * xp;  // temporary variables square of others
+    T yp2 = yp * yp;
+    // apply the distortion coefficients to refine pixel location
+    T xpp = xp + k1 * r2 * xp + k2 * r4 * xp + k3 * r6 * xp + p2 * (r2 + T(2.0) * xp2) + T(2.0) * p1 * xp * yp;
+    T ypp = yp + k1 * r2 * yp + k2 * r4 * yp + k3 * r6 * yp + p1 * (r2 + T(2.0) * yp2) + T(2.0) * p2 * xp * yp;
+    // perform projection using focal length and camera center into image plane
+    resid[0] = fx * xpp + cx - Ox;
+    resid[1] = fy * ypp + cy - Oy;
 
-      return true;
-    } // end of operator()
+    return true;
+  }  // end of operator()
 
-    // Factory to hide the construction of the CostFunction object from
-    // the client code.
+  // Factory to hide the construction of the CostFunction object from
+  // the client code.
   static ceres::CostFunction* Create(const double o_x, const double o_y)
   {
-    return (new ceres::AutoDiffCostFunction<Camera_reprj_error, 2, 6, 9, 3>(new Camera_reprj_error(o_x, o_y)));
+    return (new ceres::AutoDiffCostFunction< Camera_reprj_error, 2, 6, 9, 3 >(new Camera_reprj_error(o_x, o_y)));
   }
-  double Ox; // observed x location of object in image
-  double Oy; // observed y location of object in image
+  double Ox;  // observed x location of object in image
+  double Oy;  // observed y location of object in image
 };
 
 int main(int argc, char** argv)
 {
-
   google::InitGoogleLogging(argv[0]);
   if (argc != 5)
   {
@@ -207,7 +205,7 @@ int main(int argc, char** argv)
   //   num_observations  # read as integer
   //   x[0] y[0]         # read as double
   //   ...
-  //   x[num_observations-1] y[num_observations-1] 
+  //   x[num_observations-1] y[num_observations-1]
   // 3. Camera intrisic data stored as ascii in the ROS.ini format
   // 4. Camera initial extrinsic file stored as ascii indicating the homogeneous transform
   //  nx ox ax tx  #read all as double
@@ -216,10 +214,10 @@ int main(int argc, char** argv)
   //  0  0  0  1.0
 
   // read in the problem
-  FILE *points_fp = fopen(argv[1], "r");
-  FILE *observations_fp = fopen(argv[2], "r");
-  FILE *intrinsics_fp = fopen(argv[3], "r");
-  FILE *extrinsics_fp = fopen(argv[4], "r");
+  FILE* points_fp = fopen(argv[1], "r");
+  FILE* observations_fp = fopen(argv[2], "r");
+  FILE* intrinsics_fp = fopen(argv[3], "r");
+  FILE* extrinsics_fp = fopen(argv[4], "r");
   if (points_fp == NULL)
   {
     printf("Could not open file: %s", argv[1]);
@@ -247,7 +245,7 @@ int main(int argc, char** argv)
     printf("couldn't read num_points\n");
     exit(1);
   }
-  std::vector<point> Pts;
+  std::vector< point > Pts;
   for (int i = 0; i < num_points; i++)
   {
     point p;
@@ -270,7 +268,7 @@ int main(int argc, char** argv)
   {
     printf("WARNING, num_points NOT EQUAL to num_observations\n");
   }
-  std::vector<observation> Ob;
+  std::vector< observation > Ob;
   for (int i = 0; i < num_observations; i++)
   {
     if (fscanf(observations_fp, "%lf %lf", &o.x, &o.y) != 2)
@@ -290,28 +288,28 @@ int main(int argc, char** argv)
   int image_width;
   int image_height;
   int rtn = 0;
-  rtn += fscanf(intrinsics_fp, "%s", dum); // should be "#"
-  rtn += fscanf(intrinsics_fp, "%s", dum); // should be "Camera"
-  rtn += fscanf(intrinsics_fp, "%s", dum); // should be "intrinsics"
-  rtn += fscanf(intrinsics_fp, "%s", dum); // should be "[image]"
+  rtn += fscanf(intrinsics_fp, "%s", dum);  // should be "#"
+  rtn += fscanf(intrinsics_fp, "%s", dum);  // should be "Camera"
+  rtn += fscanf(intrinsics_fp, "%s", dum);  // should be "intrinsics"
+  rtn += fscanf(intrinsics_fp, "%s", dum);  // should be "[image]"
   //  printf("should be [image]: %s\n",dum);
-  rtn += fscanf(intrinsics_fp, "%s", dum); // should be "width"
+  rtn += fscanf(intrinsics_fp, "%s", dum);  // should be "width"
   //  printf("should be width: %s\n",dum);
-  rtn += fscanf(intrinsics_fp, "%d", &image_width); // should be the image width of provided by camera
+  rtn += fscanf(intrinsics_fp, "%d", &image_width);  // should be the image width of provided by camera
   printf("image_width: %d\n", image_width);
-  rtn += fscanf(intrinsics_fp, "%s", dum); // should be "height"
-  rtn += fscanf(intrinsics_fp, "%d", &image_height); // should be the image width of provided by camera
+  rtn += fscanf(intrinsics_fp, "%s", dum);            // should be "height"
+  rtn += fscanf(intrinsics_fp, "%d", &image_height);  // should be the image width of provided by camera
   printf("height: %d\n", image_height);
-  rtn += fscanf(intrinsics_fp, "%s", dum); // should be "[some name]"
+  rtn += fscanf(intrinsics_fp, "%s", dum);  // should be "[some name]"
   //  printf("[some name]: %s\n",dum);
-  rtn += fscanf(intrinsics_fp, "%s", dum); // should be "camera"
+  rtn += fscanf(intrinsics_fp, "%s", dum);  // should be "camera"
   //  printf("should be camera: %s\n",dum);
-  rtn += fscanf(intrinsics_fp, "%s", dum); // should be "matrix"
+  rtn += fscanf(intrinsics_fp, "%s", dum);  // should be "matrix"
   //  printf("should be matrix: %s\n",dum);
   rtn += fscanf(intrinsics_fp, "%lf %lf %lf", &C.fx, &Dum, &C.cx);
   rtn += fscanf(intrinsics_fp, "%lf %lf %lf", &Dum, &C.fy, &C.cy);
   rtn += fscanf(intrinsics_fp, "%lf %lf %lf", &Dum, &Dum2, &Dum3);
-  rtn += fscanf(intrinsics_fp, "%s", dum); // should be "distortion" 
+  rtn += fscanf(intrinsics_fp, "%s", dum);  // should be "distortion"
   printf("camera matrix:\n");
   printf("%8.3lf %8.3lf %8.3lf\n", C.fx, 0.0, C.cx);
   printf("%8.3lf %8.3lf %8.3lf\n", 0.0, C.fy, C.cy);
@@ -336,16 +334,16 @@ int main(int argc, char** argv)
   fclose(extrinsics_fp);
 
   // use the inverse of transform from camera to world as camera transform
-  double HI[9]; // note ceres uses column major order
-  HI[0] = H[0][0]; // first column becomes first row
+  double HI[9];     // note ceres uses column major order
+  HI[0] = H[0][0];  // first column becomes first row
   HI[1] = H[0][1];
   HI[2] = H[0][2];
 
-  HI[3] = H[1][0]; // second column becomes second row
+  HI[3] = H[1][0];  // second column becomes second row
   HI[4] = H[1][1];
   HI[5] = H[1][2];
 
-  HI[6] = H[2][0]; // third column becomes third row
+  HI[6] = H[2][0];  // third column becomes third row
   HI[7] = H[2][1];
   HI[8] = H[2][2];
   C.pos[0] = -(H[0][3] * H[0][0] + H[1][3] * H[1][0] + H[2][3] * H[2][0]);
@@ -354,23 +352,23 @@ int main(int argc, char** argv)
   printf("C.xyz = %lf %lf %lf\n", C.pos[0], C.pos[1], C.pos[2]);
   ceres::RotationMatrixToAngleAxis(HI, C.aa);
 
-  /* used to create sample data with known solution
-   FILE *fp6 = fopen("new_observations.txt","w");
-   fprintf(fp6,"%d\n",num_points);
-   for(int i=0;i<num_points;i++){
-   o = project_point(C,Pts[i]);
-   fprintf(fp6,"%lf %lf\n",o.x,o.y);
-   }
-   fclose(fp6); 
-   exit(1);
-   */
+/* used to create sample data with known solution
+ FILE *fp6 = fopen("new_observations.txt","w");
+ fprintf(fp6,"%d\n",num_points);
+ for(int i=0;i<num_points;i++){
+ o = project_point(C,Pts[i]);
+ fprintf(fp6,"%lf %lf\n",o.x,o.y);
+ }
+ fclose(fp6);
+ exit(1);
+ */
 #define MONO_EXCAL_DEBUG
 #ifdef MONO_EXCAL_DEBUG
   /* Print initial errors */
   /* Save projections and observations to matlab compatible form    */
-  FILE *fp_temp1 = fopen("Obs.m", "w");
-  FILE *fp_temp2 = fopen("Rep.m", "w");
-  FILE *fp_temp3 = fopen("FRep.m", "w");
+  FILE* fp_temp1 = fopen("Obs.m", "w");
+  FILE* fp_temp2 = fopen("Rep.m", "w");
+  FILE* fp_temp3 = fopen("FRep.m", "w");
   fprintf(fp_temp1, "O = [ ");
   fprintf(fp_temp2, "R = [ ");
   fprintf(fp_temp3, "F = [ ");
@@ -432,25 +430,25 @@ int main(int argc, char** argv)
   fprintf(fp_temp3, "];\n");
   fclose(fp_temp3);
 #endif  // MONO_EXCAL_DEBUG
-  // Print final camera parameters 
+  // Print final camera parameters
   print_camera(C, "final parameters");
 
   // write new extrinsics to a file
   std::string temp(argv[4]);
   std::string new_ex_file = "new_" + temp;
   extrinsics_fp = fopen(new_ex_file.c_str(), "w");
-  ceres::AngleAxisToRotationMatrix(C.aa, HI); // Column Major 
+  ceres::AngleAxisToRotationMatrix(C.aa, HI);  // Column Major
 
   // invert HI to get H
-  H[0][0] = HI[0]; // first column of HI is set to first row of H
+  H[0][0] = HI[0];  // first column of HI is set to first row of H
   H[0][1] = HI[1];
   H[0][2] = HI[2];
 
-  H[1][0] = HI[3]; // second column of HI is set to second row of H
+  H[1][0] = HI[3];  // second column of HI is set to second row of H
   H[1][1] = HI[4];
   H[1][2] = HI[5];
 
-  H[2][0] = HI[6]; // third column of HI is set to third row of H
+  H[2][0] = HI[6];  // third column of HI is set to third row of H
   H[2][1] = HI[7];
   H[2][2] = HI[8];
 

--- a/industrial_extrinsic_cal/src/nodes/mutable_joint_state_publisher.cpp
+++ b/industrial_extrinsic_cal/src/nodes/mutable_joint_state_publisher.cpp
@@ -16,7 +16,6 @@
  * limitations under the License.
  */
 
-
 #include "yaml-cpp/yaml.h"
 #include <industrial_extrinsic_cal/mutable_joint_state_publisher.h>
 #include <industrial_extrinsic_cal/yaml_utils.h>
@@ -24,158 +23,173 @@
 #include <fstream>
 namespace industrial_extrinsic_cal
 {
-  using std::string;
-  using std::vector;
+using std::string;
+using std::vector;
 
-  MutableJointStatePublisher::MutableJointStatePublisher(ros::NodeHandle nh): nh_(nh)
+MutableJointStatePublisher::MutableJointStatePublisher(ros::NodeHandle nh) : nh_(nh)
+{
+  ros::NodeHandle pnh("~");
+
+  // get the name of the yaml file containing the mutable joints
+  if (!pnh.getParam("mutable_joint_state_yaml_file", yaml_file_name_))
   {
-    ros::NodeHandle pnh("~");
-
-    // get the name of the yaml file containing the mutable joints 
-    if(!pnh.getParam("mutable_joint_state_yaml_file", yaml_file_name_)){
-      ROS_ERROR("MutableJointStatePublisher, must set mutable_joint_state_yaml_file parameter for this node");
-      yaml_file_name_ = "default_mutable_joint_states.yaml";
-    }
-
-    // load the joint names and values from the yaml file
-    if(!loadFromYamlFile()){
-      ROS_ERROR("MutableJointStatePublisher constructor can't read yaml file %s",yaml_file_name_.c_str());
-    }
-    // advertise the services for getting, setting, and storing the mutable joint values
-    set_server_ = nh_.advertiseService( "set_mutable_joint_states", &MutableJointStatePublisher::setCallBack, this);
-    get_server_ = nh_.advertiseService("get_mutable_joint_states", &MutableJointStatePublisher::getCallBack,this);
-    store_server_ = nh_.advertiseService("store_mutable_joint_states", &MutableJointStatePublisher::storeCallBack, this);
-
-    // advertise the topic for continious publication of all the mutable joint states
-    int queue_size = 10;
-    joint_state_pub_ = nh_.advertise<sensor_msgs::JointState>("mutable_joint_states", queue_size);
-    if(!joint_state_pub_){
-      ROS_ERROR("ADVERTISE DID NOT RETURN A VALID PUBLISHER");
-    }
+    ROS_ERROR("MutableJointStatePublisher, must set mutable_joint_state_yaml_file parameter for this node");
+    yaml_file_name_ = "default_mutable_joint_states.yaml";
   }
 
-  bool MutableJointStatePublisher::setCallBack(industrial_extrinsic_cal::set_mutable_joint_states::Request &req,
-					       industrial_extrinsic_cal::set_mutable_joint_states::Response &res)
+  // load the joint names and values from the yaml file
+  if (!loadFromYamlFile())
   {
-    bool return_val= true;
-    for(int i=0; i<(int)req.joint_names.size(); i++){
-      if(joints_.find(req.joint_names[i]) != joints_.end()){
-	joints_[req.joint_names[i]] = req.joint_values[i];
-	ROS_INFO("setting %s to %lf",req.joint_names[i].c_str(), req.joint_values[i]);
-      }
-      else{
-	ROS_ERROR("%s does not have joint named %s",node_name_.c_str(),req.joint_names[i].c_str());
-	return_val= false;
-      }
-    }
-
-    return(return_val);
+    ROS_ERROR("MutableJointStatePublisher constructor can't read yaml file %s", yaml_file_name_.c_str());
   }
+  // advertise the services for getting, setting, and storing the mutable joint values
+  set_server_ = nh_.advertiseService("set_mutable_joint_states", &MutableJointStatePublisher::setCallBack, this);
+  get_server_ = nh_.advertiseService("get_mutable_joint_states", &MutableJointStatePublisher::getCallBack, this);
+  store_server_ = nh_.advertiseService("store_mutable_joint_states", &MutableJointStatePublisher::storeCallBack, this);
 
-  bool MutableJointStatePublisher::getCallBack(industrial_extrinsic_cal::get_mutable_joint_states::Request &req,
-					       industrial_extrinsic_cal::get_mutable_joint_states::Response &res)
+  // advertise the topic for continious publication of all the mutable joint states
+  int queue_size = 10;
+  joint_state_pub_ = nh_.advertise< sensor_msgs::JointState >("mutable_joint_states", queue_size);
+  if (!joint_state_pub_)
   {
-    bool return_val=true;
-    res.joint_names.clear();
-    res.joint_values.clear();
-    for(int i=0; i<(int)req.joint_names.size(); i++){ // for each name asked for
-      if(joints_.find(req.joint_names[i]) != joints_.end()){ // see if it can be found
-	res.joint_names.push_back(req.joint_names[i]); // use the asked for name in resposne
-	res.joint_values.push_back(joints_[req.joint_names[i]]);// use the value in the response
-      }
-      else{ // can't be found
-	ROS_ERROR("%s does not have joint named %s",node_name_.c_str(),req.joint_names[i].c_str());
-	return_val= false;
-      }
-    }
-    return(return_val);
+    ROS_ERROR("ADVERTISE DID NOT RETURN A VALID PUBLISHER");
   }
-
-  bool MutableJointStatePublisher::storeCallBack(industrial_extrinsic_cal::store_mutable_joint_states::Request &req,
-						 industrial_extrinsic_cal::store_mutable_joint_states::Response &res)
-  {
-    std::string new_file_name =  yaml_file_name_;
-    ros::NodeHandle pnh("~");
-    bool overwrite = false;
-    pnh.getParam("overwrite_mutable_values", overwrite);
-    if(!overwrite) new_file_name = yaml_file_name_ + "new";
-
-    std::ofstream fout(new_file_name.c_str());
-    YAML::Emitter yaml_emitter;
-    yaml_emitter << YAML::BeginMap;
-    for (std::map<std::string, double>::iterator it= joints_.begin(); it != joints_.end(); ++it){
-      yaml_emitter << YAML::Key << it->first.c_str() << YAML::Value << it->second;
-      ROS_INFO("mutable joint %s has value %lf",it->first.c_str(), it->second);
-    }
-    yaml_emitter << YAML::EndMap;
-    fout << yaml_emitter.c_str();
-    fout.close();
-    return(true);
 }
 
-  bool  MutableJointStatePublisher::loadFromYamlFile()
+bool MutableJointStatePublisher::setCallBack(industrial_extrinsic_cal::set_mutable_joint_states::Request& req,
+                                             industrial_extrinsic_cal::set_mutable_joint_states::Response& res)
+{
+  bool return_val = true;
+  for (int i = 0; i < (int)req.joint_names.size(); i++)
   {
-      ROS_INFO_STREAM(yaml_file_name_);
-    // yaml file should have the followng format:
-    // joint0_name: <float_value0>
-    // joint1_name: <float_value1>
-    // joint2_name: <float_value2>
-    try{
-      YAML::Node doc;
-      if(!yamlNodeFromFileName(yaml_file_name_, doc)){
-	ROS_ERROR("Can't read yaml file %s", yaml_file_name_.c_str());
-      }
-      for(YAML_ITERATOR it=doc.begin(); it != doc.end(); ++it) {
-	  std::string key;
-	  double value;
-	  parseKeyDValue( it, key, value);
-	  joints_[key.c_str()] = value;
-      }
-    }	// end try
-    catch (YAML::ParserException& e){
-      ROS_ERROR("mutableJointStatePublisher: parsing joint states file");
-      ROS_ERROR_STREAM("Failed with exception "<< e.what());
-      return (false);
+    if (joints_.find(req.joint_names[i]) != joints_.end())
+    {
+      joints_[req.joint_names[i]] = req.joint_values[i];
+      ROS_INFO("setting %s to %lf", req.joint_names[i].c_str(), req.joint_values[i]);
     }
-    if(joints_.size() == 0) ROS_ERROR("mutable_joint_state_publisher has no joints");
-    
-    // output so we know they have been read in correctly
-    for (std::map<std::string, double>::iterator it= joints_.begin(); it != joints_.end(); ++it){
-      ROS_INFO("mutable joint %s has value %lf",it->first.c_str(), it->second);
+    else
+    {
+      ROS_ERROR("%s does not have joint named %s", node_name_.c_str(), req.joint_names[i].c_str());
+      return_val = false;
     }
-    
-    return(true);
-  } 					     
-
-  bool MutableJointStatePublisher::publishJointStates()
-  {
-      sensor_msgs::JointState joint_states;
-      joint_states.header.stamp = ros::Time::now();
-      joint_states.name.clear();
-      joint_states.position.clear();
-      joint_states.velocity.clear();
-      joint_states.effort.clear();
-      for (std::map<string, double>::iterator it=joints_.begin(); it!=joints_.end(); ++it){
-        joint_states.name.push_back(it->first);
-        joint_states.position.push_back(it->second);
-        joint_states.velocity.push_back(0.0);
-        joint_states.effort.push_back(0.0);
-      }
-      joint_state_pub_.publish(joint_states);
   }
-} // end namespace mutable_joint_state_publisher
 
-int main(int argc, char **argv)
+  return (return_val);
+}
+
+bool MutableJointStatePublisher::getCallBack(industrial_extrinsic_cal::get_mutable_joint_states::Request& req,
+                                             industrial_extrinsic_cal::get_mutable_joint_states::Response& res)
+{
+  bool return_val = true;
+  res.joint_names.clear();
+  res.joint_values.clear();
+  for (int i = 0; i < (int)req.joint_names.size(); i++)
+  {  // for each name asked for
+    if (joints_.find(req.joint_names[i]) != joints_.end())
+    {                                                           // see if it can be found
+      res.joint_names.push_back(req.joint_names[i]);            // use the asked for name in resposne
+      res.joint_values.push_back(joints_[req.joint_names[i]]);  // use the value in the response
+    }
+    else
+    {  // can't be found
+      ROS_ERROR("%s does not have joint named %s", node_name_.c_str(), req.joint_names[i].c_str());
+      return_val = false;
+    }
+  }
+  return (return_val);
+}
+
+bool MutableJointStatePublisher::storeCallBack(industrial_extrinsic_cal::store_mutable_joint_states::Request& req,
+                                               industrial_extrinsic_cal::store_mutable_joint_states::Response& res)
+{
+  std::string new_file_name = yaml_file_name_;
+  ros::NodeHandle pnh("~");
+  bool overwrite = false;
+  pnh.getParam("overwrite_mutable_values", overwrite);
+  if (!overwrite) new_file_name = yaml_file_name_ + "new";
+
+  std::ofstream fout(new_file_name.c_str());
+  YAML::Emitter yaml_emitter;
+  yaml_emitter << YAML::BeginMap;
+  for (std::map< std::string, double >::iterator it = joints_.begin(); it != joints_.end(); ++it)
+  {
+    yaml_emitter << YAML::Key << it->first.c_str() << YAML::Value << it->second;
+    ROS_INFO("mutable joint %s has value %lf", it->first.c_str(), it->second);
+  }
+  yaml_emitter << YAML::EndMap;
+  fout << yaml_emitter.c_str();
+  fout.close();
+  return (true);
+}
+
+bool MutableJointStatePublisher::loadFromYamlFile()
+{
+  ROS_INFO_STREAM(yaml_file_name_);
+  // yaml file should have the followng format:
+  // joint0_name: <float_value0>
+  // joint1_name: <float_value1>
+  // joint2_name: <float_value2>
+  try
+  {
+    YAML::Node doc;
+    if (!yamlNodeFromFileName(yaml_file_name_, doc))
+    {
+      ROS_ERROR("Can't read yaml file %s", yaml_file_name_.c_str());
+    }
+    for (YAML_ITERATOR it = doc.begin(); it != doc.end(); ++it)
+    {
+      std::string key;
+      double value;
+      parseKeyDValue(it, key, value);
+      joints_[key.c_str()] = value;
+    }
+  }  // end try
+  catch (YAML::ParserException& e)
+  {
+    ROS_ERROR("mutableJointStatePublisher: parsing joint states file");
+    ROS_ERROR_STREAM("Failed with exception " << e.what());
+    return (false);
+  }
+  if (joints_.size() == 0) ROS_ERROR("mutable_joint_state_publisher has no joints");
+
+  // output so we know they have been read in correctly
+  for (std::map< std::string, double >::iterator it = joints_.begin(); it != joints_.end(); ++it)
+  {
+    ROS_INFO("mutable joint %s has value %lf", it->first.c_str(), it->second);
+  }
+
+  return (true);
+}
+
+bool MutableJointStatePublisher::publishJointStates()
+{
+  sensor_msgs::JointState joint_states;
+  joint_states.header.stamp = ros::Time::now();
+  joint_states.name.clear();
+  joint_states.position.clear();
+  joint_states.velocity.clear();
+  joint_states.effort.clear();
+  for (std::map< string, double >::iterator it = joints_.begin(); it != joints_.end(); ++it)
+  {
+    joint_states.name.push_back(it->first);
+    joint_states.position.push_back(it->second);
+    joint_states.velocity.push_back(0.0);
+    joint_states.effort.push_back(0.0);
+  }
+  joint_state_pub_.publish(joint_states);
+}
+}  // end namespace mutable_joint_state_publisher
+
+int main(int argc, char** argv)
 {
   ros::init(argc, argv, "mutable_joint_state_publisher");
   ros::NodeHandle nh;
   industrial_extrinsic_cal::MutableJointStatePublisher MJSP(nh);
   ros::Rate loop_rate(1);
-  while(ros::ok()){
+  while (ros::ok())
+  {
     MJSP.publishJointStates();
     ros::spinOnce();
     loop_rate.sleep();
   }
 }
-
-

--- a/industrial_extrinsic_cal/src/nodes/nist_analysis.cpp
+++ b/industrial_extrinsic_cal/src/nodes/nist_analysis.cpp
@@ -44,45 +44,45 @@ using industrial_extrinsic_cal::Cost_function;
 
 typedef boost::minstd_rand base_gen_type;
 base_gen_type gen(42);
-boost::normal_distribution<> normal_dist(0,1); // zero mean unit variance
-boost::variate_generator<base_gen_type&, boost::normal_distribution<> > randn(gen, normal_dist);
+boost::normal_distribution<> normal_dist(0, 1);  // zero mean unit variance
+boost::variate_generator< base_gen_type&, boost::normal_distribution<> > randn(gen, normal_dist);
 
 typedef struct observation
 {
   double x;
   double y;
-}Observation;
+} Observation;
 
 typedef struct scene
 {
   int scene_id;
   Pose6d target_pose;
-  std::vector<std::string> camera_names;
-}Scene;
+  std::vector< std::string > camera_names;
+} Scene;
 
 /*! Brief defines a camera with extra structures to maintain statistics */
-class CameraWithHistory: public Camera
+class CameraWithHistory : public Camera
 {
 public:
   int height;
   int width;
-  vector<Pose6d> pose_history;
+  vector< Pose6d > pose_history;
   double pose_position_mean_error;
   double pose_position_sigma;
   double pose_orientation_mean_error;
   double pose_orientation_sigma;
-  double sigma_ax,sigma_ay,sigma_az;
+  double sigma_ax, sigma_ay, sigma_az;
   int num_observations;
 };
 
 /*! Brief defines a 3d point with extra structures to maintain statistics*/
-class Point3dWithHistory 
+class Point3dWithHistory
 {
 public:
   Point3d point;
-  vector<double> x_history;
-  vector<double> y_history;
-  vector<double> z_history;
+  vector< double > x_history;
+  vector< double > y_history;
+  vector< double > z_history;
   double mean_x;
   double mean_y;
   double mean_z;
@@ -98,135 +98,127 @@ void printAATasH(double x, double y, double z, double tx, double ty, double tz);
 void printAATasHI(double x, double y, double z, double tx, double ty, double tz);
 void printAAasEuler(double x, double y, double z);
 void printCamera(CameraWithHistory C, string words);
-void computeObservations(vector<CameraWithHistory> &cameras, 
-			  vector<Point3dWithHistory> &points, 
-			  double noise,
-			  double max_dist,
-			  vector<ObservationDataPoint> &observations);
-void perturbCameras(vector<CameraWithHistory> &cameras, double position_noise, double degrees_noise);
-void perturbPoints(vector<Point3dWithHistory> &points, double position_noise);
-void perturbPose(Pose6d &pose, double position_noise, double degree_noise);
-void independentlyPerturbCameras(vector<CameraWithHistory> &cameras);
-void copyCamerasWoHistory(vector<CameraWithHistory> &original_cameras, vector<CameraWithHistory> & cameras);
-void copyPoints(vector<Point3dWithHistory> &original_points, vector<Point3dWithHistory> & points);
-void addPoseToHistory(vector<CameraWithHistory> &cameras, vector<CameraWithHistory> &original_cameras);
-void computeHistoricPoseStatistics(vector<CameraWithHistory> &cameras);
-void addPointsToHistory(vector<Point3dWithHistory> &points, vector<Point3dWithHistory> &original_points);
-void computeHistoricPointStatistics(vector<Point3dWithHistory> & points);
-void compareCameras(vector<CameraWithHistory> &C1, vector<CameraWithHistory> &C2);
-void compareObservations(vector<ObservationDataPoint> &O1, vector<ObservationDataPoint> &O2);
-bool  parseScenes(std::string &scene_file_name, std::vector<Scene> &scenes);
-void showScenes(vector<Scene> &scenes);
-void addTargetPoints(int rows, int cols, double spacing, vector<Point3dWithHistory> &points, Pose6d &target_pose);
-void computeObservationsFromScenes(vector<Scene> &scenes, // pose of target, and which cameras observed it
-				      vector<CameraWithHistory> &cameras, // list of cameras
-				      double target_pos_noise, // perturb position of target by this amount then compute
-				      double target_degree_noise, // peturb orientation of target by this amount then compute
-				      double image_noise,  // amount of noise to add to each observation
-				      vector<ObservationDataPoint> &observations, // returned data
-				      vector<Point3dWithHistory> &points); // returned target points
-ObservationDataPoint predictObservationOfPoint(CameraWithHistory &C,
-					       Point3dWithHistory &P, 
-					       Pose6d &target_pose, 
-					       int scene_id, 
-					       int point_id, 
-					       double image_noise,
-					       bool &results_within_image);
-void computeObservationsOfPoints(vector<CameraWithHistory> &cameras,
-				 vector<Point3dWithHistory> &points,
-				 Pose6d &target_pose,
-				 int scene_id,
-				 vector<ObservationDataPoint> &observations,
-				 double camera_position_noise = 0.0,
-				 double camera_degree_noise = 0.0,
-				 double image_noise=0.0);
+void computeObservations(vector< CameraWithHistory >& cameras, vector< Point3dWithHistory >& points, double noise,
+                         double max_dist, vector< ObservationDataPoint >& observations);
+void perturbCameras(vector< CameraWithHistory >& cameras, double position_noise, double degrees_noise);
+void perturbPoints(vector< Point3dWithHistory >& points, double position_noise);
+void perturbPose(Pose6d& pose, double position_noise, double degree_noise);
+void independentlyPerturbCameras(vector< CameraWithHistory >& cameras);
+void copyCamerasWoHistory(vector< CameraWithHistory >& original_cameras, vector< CameraWithHistory >& cameras);
+void copyPoints(vector< Point3dWithHistory >& original_points, vector< Point3dWithHistory >& points);
+void addPoseToHistory(vector< CameraWithHistory >& cameras, vector< CameraWithHistory >& original_cameras);
+void computeHistoricPoseStatistics(vector< CameraWithHistory >& cameras);
+void addPointsToHistory(vector< Point3dWithHistory >& points, vector< Point3dWithHistory >& original_points);
+void computeHistoricPointStatistics(vector< Point3dWithHistory >& points);
+void compareCameras(vector< CameraWithHistory >& C1, vector< CameraWithHistory >& C2);
+void compareObservations(vector< ObservationDataPoint >& O1, vector< ObservationDataPoint >& O2);
+bool parseScenes(std::string& scene_file_name, std::vector< Scene >& scenes);
+void showScenes(vector< Scene >& scenes);
+void addTargetPoints(int rows, int cols, double spacing, vector< Point3dWithHistory >& points, Pose6d& target_pose);
+void computeObservationsFromScenes(vector< Scene >& scenes,  // pose of target, and which cameras observed it
+                                   vector< CameraWithHistory >& cameras,  // list of cameras
+                                   double target_pos_noise,  // perturb position of target by this amount then compute
+                                   double target_degree_noise,  // peturb orientation of target by this amount then
+                                                                // compute
+                                   double image_noise,          // amount of noise to add to each observation
+                                   vector< ObservationDataPoint >& observations,  // returned data
+                                   vector< Point3dWithHistory >& points);         // returned target points
+ObservationDataPoint predictObservationOfPoint(CameraWithHistory& C, Point3dWithHistory& P, Pose6d& target_pose,
+                                               int scene_id, int point_id, double image_noise,
+                                               bool& results_within_image);
+void computeObservationsOfPoints(vector< CameraWithHistory >& cameras, vector< Point3dWithHistory >& points,
+                                 Pose6d& target_pose, int scene_id, vector< ObservationDataPoint >& observations,
+                                 double camera_position_noise = 0.0, double camera_degree_noise = 0.0,
+                                 double image_noise = 0.0);
 
 int main(int argc, char** argv)
 {
   ros::init(argc, argv, "nist_analysis");
 
-  vector<Point3d> original_points_nh; // original as read in, no history
-  vector<Point3dWithHistory> original_points; // working copy of original points
-  vector<shared_ptr<Camera> >  original_cameras_sp; // cameras with given poses
-  vector<CameraWithHistory>  original_cameras; // cameras with given poses
+  vector< Point3d > original_points_nh;                // original as read in, no history
+  vector< Point3dWithHistory > original_points;        // working copy of original points
+  vector< shared_ptr< Camera > > original_cameras_sp;  // cameras with given poses
+  vector< CameraWithHistory > original_cameras;        // cameras with given poses
 
-  vector<Point3dWithHistory> points; // working copy of original points
-  vector<Point3d> original_field_points_nh;// test points for accuracy estimation
-  vector<Point3dWithHistory> original_field_points;// test points for accuracy estimation
-  vector<Point3dWithHistory> field_points; // working copy of original field points
+  vector< Point3dWithHistory > points;                 // working copy of original points
+  vector< Point3d > original_field_points_nh;          // test points for accuracy estimation
+  vector< Point3dWithHistory > original_field_points;  // test points for accuracy estimation
+  vector< Point3dWithHistory > field_points;           // working copy of original field points
 
-  vector<CameraWithHistory>  cameras; // working copy of original cameras
-  vector<ObservationDataPoint> original_observations; // noisless observations of original points
-  vector<ObservationDataPoint> original_field_observations; // noisless observations field points
-  vector<ObservationDataPoint> observations; // working observations
+  vector< CameraWithHistory > cameras;                         // working copy of original cameras
+  vector< ObservationDataPoint > original_observations;        // noisless observations of original points
+  vector< ObservationDataPoint > original_field_observations;  // noisless observations field points
+  vector< ObservationDataPoint > observations;                 // working observations
 
   // TODO use a parameter file for these, or make them arguments
-  // hard coded constants 
-  double camera_pos_noise     = 0.10; // 25 cm
-  double camera_or_noise      = 3.0; // degrees
-  double point_pos_noise      = 0.1; // 10cm perturbation prior to triangulation
-  double target_pos_noise     = 0.003; // 3mm
-  double target_or_noise     = 1.0; // degrees
-  double image_noise          = 0.1; // pixels
-  int num_test_cases          = 100; // each test case is a statistical sample
+  // hard coded constants
+  double camera_pos_noise = 0.10;   // 25 cm
+  double camera_or_noise = 3.0;     // degrees
+  double point_pos_noise = 0.1;     // 10cm perturbation prior to triangulation
+  double target_pos_noise = 0.003;  // 3mm
+  double target_or_noise = 1.0;     // degrees
+  double image_noise = 0.1;         // pixels
+  int num_test_cases = 100;         // each test case is a statistical sample
 
   google::InitGoogleLogging(argv[0]);
   if (argc != 4)
-    {
-      std::cerr << "usage: NistAnalysis <scene_file> <cameras_file> <fieldpoints_file\n";
-      return 1;
-    }
+  {
+    std::cerr << "usage: NistAnalysis <scene_file> <cameras_file> <fieldpoints_file\n";
+    return 1;
+  }
 
   std::string scene_file_name;
   ifstream scene_file(argv[1]);
   scene_file_name = argv[1];
   if (scene_file.fail())
-    {
-      ROS_ERROR_STREAM("ERROR can't open scene_file:  "<< scene_file_name.c_str());
-      return (false);
-    }
+  {
+    ROS_ERROR_STREAM("ERROR can't open scene_file:  " << scene_file_name.c_str());
+    return (false);
+  }
 
   std::string cameras_file(argv[2]);
   std::string field_points_file(argv[3]);
 
   // read in the camera data, observation data and field points from yaml files
-  parseCameras(cameras_file, original_cameras_sp); 
+  parseCameras(cameras_file, original_cameras_sp);
 
   // copy each into a history capable version
   // NOTE: pullTransform() is called which installs the results from extrinsic calibration in the camera data
   std::string ref_frame("world");
-  BOOST_FOREACH(shared_ptr<Camera> &current_camera, original_cameras_sp){
+  BOOST_FOREACH (shared_ptr< Camera >& current_camera, original_cameras_sp)
+  {
     CameraWithHistory temp_camera;
     temp_camera.setTransformInterface(current_camera->getTransformInterface());
-    temp_camera.camera_observer_             = current_camera->camera_observer_;
-    temp_camera.trigger_                            = current_camera->trigger_;
-    temp_camera.camera_parameters_      = current_camera->camera_parameters_;
-    temp_camera.camera_name_               = current_camera->camera_name_;
-    temp_camera.intermediate_frame_      = current_camera->intermediate_frame_;
-    temp_camera.is_moving_                    = current_camera->is_moving_;
-    temp_camera.height                          = current_camera->camera_parameters_.height;
-    temp_camera.width                          = current_camera->camera_parameters_.width;
+    temp_camera.camera_observer_ = current_camera->camera_observer_;
+    temp_camera.trigger_ = current_camera->trigger_;
+    temp_camera.camera_parameters_ = current_camera->camera_parameters_;
+    temp_camera.camera_name_ = current_camera->camera_name_;
+    temp_camera.intermediate_frame_ = current_camera->intermediate_frame_;
+    temp_camera.is_moving_ = current_camera->is_moving_;
+    temp_camera.height = current_camera->camera_parameters_.height;
+    temp_camera.width = current_camera->camera_parameters_.width;
     temp_camera.setTIReferenceFrame(ref_frame);
     temp_camera.pullTransform();
     original_cameras.push_back(temp_camera);
   }
 
-  // parse the scenes. 
+  // parse the scenes.
   // This is the output from the extrinsic calibration script
   // every scene has an id, a location of the target, and a list of cameras that observed the target
-  std::vector<Scene> scenes;
+  std::vector< Scene > scenes;
   parseScenes(scene_file_name, scenes);
-  if(SHOW_DEBUG)  showScenes(scenes);
+  if (SHOW_DEBUG) showScenes(scenes);
 
   // create original_points and original_observations from scenes
   // Note, these are nominal, no observation data is kept from calibration
   // it is expected that the nominal is good enough for analyis of the gometry
-  computeObservationsFromScenes(scenes, original_cameras, 0.0, 0.0, 0.0 , original_observations, original_points);
+  computeObservationsFromScenes(scenes, original_cameras, 0.0, 0.0, 0.0, original_observations, original_points);
 
   // parse the field points used to generate the accuracy map
-  parsePoints(field_points_file,original_field_points_nh);
+  parsePoints(field_points_file, original_field_points_nh);
   original_field_points.clear();
-  for(int i=0; i<original_field_points_nh.size(); i++){
+  for (int i = 0; i < original_field_points_nh.size(); i++)
+  {
     Point3dWithHistory temp_point;
     temp_point.point.x = original_field_points_nh[i].x;
     temp_point.point.y = original_field_points_nh[i].y;
@@ -243,45 +235,49 @@ int main(int argc, char** argv)
   copyPoints(original_points, points);
   // compute noise free observations
   // these should be exactly the same as the original observations and original points
-  computeObservationsFromScenes(scenes, cameras, 0.0, 0.0, 0.0 , observations, points);
+  computeObservationsFromScenes(scenes, cameras, 0.0, 0.0, 0.0, observations, points);
 
   // compute noisy observations
   computeObservationsFromScenes(scenes, cameras, 0.0, 0.0, image_noise, observations, points);
 
   // compare noisy observations to noise free observations
-  ROS_INFO("Comparing %d noiseless observations to %d noisy observations",(int) original_observations.size(),(int) observations.size());
-  compareObservations(original_observations, observations);// shows noise is correct
+  ROS_INFO("Comparing %d noiseless observations to %d noisy observations", (int)original_observations.size(),
+           (int)observations.size());
+  compareObservations(original_observations, observations);  // shows noise is correct
 
   // regenerate noiseless observations with unperturbed cameras, note observations point to cameras parameters
   computeObservationsFromScenes(scenes, cameras, 0.0, 0.0, 0.0, observations, points);
 
-  // perturb cameras 
+  // perturb cameras
   ROS_INFO("perturbing cameras");
   perturbCameras(cameras, camera_pos_noise, camera_or_noise);
   // compare the original camera's locations to the perturbed ones
   ROS_INFO("comparing perturbed cameras to original cameras");
-  compareCameras(original_cameras, cameras); // shows how far apart they started
+  compareCameras(original_cameras, cameras);  // shows how far apart they started
 
   // Create residuals for each observation in the bundle adjustment problem. The
   // parameters for cameras and points are added automatically.
   ceres::Problem problem1;
   // each observation is noisy and points to cameras whose extrinsics are perturbed
   // each point is a fiducial in a known/surveyed location
-  ROS_INFO("solving with %d observations",(int)observations.size());
-  int b1o=0, b2o=0, b3o=0, b4o=0, b5o=0, b6o=0, b7o=0;
-  BOOST_FOREACH(ObservationDataPoint obs, observations){
-    double *extrinsics = obs.camera_extrinsics_;
+  ROS_INFO("solving with %d observations", (int)observations.size());
+  int b1o = 0, b2o = 0, b3o = 0, b4o = 0, b5o = 0, b6o = 0, b7o = 0;
+  BOOST_FOREACH (ObservationDataPoint obs, observations)
+  {
+    double* extrinsics = obs.camera_extrinsics_;
     Point3d point;
-    point.x= obs.point_position_[0];
-    point.y= obs.point_position_[1];
-    point.z= obs.point_position_[2];
+    point.x = obs.point_position_[0];
+    point.y = obs.point_position_[1];
+    point.z = obs.point_position_[2];
     double fx, fy, cx, cy, k1, k2, k3, p1, p2;
     industrial_extrinsic_cal::extractCameraIntrinsics(obs.camera_intrinsics_, fx, fy, cx, cy, k1, k2, k3, p1, p2);
-    ceres::CostFunction* cost_function = industrial_extrinsic_cal::CameraReprjErrorPK::Create(obs.image_x_,obs.image_y_,fx,fy,cx,cy,point);
+    ceres::CostFunction* cost_function =
+        industrial_extrinsic_cal::CameraReprjErrorPK::Create(obs.image_x_, obs.image_y_, fx, fy, cx, cy, point);
     problem1.AddResidualBlock(cost_function, NULL, extrinsics);
   }
-  BOOST_FOREACH(CameraWithHistory &C, cameras){
-    ROS_INFO("%s has %d observations", C.camera_name_.c_str(),C.num_observations);
+  BOOST_FOREACH (CameraWithHistory& C, cameras)
+  {
+    ROS_INFO("%s has %d observations", C.camera_name_.c_str(), C.num_observations);
   }
 
   // solve problem
@@ -291,45 +287,49 @@ int main(int argc, char** argv)
   options.max_num_iterations = 1000;
   ceres::Solver::Summary summary;
   ceres::Solve(options, &problem1, &summary);
-  if(SHOW_DEBUG){  // display results
+  if (SHOW_DEBUG)
+  {  // display results
     std::cout << summary.FullReport() << "\n";
   }
 
   // see how well original camera poses were recoved with noisy observations
   ROS_INFO("comparing camera poses derived from noiseless measurements to actual");
-  compareCameras(original_cameras, cameras); // shows that cameras were recovered
+  compareCameras(original_cameras, cameras);  // shows that cameras were recovered
 
   // compute observations of cameras at solved poses to noiseless observations
   computeObservationsFromScenes(scenes, cameras, 0.0, 0.0, 0.0, observations, points);
   ROS_INFO("comparing original observations to those made from poses derived from noisy measurments");
-  compareObservations(original_observations,observations);// ceres minimized observation noise?
+  compareObservations(original_observations, observations);  // ceres minimized observation noise?
 
   ROS_ERROR("verify recovery of camera poses for cameras with observations");
 
   // now, add noise to observations and see how well camera poses are recoverd
-  copyCamerasWoHistory(original_cameras,cameras);
+  copyCamerasWoHistory(original_cameras, cameras);
   computeObservationsFromScenes(scenes, cameras, 0.0, 0.0, image_noise, observations, points);
-  perturbCameras(cameras,camera_pos_noise,camera_or_noise);
+  perturbCameras(cameras, camera_pos_noise, camera_or_noise);
   ceres::Problem problem2;
-  BOOST_FOREACH(ObservationDataPoint obs, observations){
-    double *extrinsics = obs.camera_extrinsics_;
+  BOOST_FOREACH (ObservationDataPoint obs, observations)
+  {
+    double* extrinsics = obs.camera_extrinsics_;
     Point3d point;
-    point.x= obs.point_position_[0];
-    point.y= obs.point_position_[1];
-    point.z= obs.point_position_[2];
+    point.x = obs.point_position_[0];
+    point.y = obs.point_position_[1];
+    point.z = obs.point_position_[2];
     double fx, fy, cx, cy, k1, k2, k3, p1, p2;
     industrial_extrinsic_cal::extractCameraIntrinsics(obs.camera_intrinsics_, fx, fy, cx, cy, k1, k2, k3, p1, p2);
-    ceres::CostFunction* cost_function = industrial_extrinsic_cal::CameraReprjErrorPK::Create(obs.image_x_,obs.image_y_,fx,fy,cx,cy,point);
+    ceres::CostFunction* cost_function =
+        industrial_extrinsic_cal::CameraReprjErrorPK::Create(obs.image_x_, obs.image_y_, fx, fy, cx, cy, point);
     problem2.AddResidualBlock(cost_function, NULL, extrinsics);
   }
   // solve problem
   ceres::Solve(options, &problem2, &summary);
-  if(SHOW_DEBUG){  // display results
+  if (SHOW_DEBUG)
+  {  // display results
     std::cout << summary.FullReport() << "\n";
   }
   // see how well original camera poses were recoved with noisy observations
   ROS_INFO("comparing camera poses derived from noisy measurements to actual");
-  compareCameras(original_cameras, cameras); // shows that cameras were recovered
+  compareCameras(original_cameras, cameras);  // shows that cameras were recovered
 
   ROS_ERROR("verify recovery of camera poses with reduced accuracy for cameras with observations");
 
@@ -342,50 +342,51 @@ int main(int argc, char** argv)
 
   // compute poses for cameras for a bunch of test cases
   options.minimizer_progress_to_stdout = false;
-  for(int test_case=0; test_case<num_test_cases; test_case++){
+  for (int test_case = 0; test_case < num_test_cases; test_case++)
+  {
     copyCamerasWoHistory(original_cameras, cameras);
     computeObservationsFromScenes(scenes, cameras, 0.0, 0.0, image_noise, observations, points);
-    perturbCameras(cameras,camera_pos_noise,camera_or_noise);
+    perturbCameras(cameras, camera_pos_noise, camera_or_noise);
 
     ceres::Problem problem;
-    BOOST_FOREACH(ObservationDataPoint obs, observations){
-      double x  = obs.image_x_;
-      double y  = obs.image_y_;
-      double *extrinsics = obs.camera_extrinsics_;
+    BOOST_FOREACH (ObservationDataPoint obs, observations)
+    {
+      double x = obs.image_x_;
+      double y = obs.image_y_;
+      double* extrinsics = obs.camera_extrinsics_;
       Point3d point;
-      point.x= obs.point_position_[0];
-      point.y= obs.point_position_[1];
-      point.z= obs.point_position_[2];
+      point.x = obs.point_position_[0];
+      point.y = obs.point_position_[1];
+      point.z = obs.point_position_[2];
       double fx, fy, cx, cy, k1, k2, k3, p1, p2;
       industrial_extrinsic_cal::extractCameraIntrinsics(obs.camera_intrinsics_, fx, fy, cx, cy, k1, k2, k3, p1, p2);
-      ceres::CostFunction* cost_function = industrial_extrinsic_cal::CameraReprjErrorPK::Create(x,y,fx,fy,cx,cy,point);
+      ceres::CostFunction* cost_function =
+          industrial_extrinsic_cal::CameraReprjErrorPK::Create(x, y, fx, fy, cx, cy, point);
       problem.AddResidualBlock(cost_function, NULL, extrinsics);
     }
     ceres::Solve(options, &problem, &summary);
     addPoseToHistory(cameras, original_cameras);
-  }// end of test cases
+  }  // end of test cases
   computeHistoricPoseStatistics(original_cameras);
-  
-  BOOST_FOREACH(CameraWithHistory &C, original_cameras){
+
+  BOOST_FOREACH (CameraWithHistory& C, original_cameras)
+  {
     ROS_INFO("%s\t:mean_pos_error = %7.5lf sigma=  %7.5lf angular %7.5lf number_observations = %d",
-	   C.camera_name_.c_str(),
-	   C.pose_position_mean_error,
-	   C.pose_position_sigma,
-	   C.pose_orientation_sigma*180/3.1415,
-	   C.num_observations);
-  } 
+             C.camera_name_.c_str(), C.pose_position_mean_error, C.pose_position_sigma,
+             C.pose_orientation_sigma * 180 / 3.1415, C.num_observations);
+  }
 
   // at this point cameras each have an uncertianty model.
   // the uncertianty model is the variance in both position and orientation
   // We can now sample from this model to get uncertianty estimates for field points.
   // for .25 pixel error, most cameras have between  in position variance
-  // and have less than .9 degrees in angular variance  
+  // and have less than .9 degrees in angular variance
 
   // Now we are ready to compute the field accuracy of the working volume
   // To to this we do the following.
   // Create a grid of locations representative of the field accuracy
   // For this optimization, the points will be solve, while the cameras are fixed
-  // The cameras will be fixed at their original/nominal locations 
+  // The cameras will be fixed at their original/nominal locations
   // But the observations will be made from the perturbed/real locations with each test case
   // Loop:
   //    Perturb the cameras using each camera's pose accuracy estimate
@@ -398,39 +399,43 @@ int main(int argc, char** argv)
   // Compute noiseless observations of field points
   // determine how many times each point gets observed (need at least 2 to be triangulated)
   copyCamerasWoHistory(original_cameras, cameras);
-  Pose6d target_pose;// not used, but needed to fill out the observation data structure
-  int scene_id = 0;// not used
+  Pose6d target_pose;  // not used, but needed to fill out the observation data structure
+  int scene_id = 0;    // not used
   computeObservationsOfPoints(cameras, original_field_points, target_pose, scene_id, original_field_observations);
 
   independentlyPerturbCameras(cameras);
   ROS_ERROR("comparing original camera poses to those using independent perturbations\n");
-  compareCameras(original_cameras,cameras); // will have some agregate overall statistics
+  compareCameras(original_cameras, cameras);  // will have some agregate overall statistics
 
-  for(int test_case=0; test_case<num_test_cases; test_case++){
-    copyPoints(original_field_points, field_points); // working copy of field points
-    copyCamerasWoHistory(original_cameras,cameras); // working copy of cameras
+  for (int test_case = 0; test_case < num_test_cases; test_case++)
+  {
+    copyPoints(original_field_points, field_points);  // working copy of field points
+    copyCamerasWoHistory(original_cameras, cameras);  // working copy of cameras
 
-    // noiseless ideal observations of cameras at their actual locations, these observation now point toward field points
+    // noiseless ideal observations of cameras at their actual locations, these observation now point toward field
+    // points
     computeObservationsOfPoints(cameras, field_points, target_pose, scene_id, observations);
     // noisey ideal observations of cameras at their actual locations
     // computeObservationsOfPoints(cameras, field_points, target_pose, scene_id, observations, 0.0, 0.0, image_noise);
 
     // cameras independently perturbed from their actual locations for triangulation
-    independentlyPerturbCameras(cameras); 
-    perturbPoints(field_points, point_pos_noise); 
+    independentlyPerturbCameras(cameras);
+    perturbPoints(field_points, point_pos_noise);
 
     ceres::Problem problem;
     options.minimizer_progress_to_stdout = false;
-    BOOST_FOREACH(ObservationDataPoint obs, observations){
-      double x  = obs.image_x_;
-      double y  = obs.image_y_;
-      double *points     = obs.point_position_; // this is perturbed from ideal by point_pos_noise
+    BOOST_FOREACH (ObservationDataPoint obs, observations)
+    {
+      double x = obs.image_x_;
+      double y = obs.image_y_;
+      double* points = obs.point_position_;  // this is perturbed from ideal by point_pos_noise
       double fx, fy, cx, cy, k1, k2, k3, p1, p2;
       industrial_extrinsic_cal::extractCameraIntrinsics(obs.camera_intrinsics_, fx, fy, cx, cy, k1, k2, k3, p1, p2);
       double tx, ty, tz, ax, ay, az;
       industrial_extrinsic_cal::extractCameraExtrinsics(obs.camera_extrinsics_, tx, ty, tz, ax, ay, az);
-      Pose6d camera_pose(tx, ty, tz, ax, ay, az); // note this is the pose from camera to world
-      ceres::CostFunction* cost_function = industrial_extrinsic_cal::TriangulationError::Create(x,y,fx,fy,cx,cy,camera_pose);
+      Pose6d camera_pose(tx, ty, tz, ax, ay, az);  // note this is the pose from camera to world
+      ceres::CostFunction* cost_function =
+          industrial_extrinsic_cal::TriangulationError::Create(x, y, fx, fy, cx, cy, camera_pose);
       problem.AddResidualBlock(cost_function, NULL, points);
     }
     ceres::Solve(options, &problem, &summary);
@@ -438,29 +443,16 @@ int main(int argc, char** argv)
     addPointsToHistory(field_points, original_field_points);
   }
   computeHistoricPointStatistics(original_field_points);
-  FILE *fp = fopen("field_results.m","w");
-  fprintf(fp,"f = [\n");
-  BOOST_FOREACH(Point3dWithHistory P, original_field_points){
-    printf("Mean Error= %9.5lf %9.5lf %9.5lf sigma= %9.5lf %9.5lf %9.5lf num_obs=%d\n",
-	   P.mean_x-P.point.x,
-	   P.mean_y-P.point.y,
-	   P.mean_z-P.point.z,
-	   P.sigma_x,
-	   P.sigma_y,
-	   P.sigma_z,
-	   P.num_observations);
-    fprintf(fp,"%9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf;\n",
-	    P.point.x,
-	    P.point.y,
-	    P.point.z,
-	    P.mean_x,
-	    P.mean_y,
-	    P.mean_z,
-	    P.sigma_x,
-	    P.sigma_y,
-	    P.sigma_z);
+  FILE* fp = fopen("field_results.m", "w");
+  fprintf(fp, "f = [\n");
+  BOOST_FOREACH (Point3dWithHistory P, original_field_points)
+  {
+    printf("Mean Error= %9.5lf %9.5lf %9.5lf sigma= %9.5lf %9.5lf %9.5lf num_obs=%d\n", P.mean_x - P.point.x,
+           P.mean_y - P.point.y, P.mean_z - P.point.z, P.sigma_x, P.sigma_y, P.sigma_z, P.num_observations);
+    fprintf(fp, "%9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf;\n", P.point.x, P.point.y, P.point.z,
+            P.mean_x, P.mean_y, P.mean_z, P.sigma_x, P.sigma_y, P.sigma_z);
   }
-  fprintf(fp,"];\n");
+  fprintf(fp, "];\n");
   fclose(fp);
 }
 
@@ -533,126 +525,133 @@ void printAAasEuler(double x, double y, double z)
 }
 void printCamera(CameraWithHistory C, string words)
 {
-  
   printf("%s\n", words.c_str());
   printf("Point in Camera frame to points in World frame Transform:\n");
-  printAATasHI(C.camera_parameters_.angle_axis[0], C.camera_parameters_.angle_axis[1], C.camera_parameters_.angle_axis[2], 
-		C.camera_parameters_.position[0],   C.camera_parameters_.position[1],   C.camera_parameters_.position[2]);
+  printAATasHI(C.camera_parameters_.angle_axis[0], C.camera_parameters_.angle_axis[1],
+               C.camera_parameters_.angle_axis[2], C.camera_parameters_.position[0], C.camera_parameters_.position[1],
+               C.camera_parameters_.position[2]);
 
   printf("Points in World frame to points in Camera frame transform\n");
-  printAATasH(C.camera_parameters_.angle_axis[0], C.camera_parameters_.angle_axis[1], C.camera_parameters_.angle_axis[2], 
-	       C.camera_parameters_.position[0],   C.camera_parameters_.position[1],   C.camera_parameters_.position[2]);
+  printAATasH(C.camera_parameters_.angle_axis[0], C.camera_parameters_.angle_axis[1],
+              C.camera_parameters_.angle_axis[2], C.camera_parameters_.position[0], C.camera_parameters_.position[1],
+              C.camera_parameters_.position[2]);
 
-  printAAasEuler(C.camera_parameters_.angle_axis[0], C.camera_parameters_.angle_axis[1], C.camera_parameters_.angle_axis[2]);
+  printAAasEuler(C.camera_parameters_.angle_axis[0], C.camera_parameters_.angle_axis[1],
+                 C.camera_parameters_.angle_axis[2]);
   printf("fx = %8.3lf fy = %8.3lf\n", C.camera_parameters_.focal_length_x, C.camera_parameters_.focal_length_y);
   printf("cx = %8.3lf cy = %8.3lf\n", C.camera_parameters_.center_x, C.camera_parameters_.center_y);
 }
 
-
-void computeObservations(vector<CameraWithHistory> &cameras, 
-			  vector<Point3dWithHistory> &points, 
-			  double noise,
-			  double max_dist,
-			  vector<ObservationDataPoint> &observations)
+void computeObservations(vector< CameraWithHistory >& cameras, vector< Point3dWithHistory >& points, double noise,
+                         double max_dist, vector< ObservationDataPoint >& observations)
 {
-  double pnoise = noise/sqrt(1.58085);// magic number found by trial and error
+  double pnoise = noise / sqrt(1.58085);  // magic number found by trial and error
   int n_observations = 0;
   observations.clear();
 
   // reset number of observations for the points
-  BOOST_FOREACH(Point3dWithHistory &P, points){
+  BOOST_FOREACH (Point3dWithHistory& P, points)
+  {
     P.num_observations = 0;
   }
 
   // create nominal observations of points using camera parameters
-  BOOST_FOREACH(CameraWithHistory &C, cameras){
+  BOOST_FOREACH (CameraWithHistory& C, cameras)
+  {
     C.num_observations = 0;
-    int j=0;
-    BOOST_FOREACH(Point3dWithHistory &P, points){
+    int j = 0;
+    BOOST_FOREACH (Point3dWithHistory& P, points)
+    {
       j++;
       // find image of point in camera
       double dx = C.camera_parameters_.position[0] - P.point.x;
       double dy = C.camera_parameters_.position[1] - P.point.y;
       double dz = C.camera_parameters_.position[2] - P.point.z;
-      double distance = sqrt(dx*dx + dy*dy + dz*dz);
-      if(distance < max_dist){
-	double fx, fy, cx, cy, k1, k2, k3, p1, p2;
-	Observation obs;
-	double *intrinsics = C.camera_parameters_.pb_intrinsics;
-	industrial_extrinsic_cal::extractCameraIntrinsics(intrinsics, fx, fy, cx, cy, k1, k2, k3, p1, p2);
-	P_BLOCK point = &P.point.pb[0];
-	industrial_extrinsic_cal::projectPntNoDistortion(point, fx, fy, cx, cy, obs.x, obs.y);
-	obs.x += pnoise*randn(); // add observation noise
-	obs.y += pnoise*randn();
-	if(obs.x >= 0 && obs.x < C.width && obs.y >= 0 &&obs.y < C.height ){
-	  // save observation
-	  Pose6d target_pose, intermediate_frame;
-	  industrial_extrinsic_cal::Cost_function cost_type;
-	  ObservationDataPoint new_obs(C.camera_name_, 
-				       "who_cares", // target name
-				       2, // target type
-				       0, // scene id (who cares)
-				       C.camera_parameters_.pb_intrinsics, // camera intrinsics
-				       C.camera_parameters_.pb_extrinsics, // camera extrinsics
-				       0, // point_id
-				       target_pose.pb_pose, // target_pose
-				       point, // point position
-				       obs.x, // observation x
-				       obs.x, // observation y
-				       cost_type, // const Cost_function
-				       intermediate_frame); // Pose6d of intermediate frame
-	  observations.push_back(new_obs);
-	  C.num_observations++;
-	  P.num_observations++;
-	  n_observations++;
-	} // end if observation within field of view
-      } // end if point close enough to camera
-    }// end for each fiducial point
-   }// end for each camera
-}// end compute observations
+      double distance = sqrt(dx * dx + dy * dy + dz * dz);
+      if (distance < max_dist)
+      {
+        double fx, fy, cx, cy, k1, k2, k3, p1, p2;
+        Observation obs;
+        double* intrinsics = C.camera_parameters_.pb_intrinsics;
+        industrial_extrinsic_cal::extractCameraIntrinsics(intrinsics, fx, fy, cx, cy, k1, k2, k3, p1, p2);
+        P_BLOCK point = &P.point.pb[0];
+        industrial_extrinsic_cal::projectPntNoDistortion(point, fx, fy, cx, cy, obs.x, obs.y);
+        obs.x += pnoise * randn();  // add observation noise
+        obs.y += pnoise * randn();
+        if (obs.x >= 0 && obs.x < C.width && obs.y >= 0 && obs.y < C.height)
+        {
+          // save observation
+          Pose6d target_pose, intermediate_frame;
+          industrial_extrinsic_cal::Cost_function cost_type;
+          ObservationDataPoint new_obs(C.camera_name_,
+                                       "who_cares",                         // target name
+                                       2,                                   // target type
+                                       0,                                   // scene id (who cares)
+                                       C.camera_parameters_.pb_intrinsics,  // camera intrinsics
+                                       C.camera_parameters_.pb_extrinsics,  // camera extrinsics
+                                       0,                                   // point_id
+                                       target_pose.pb_pose,                 // target_pose
+                                       point,                               // point position
+                                       obs.x,                               // observation x
+                                       obs.x,                               // observation y
+                                       cost_type,                           // const Cost_function
+                                       intermediate_frame);                 // Pose6d of intermediate frame
+          observations.push_back(new_obs);
+          C.num_observations++;
+          P.num_observations++;
+          n_observations++;
+        }  // end if observation within field of view
+      }    // end if point close enough to camera
+    }      // end for each fiducial point
+  }        // end for each camera
+}  // end compute observations
 
-void perturbCameras(vector<CameraWithHistory> &cameras, double position_noise, double degrees_noise)
+void perturbCameras(vector< CameraWithHistory >& cameras, double position_noise, double degrees_noise)
 {
-  double pos_noise    = position_noise/sqrt(2.274625);
-  double radian_noise = degrees_noise*3.1415/(180.0*sqrt(2.58047));
-  BOOST_FOREACH(CameraWithHistory &C, cameras){
-      C.camera_parameters_.position[0]   += pos_noise*randn();	
-      C.camera_parameters_.position[1]   += pos_noise*randn();
-      C.camera_parameters_.position[2]   += pos_noise*randn();
-      C.camera_parameters_.angle_axis[0] += radian_noise*randn();
-      C.camera_parameters_.angle_axis[1] += radian_noise*randn();
-      C.camera_parameters_.angle_axis[2] += radian_noise*randn();
+  double pos_noise = position_noise / sqrt(2.274625);
+  double radian_noise = degrees_noise * 3.1415 / (180.0 * sqrt(2.58047));
+  BOOST_FOREACH (CameraWithHistory& C, cameras)
+  {
+    C.camera_parameters_.position[0] += pos_noise * randn();
+    C.camera_parameters_.position[1] += pos_noise * randn();
+    C.camera_parameters_.position[2] += pos_noise * randn();
+    C.camera_parameters_.angle_axis[0] += radian_noise * randn();
+    C.camera_parameters_.angle_axis[1] += radian_noise * randn();
+    C.camera_parameters_.angle_axis[2] += radian_noise * randn();
   }
 }
 
-void perturbPoints(vector<Point3dWithHistory> &points, double position_noise)
+void perturbPoints(vector< Point3dWithHistory >& points, double position_noise)
 {
-  double pos_noise    = position_noise/sqrt(2.274625);
-  BOOST_FOREACH(Point3dWithHistory &P, points){
-      P.point.x  += pos_noise*randn();	
-      P.point.y  += pos_noise*randn();
-      P.point.z  += pos_noise*randn();
+  double pos_noise = position_noise / sqrt(2.274625);
+  BOOST_FOREACH (Point3dWithHistory& P, points)
+  {
+    P.point.x += pos_noise * randn();
+    P.point.y += pos_noise * randn();
+    P.point.z += pos_noise * randn();
   }
 }
 
-void independentlyPerturbCameras(vector<CameraWithHistory> &cameras)
+void independentlyPerturbCameras(vector< CameraWithHistory >& cameras)
 {
-  BOOST_FOREACH(CameraWithHistory &C, cameras){
-    double pos_noise    = C.pose_position_sigma/sqrt(2.274625);
-    double radian_noise = C.pose_orientation_sigma/sqrt(2.58047);
-    C.camera_parameters_.position[0]   += pos_noise*randn();	
-    C.camera_parameters_.position[1]   += pos_noise*randn();
-    C.camera_parameters_.position[2]   += pos_noise*randn();
-    C.camera_parameters_.angle_axis[0] += radian_noise*randn();
-    C.camera_parameters_.angle_axis[1] += radian_noise*randn();
-    C.camera_parameters_.angle_axis[2] += radian_noise*randn();
+  BOOST_FOREACH (CameraWithHistory& C, cameras)
+  {
+    double pos_noise = C.pose_position_sigma / sqrt(2.274625);
+    double radian_noise = C.pose_orientation_sigma / sqrt(2.58047);
+    C.camera_parameters_.position[0] += pos_noise * randn();
+    C.camera_parameters_.position[1] += pos_noise * randn();
+    C.camera_parameters_.position[2] += pos_noise * randn();
+    C.camera_parameters_.angle_axis[0] += radian_noise * randn();
+    C.camera_parameters_.angle_axis[1] += radian_noise * randn();
+    C.camera_parameters_.angle_axis[2] += radian_noise * randn();
   }
 }
 
-void copyCamerasWoHistory(vector<CameraWithHistory> &original_cameras, vector<CameraWithHistory> & cameras)
+void copyCamerasWoHistory(vector< CameraWithHistory >& original_cameras, vector< CameraWithHistory >& cameras)
 {
   cameras.clear();
-  BOOST_FOREACH(CameraWithHistory &C, original_cameras){
+  BOOST_FOREACH (CameraWithHistory& C, original_cameras)
+  {
     CameraWithHistory newC = C;
     newC.pose_history.clear();
     newC.num_observations = 0;
@@ -660,24 +659,25 @@ void copyCamerasWoHistory(vector<CameraWithHistory> &original_cameras, vector<Ca
   }
 }
 
-void copyPoints(vector<Point3dWithHistory> &original_points, vector<Point3dWithHistory> & points)
+void copyPoints(vector< Point3dWithHistory >& original_points, vector< Point3dWithHistory >& points)
 {
   points.clear();
-  BOOST_FOREACH(Point3dWithHistory &P, original_points){
+  BOOST_FOREACH (Point3dWithHistory& P, original_points)
+  {
     points.push_back(P);
   }
-} 
+}
 
-void addPoseToHistory(vector<CameraWithHistory> &cameras, vector<CameraWithHistory> & original_cameras)
+void addPoseToHistory(vector< CameraWithHistory >& cameras, vector< CameraWithHistory >& original_cameras)
 {
-  if(cameras.size() != original_cameras.size())
-    ROS_ERROR_STREAM("number of cameras in vectors do not match");
+  if (cameras.size() != original_cameras.size()) ROS_ERROR_STREAM("number of cameras in vectors do not match");
 
-  for(int i=0;i<(int)cameras.size();i++){
+  for (int i = 0; i < (int)cameras.size(); i++)
+  {
     Pose6d pose;
-    pose.x  = cameras[i].camera_parameters_.position[0];
-    pose.y  = cameras[i].camera_parameters_.position[1];
-    pose.z  = cameras[i].camera_parameters_.position[2];
+    pose.x = cameras[i].camera_parameters_.position[0];
+    pose.y = cameras[i].camera_parameters_.position[1];
+    pose.z = cameras[i].camera_parameters_.position[2];
     pose.ax = cameras[i].camera_parameters_.angle_axis[0];
     pose.ay = cameras[i].camera_parameters_.angle_axis[1];
     pose.az = cameras[i].camera_parameters_.angle_axis[2];
@@ -685,42 +685,44 @@ void addPoseToHistory(vector<CameraWithHistory> &cameras, vector<CameraWithHisto
   }
 }
 
-void computeHistoricPoseStatistics(vector<CameraWithHistory> & cameras)
+void computeHistoricPoseStatistics(vector< CameraWithHistory >& cameras)
 {
   // calculate statistics of test case
   double mean_x, mean_y, mean_z, mean_ax, mean_ay, mean_az;
   double sigma_x, sigma_y, sigma_z, sigma_ax, sigma_ay, sigma_az;
-  BOOST_FOREACH(CameraWithHistory &C, cameras){
-    mean_x  = 0.0;
-    mean_y  = 0.0;
-    mean_z  = 0.0;
+  BOOST_FOREACH (CameraWithHistory& C, cameras)
+  {
+    mean_x = 0.0;
+    mean_y = 0.0;
+    mean_z = 0.0;
     mean_ax = 0.0;
     mean_ay = 0.0;
     mean_az = 0.0;
-    BOOST_FOREACH(Pose6d &p, C.pose_history){
-      mean_x  += p.x;
-      mean_y  += p.y;
-      mean_z  += p.z;
+    BOOST_FOREACH (Pose6d& p, C.pose_history)
+    {
+      mean_x += p.x;
+      mean_y += p.y;
+      mean_z += p.z;
       mean_ax += p.ax;
       mean_ay += p.ay;
       mean_az += p.az;
     }
-    int num_poses = (int) C.pose_history.size();
-    mean_x  = mean_x/num_poses;
-    mean_y  = mean_y/num_poses;
-    mean_z  = mean_z/num_poses;
-    mean_ax = mean_ax/num_poses;
-    mean_ay = mean_ay/num_poses;
-    mean_az = mean_az/num_poses;
+    int num_poses = (int)C.pose_history.size();
+    mean_x = mean_x / num_poses;
+    mean_y = mean_y / num_poses;
+    mean_z = mean_z / num_poses;
+    mean_ax = mean_ax / num_poses;
+    mean_ay = mean_ay / num_poses;
+    mean_az = mean_az / num_poses;
 
     double d_x = mean_x - C.camera_parameters_.position[0];
     double d_y = mean_y - C.camera_parameters_.position[1];
     double d_z = mean_z - C.camera_parameters_.position[2];
-    C.pose_position_mean_error = sqrt(d_x*d_x + d_y*d_y + d_z*d_z);
+    C.pose_position_mean_error = sqrt(d_x * d_x + d_y * d_y + d_z * d_z);
     double d_ax = mean_ax - C.camera_parameters_.angle_axis[0];
     double d_ay = mean_ay - C.camera_parameters_.angle_axis[1];
     double d_az = mean_az - C.camera_parameters_.angle_axis[2];
-    C.pose_orientation_mean_error = sqrt(d_ax*d_ax + d_ay*d_ay + d_az*d_az);
+    C.pose_orientation_mean_error = sqrt(d_ax * d_ax + d_ay * d_ay + d_az * d_az);
 
     sigma_x = 0.0;
     sigma_y = 0.0;
@@ -728,325 +730,369 @@ void computeHistoricPoseStatistics(vector<CameraWithHistory> & cameras)
     sigma_ax = 0.0;
     sigma_ay = 0.0;
     sigma_az = 0.0;
-    BOOST_FOREACH(Pose6d &p, C.pose_history){
-      sigma_x  += (mean_x  - p.x)*(mean_x - p.x);;
-      sigma_y  += (mean_y  - p.y)*(mean_y - p.y);;
-      sigma_z  += (mean_z  - p.z)*(mean_z - p.z);;
-      sigma_ax += (mean_ax - p.ax)*(mean_ax - p.ax);;
-      sigma_ay += (mean_ay - p.ay)*(mean_ay - p.ay);;
-      sigma_az += (mean_az - p.az)*(mean_az - p.az);;
+    BOOST_FOREACH (Pose6d& p, C.pose_history)
+    {
+      sigma_x += (mean_x - p.x) * (mean_x - p.x);
+      ;
+      sigma_y += (mean_y - p.y) * (mean_y - p.y);
+      ;
+      sigma_z += (mean_z - p.z) * (mean_z - p.z);
+      ;
+      sigma_ax += (mean_ax - p.ax) * (mean_ax - p.ax);
+      ;
+      sigma_ay += (mean_ay - p.ay) * (mean_ay - p.ay);
+      ;
+      sigma_az += (mean_az - p.az) * (mean_az - p.az);
+      ;
     }
-    sigma_x  = sqrt(sigma_x/(num_poses - 1.0));
-    sigma_y  = sqrt(sigma_y/(num_poses - 1.0));
-    sigma_z  = sqrt(sigma_z/(num_poses - 1.0));
-    C.sigma_ax = sigma_ax = sqrt(sigma_ax/(num_poses - 1.0));
-    C.sigma_ay = sigma_ay = sqrt(sigma_ay/(num_poses - 1.0));
-    C.sigma_az = sigma_az = sqrt(sigma_az/(num_poses - 1.0));
+    sigma_x = sqrt(sigma_x / (num_poses - 1.0));
+    sigma_y = sqrt(sigma_y / (num_poses - 1.0));
+    sigma_z = sqrt(sigma_z / (num_poses - 1.0));
+    C.sigma_ax = sigma_ax = sqrt(sigma_ax / (num_poses - 1.0));
+    C.sigma_ay = sigma_ay = sqrt(sigma_ay / (num_poses - 1.0));
+    C.sigma_az = sigma_az = sqrt(sigma_az / (num_poses - 1.0));
 
-    double dv = sqrt(sigma_x*sigma_x + sigma_y*sigma_y + sigma_z*sigma_z);
-    double av = sqrt(sigma_ax*sigma_ax + sigma_ay*sigma_ay + sigma_az*sigma_az);
+    double dv = sqrt(sigma_x * sigma_x + sigma_y * sigma_y + sigma_z * sigma_z);
+    double av = sqrt(sigma_ax * sigma_ax + sigma_ay * sigma_ay + sigma_az * sigma_az);
 
-    C.pose_position_sigma    = dv;
+    C.pose_position_sigma = dv;
     C.pose_orientation_sigma = av;
-  } // end for each camera
+  }  // end for each camera
 }
 
-void computeHistoricPointStatistics(vector<Point3dWithHistory> & points)
+void computeHistoricPointStatistics(vector< Point3dWithHistory >& points)
 {
   // calculate statistics of test case
   double mean_x, mean_y, mean_z;
 
-  BOOST_FOREACH(Point3dWithHistory &P, points){
+  BOOST_FOREACH (Point3dWithHistory& P, points)
+  {
     P.mean_x = P.mean_y = P.mean_z = 0.0;
-    BOOST_FOREACH(double &p, P.x_history){
-      P.mean_x  += p;
+    BOOST_FOREACH (double& p, P.x_history)
+    {
+      P.mean_x += p;
     }
-    BOOST_FOREACH(double &p, P.y_history){
-      P.mean_y  += p;
+    BOOST_FOREACH (double& p, P.y_history)
+    {
+      P.mean_y += p;
     }
-    BOOST_FOREACH(double &p, P.z_history){
-      P.mean_z  += p;
+    BOOST_FOREACH (double& p, P.z_history)
+    {
+      P.mean_z += p;
     }
-    int num_values = (int) P.x_history.size();
-    if(num_values == 0){ 
-      num_values=1.0;
+    int num_values = (int)P.x_history.size();
+    if (num_values == 0)
+    {
+      num_values = 1.0;
     }
-    P.mean_x  = P.mean_x/num_values;
-    P.mean_y  = P.mean_y/num_values;
-    P.mean_z  = P.mean_z/num_values;
+    P.mean_x = P.mean_x / num_values;
+    P.mean_y = P.mean_y / num_values;
+    P.mean_z = P.mean_z / num_values;
 
     P.sigma_x = P.sigma_y = P.sigma_z = 0.0;
-    BOOST_FOREACH(double &p, P.x_history){
-      P.sigma_x  += (P.mean_x - p)*(P.mean_x - p);;
+    BOOST_FOREACH (double& p, P.x_history)
+    {
+      P.sigma_x += (P.mean_x - p) * (P.mean_x - p);
+      ;
     }
-    BOOST_FOREACH(double &p, P.y_history){
-      P.sigma_y  += (P.mean_y - p)*(P.mean_y - p);;
+    BOOST_FOREACH (double& p, P.y_history)
+    {
+      P.sigma_y += (P.mean_y - p) * (P.mean_y - p);
+      ;
     }
-    BOOST_FOREACH(double &p, P.z_history){
-      P.sigma_z  += (P.mean_z - p)*(P.mean_z - p);;
+    BOOST_FOREACH (double& p, P.z_history)
+    {
+      P.sigma_z += (P.mean_z - p) * (P.mean_z - p);
+      ;
     }
-    double denom = num_values-1.0;
-    if(denom==0 || P.num_observations ==0){
+    double denom = num_values - 1.0;
+    if (denom == 0 || P.num_observations == 0)
+    {
       P.sigma_x = 1000;
       P.sigma_y = 1000;
       P.sigma_z = 1000;
     }
-    else if(P.num_observations ==1){//can't triangulate with only one observation
+    else if (P.num_observations == 1)
+    {  // can't triangulate with only one observation
       P.sigma_x = 0.4;
       P.sigma_y = 0.4;
       P.sigma_z = 0.4;
     }
-    else{
-      P.sigma_x  = sqrt(P.sigma_x/denom);
-      P.sigma_y  = sqrt(P.sigma_y/denom);
-      P.sigma_z  = sqrt(P.sigma_z/denom);
+    else
+    {
+      P.sigma_x = sqrt(P.sigma_x / denom);
+      P.sigma_y = sqrt(P.sigma_y / denom);
+      P.sigma_z = sqrt(P.sigma_z / denom);
     }
-  } // end for each point
+  }  // end for each point
 }
 
-void compareCameras(vector<CameraWithHistory> &C1, vector<CameraWithHistory> &C2)
+void compareCameras(vector< CameraWithHistory >& C1, vector< CameraWithHistory >& C2)
 {
-  if(C1.size()!= C2.size()){
+  if (C1.size() != C2.size())
+  {
     ROS_ERROR_STREAM("compareCameras() camera vectors different in length");
   }
-  double d_x,d_y,d_z,dist;
-  double mean_dist=0;
-  double sigma_dist=0;
-  double d_ax,d_ay,d_az,angle;
-  double mean_angle=0;
-  double sigma_angle=0;
-  for(int i=0;i<(int)C1.size();i++){
-    if(C1[i].camera_name_ == C2[i].camera_name_){
-      d_x = C1[i].camera_parameters_.position[0]-C2[i].camera_parameters_.position[0];
-      d_y = C1[i].camera_parameters_.position[1]-C2[i].camera_parameters_.position[1];
-      d_z = C1[i].camera_parameters_.position[2]-C2[i].camera_parameters_.position[2];
-      d_ax = C1[i].camera_parameters_.angle_axis[0]-C2[i].camera_parameters_.angle_axis[0];
-      d_ay = C1[i].camera_parameters_.angle_axis[1]-C2[i].camera_parameters_.angle_axis[1];
-      d_az = C1[i].camera_parameters_.angle_axis[2]-C2[i].camera_parameters_.angle_axis[2];
-      dist = sqrt(d_x*d_x + d_y*d_y + d_z*d_z);
-      angle = sqrt(d_ax*d_ax + d_ay*d_ay + d_az*d_az);
-      ROS_INFO("camera %s position_diff = %7.5lf meters, orientation diff = %7.5lf degrees", C1[i].camera_name_.c_str(), dist, angle*180/3.14);
+  double d_x, d_y, d_z, dist;
+  double mean_dist = 0;
+  double sigma_dist = 0;
+  double d_ax, d_ay, d_az, angle;
+  double mean_angle = 0;
+  double sigma_angle = 0;
+  for (int i = 0; i < (int)C1.size(); i++)
+  {
+    if (C1[i].camera_name_ == C2[i].camera_name_)
+    {
+      d_x = C1[i].camera_parameters_.position[0] - C2[i].camera_parameters_.position[0];
+      d_y = C1[i].camera_parameters_.position[1] - C2[i].camera_parameters_.position[1];
+      d_z = C1[i].camera_parameters_.position[2] - C2[i].camera_parameters_.position[2];
+      d_ax = C1[i].camera_parameters_.angle_axis[0] - C2[i].camera_parameters_.angle_axis[0];
+      d_ay = C1[i].camera_parameters_.angle_axis[1] - C2[i].camera_parameters_.angle_axis[1];
+      d_az = C1[i].camera_parameters_.angle_axis[2] - C2[i].camera_parameters_.angle_axis[2];
+      dist = sqrt(d_x * d_x + d_y * d_y + d_z * d_z);
+      angle = sqrt(d_ax * d_ax + d_ay * d_ay + d_az * d_az);
+      ROS_INFO("camera %s position_diff = %7.5lf meters, orientation diff = %7.5lf degrees", C1[i].camera_name_.c_str(),
+               dist, angle * 180 / 3.14);
       mean_dist += dist;
       mean_angle += angle;
     }
-    else{
+    else
+    {
       printf("cameras not same\n");
     }
   }
-  mean_dist = mean_dist/(int)C1.size();
-  mean_angle = mean_angle/(int)C1.size();
-  for(int i=0;i<(int)C1.size();i++){
-    d_x = C1[i].camera_parameters_.position[0]-C2[i].camera_parameters_.position[0];
-    d_y = C1[i].camera_parameters_.position[1]-C2[i].camera_parameters_.position[1];
-    d_z = C1[i].camera_parameters_.position[2]-C2[i].camera_parameters_.position[2];
-    d_ax = C1[i].camera_parameters_.angle_axis[0]-C2[i].camera_parameters_.angle_axis[0];
-    d_ay = C1[i].camera_parameters_.angle_axis[1]-C2[i].camera_parameters_.angle_axis[1];
-    d_az = C1[i].camera_parameters_.angle_axis[2]-C2[i].camera_parameters_.angle_axis[2];
-    dist = sqrt(d_x*d_x + d_y*d_y + d_z*d_z);
-    angle = sqrt(d_ax*d_ax + d_ay*d_ay + d_az*d_az);
-    sigma_dist  += (dist-mean_dist)*(dist-mean_dist);
-    sigma_angle += (angle-mean_angle)*(angle-mean_angle);
+  mean_dist = mean_dist / (int)C1.size();
+  mean_angle = mean_angle / (int)C1.size();
+  for (int i = 0; i < (int)C1.size(); i++)
+  {
+    d_x = C1[i].camera_parameters_.position[0] - C2[i].camera_parameters_.position[0];
+    d_y = C1[i].camera_parameters_.position[1] - C2[i].camera_parameters_.position[1];
+    d_z = C1[i].camera_parameters_.position[2] - C2[i].camera_parameters_.position[2];
+    d_ax = C1[i].camera_parameters_.angle_axis[0] - C2[i].camera_parameters_.angle_axis[0];
+    d_ay = C1[i].camera_parameters_.angle_axis[1] - C2[i].camera_parameters_.angle_axis[1];
+    d_az = C1[i].camera_parameters_.angle_axis[2] - C2[i].camera_parameters_.angle_axis[2];
+    dist = sqrt(d_x * d_x + d_y * d_y + d_z * d_z);
+    angle = sqrt(d_ax * d_ax + d_ay * d_ay + d_az * d_az);
+    sigma_dist += (dist - mean_dist) * (dist - mean_dist);
+    sigma_angle += (angle - mean_angle) * (angle - mean_angle);
   }
-  sigma_dist = sqrt(sigma_dist/C1.size());
-  sigma_angle = sqrt(sigma_angle/C1.size());
+  sigma_dist = sqrt(sigma_dist / C1.size());
+  sigma_angle = sqrt(sigma_angle / C1.size());
   ROS_INFO("mean distance between camera poses = %9.5lf meters sigma= %9.5lf", mean_dist, sigma_dist);
-  ROS_INFO("mean angle between camera poses = %9.5lf degrees sigma= %9.5lf", mean_angle*180/3.1415, sigma_angle*180/3.1415);
+  ROS_INFO("mean angle between camera poses = %9.5lf degrees sigma= %9.5lf", mean_angle * 180 / 3.1415,
+           sigma_angle * 180 / 3.1415);
 }
 
-void compareObservations(vector<ObservationDataPoint> &O1, vector<ObservationDataPoint> &O2)
+void compareObservations(vector< ObservationDataPoint >& O1, vector< ObservationDataPoint >& O2)
 {
-  if(O1.size()!= O2.size()){
+  if (O1.size() != O2.size())
+  {
     ROS_ERROR_STREAM("compareObservations() vectors different in length");
   }
-  double d_x,d_y,dist;
-  double mean_dist=0.0;
-  double sigma_dist=0.0;
-  int n_compared=0;
-  for(int i=0;i<(int)O1.size();i++){
-    if(O1[i].camera_name_ == O2[i].camera_name_ &&
-       O1[i].point_id_            == O2[i].point_id_ ){
+  double d_x, d_y, dist;
+  double mean_dist = 0.0;
+  double sigma_dist = 0.0;
+  int n_compared = 0;
+  for (int i = 0; i < (int)O1.size(); i++)
+  {
+    if (O1[i].camera_name_ == O2[i].camera_name_ && O1[i].point_id_ == O2[i].point_id_)
+    {
       d_x = O1[i].image_x_ - O2[i].image_x_;
       d_y = O1[i].image_y_ - O2[i].image_y_;
-      dist = sqrt(d_x*d_x + d_y*d_y);
+      dist = sqrt(d_x * d_x + d_y * d_y);
       mean_dist += dist;
       n_compared++;
     }
   }
-  mean_dist = mean_dist/n_compared;
-  for(int i=0;i<(int)O1.size();i++){
-    if(O1[i].camera_name_ == O2[i].camera_name_ &&
-       O1[i].point_id_            == O2[i].point_id_ ){
-
+  mean_dist = mean_dist / n_compared;
+  for (int i = 0; i < (int)O1.size(); i++)
+  {
+    if (O1[i].camera_name_ == O2[i].camera_name_ && O1[i].point_id_ == O2[i].point_id_)
+    {
       d_x = O1[i].image_x_ - O2[i].image_x_;
       d_y = O1[i].image_y_ - O2[i].image_y_;
-      dist = sqrt(d_x*d_x + d_y*d_y);
-      sigma_dist += (dist-mean_dist)*(dist-mean_dist);
+      dist = sqrt(d_x * d_x + d_y * d_y);
+      sigma_dist += (dist - mean_dist) * (dist - mean_dist);
     }
   }
-  sigma_dist = sqrt(sigma_dist/n_compared);
+  sigma_dist = sqrt(sigma_dist / n_compared);
   ROS_INFO("mean distance between observations = %9.5lf pixels sigma= %9.5lf ", mean_dist, sigma_dist);
 }
 
-void addPointsToHistory(vector<Point3dWithHistory> &points, vector<Point3dWithHistory> &original_points)
+void addPointsToHistory(vector< Point3dWithHistory >& points, vector< Point3dWithHistory >& original_points)
 {
-  if(points.size() != original_points.size())
-    ROS_ERROR_STREAM("number of points in vectors do not match");
+  if (points.size() != original_points.size()) ROS_ERROR_STREAM("number of points in vectors do not match");
 
-  for(int i=0;i<(int)points.size();i++){
+  for (int i = 0; i < (int)points.size(); i++)
+  {
     original_points[i].x_history.push_back(points[i].point.x);
     original_points[i].y_history.push_back(points[i].point.y);
     original_points[i].z_history.push_back(points[i].point.z);
   }
 }
 
-bool  parseScenes(std::string &scene_file_name, std::vector<Scene> &scenes)
+bool parseScenes(std::string& scene_file_name, std::vector< Scene >& scenes)
 {
-  FILE *fp = fopen(scene_file_name.c_str(), "r" );
-  if( fp == NULL){
-    ROS_ERROR("Can't open file %s",scene_file_name.c_str());
-    return(false);
+  FILE* fp = fopen(scene_file_name.c_str(), "r");
+  if (fp == NULL)
+  {
+    ROS_ERROR("Can't open file %s", scene_file_name.c_str());
+    return (false);
   }
-  int scene_id=10;
+  int scene_id = 10;
   scenes.clear();
-  while(fscanf(fp, "scene_id = %d/n", &scene_id) ==1){
+  while (fscanf(fp, "scene_id = %d/n", &scene_id) == 1)
+  {
     Scene temp_scene;
     temp_scene.scene_id = scene_id;
     tf::Matrix3x3 R;
-    double x,y,z;
+    double x, y, z;
     char dum[100], dum2[100], dum3[100];
-    double z1,z2,z3,z4;
-    fscanf(fp, "%s %s %s %lf %lf %lf %lf;/n",dum, dum2, dum3, &R[0][0],  &R[0][1],  &R[0][2], &x);
-    fscanf(fp, "%lf %lf %lf %lf;/n", &R[1][0],  &R[1][1],  &R[1][2], &y);
-    fscanf(fp, "%lf %lf %lf %lf;/n", &R[2][0],  &R[2][1],  &R[2][2], &z);
-    fscanf(fp, "%lf %lf %lf %lf];/n", &z1,&z2,&z3,&z4);// gobble last row
+    double z1, z2, z3, z4;
+    fscanf(fp, "%s %s %s %lf %lf %lf %lf;/n", dum, dum2, dum3, &R[0][0], &R[0][1], &R[0][2], &x);
+    fscanf(fp, "%lf %lf %lf %lf;/n", &R[1][0], &R[1][1], &R[1][2], &y);
+    fscanf(fp, "%lf %lf %lf %lf;/n", &R[2][0], &R[2][1], &R[2][2], &z);
+    fscanf(fp, "%lf %lf %lf %lf];/n", &z1, &z2, &z3, &z4);  // gobble last row
     temp_scene.target_pose.setBasis(R);
-    tf::Vector3 v(x,y,z);
+    tf::Vector3 v(x, y, z);
     temp_scene.target_pose.setOrigin(v);
     temp_scene.camera_names.clear();
     char temp_char_data[100];
-    fscanf(fp,"%s %s %s %s", dum, dum2, dum3, temp_char_data);
+    fscanf(fp, "%s %s %s %s", dum, dum2, dum3, temp_char_data);
     temp_scene.camera_names.push_back(std::string(temp_char_data));
-    bool done=false;
-    do{
-      fscanf(fp,"%s",temp_char_data);
-      if(temp_char_data[0] == ']'){
-	done = true;
-	char c='a';
-	while(c !='\n') fscanf(fp,"%c",&c);
+    bool done = false;
+    do
+    {
+      fscanf(fp, "%s", temp_char_data);
+      if (temp_char_data[0] == ']')
+      {
+        done = true;
+        char c = 'a';
+        while (c != '\n')
+          fscanf(fp, "%c", &c);
       }
-      else{
-	temp_scene.camera_names.push_back(std::string(temp_char_data));
+      else
+      {
+        temp_scene.camera_names.push_back(std::string(temp_char_data));
       }
-    }while(!done);
-    ROS_INFO("scene %d has %d cameras",(int) scene_id, (int) temp_scene.camera_names.size());
+    } while (!done);
+    ROS_INFO("scene %d has %d cameras", (int)scene_id, (int)temp_scene.camera_names.size());
     scenes.push_back(temp_scene);
-  }// end while there are more scenes
+  }  // end while there are more scenes
   fclose(fp);
-  return(true);
+  return (true);
 }
 
-void show_scenes(vector<Scene> &scenes)
+void show_scenes(vector< Scene >& scenes)
 {
-  BOOST_FOREACH( Scene S, scenes){
-    ROS_INFO("scene_id %d",S.scene_id);
+  BOOST_FOREACH (Scene S, scenes)
+  {
+    ROS_INFO("scene_id %d", S.scene_id);
     S.target_pose.show("target pose:");
-    BOOST_FOREACH(string s, S.camera_names){
+    BOOST_FOREACH (string s, S.camera_names)
+    {
       ROS_INFO("%s", s.c_str());
     }
   }
 }
-void perturbPose(Pose6d &pose, double position_noise, double degree_noise)
+void perturbPose(Pose6d& pose, double position_noise, double degree_noise)
 {
-  double pos_noise    = position_noise/sqrt(2.274625);
-  double radian_noise = degree_noise*3.1415/(180.0*sqrt(2.58047));
-  pose.x  += pos_noise*randn();	
-  pose.y  += pos_noise*randn();
-  pose.z  += pos_noise*randn();
-  pose.ax += radian_noise*randn();
-  pose.ay += radian_noise*randn();
-  pose.ay += radian_noise*randn();
+  double pos_noise = position_noise / sqrt(2.274625);
+  double radian_noise = degree_noise * 3.1415 / (180.0 * sqrt(2.58047));
+  pose.x += pos_noise * randn();
+  pose.y += pos_noise * randn();
+  pose.z += pos_noise * randn();
+  pose.ax += radian_noise * randn();
+  pose.ay += radian_noise * randn();
+  pose.ay += radian_noise * randn();
 }
 
-void computeObservationsOfPoints(vector<CameraWithHistory> &cameras,
-				 vector<Point3dWithHistory> &points,
-				 Pose6d &target_pose,
-				 int scene_id,
-				 vector<ObservationDataPoint> &observations,
-				 double camera_position_noise,
-				 double camera_degree_noise,
-				 double image_noise)
+void computeObservationsOfPoints(vector< CameraWithHistory >& cameras, vector< Point3dWithHistory >& points,
+                                 Pose6d& target_pose, int scene_id, vector< ObservationDataPoint >& observations,
+                                 double camera_position_noise, double camera_degree_noise, double image_noise)
 
 {
   observations.clear();
-  BOOST_FOREACH(CameraWithHistory &C, cameras){
-    int q=0;
-    BOOST_FOREACH(Point3dWithHistory &P, points){
+  BOOST_FOREACH (CameraWithHistory& C, cameras)
+  {
+    int q = 0;
+    BOOST_FOREACH (Point3dWithHistory& P, points)
+    {
       bool good_observation;
-      ObservationDataPoint obs = predictObservationOfPoint(C, P, target_pose, scene_id, q++, image_noise, good_observation);
-      if(good_observation) {
-	observations.push_back(obs);
-	P.num_observations++;
+      ObservationDataPoint obs =
+          predictObservationOfPoint(C, P, target_pose, scene_id, q++, image_noise, good_observation);
+      if (good_observation)
+      {
+        observations.push_back(obs);
+        P.num_observations++;
       }
     }
   }
 }
-void computeObservationsFromScenes(vector<Scene> &scenes, // pose of target, and which cameras observed it
-				      vector<CameraWithHistory> &cameras, // list of cameras
-				      double target_pos_noise, // perturb position of target by this amount then compute
-				      double target_degree_noise, // peturb orientation of target by this amount then compute
-				      double image_noise,  // amount of noise to add to each observation
-				      vector<ObservationDataPoint> &observations, // returned data
-				      vector<Point3dWithHistory> &points) // returned target points
+void computeObservationsFromScenes(vector< Scene >& scenes,  // pose of target, and which cameras observed it
+                                   vector< CameraWithHistory >& cameras,  // list of cameras
+                                   double target_pos_noise,  // perturb position of target by this amount then compute
+                                   double target_degree_noise,  // peturb orientation of target by this amount then
+                                                                // compute
+                                   double image_noise,          // amount of noise to add to each observation
+                                   vector< ObservationDataPoint >& observations,  // returned data
+                                   vector< Point3dWithHistory >& points)          // returned target points
 {
   observations.clear();
-  BOOST_FOREACH(CameraWithHistory &C, cameras) C.num_observations=0;
-  double pnoise = image_noise/sqrt(1.58085);// magic number found by trial and error
+  BOOST_FOREACH (CameraWithHistory& C, cameras)
+    C.num_observations = 0;
+  double pnoise = image_noise / sqrt(1.58085);  // magic number found by trial and error
   int rows = 10;
   int cols = 10;
   double spacing = .025;
   points.clear();
-  BOOST_FOREACH(Scene &S, scenes){  
+  BOOST_FOREACH (Scene& S, scenes)
+  {
     // add a new set of target points to the vector of all points
-    int target_point_offset = points.size(); // points[target_point_offset] is the first of the new points being added
+    int target_point_offset = points.size();  // points[target_point_offset] is the first of the new points being added
     // add any target position and pose noise to target's pose
-    if(target_pos_noise >0.0 || target_degree_noise >0.0 ){
+    if (target_pos_noise > 0.0 || target_degree_noise > 0.0)
+    {
       perturbPose(S.target_pose, target_pos_noise, target_degree_noise);
     }
-    addTargetPoints(rows, cols, spacing, points, S.target_pose); // added in world coordinates
+    addTargetPoints(rows, cols, spacing, points, S.target_pose);  // added in world coordinates
     // for each camera in scene
-    BOOST_FOREACH(string camera_name, S.camera_names){
-      CameraWithHistory *current_camera_ptr = NULL;
-      for(int i=0; i<cameras.size(); i++){
-	if( cameras[i].camera_name_ == camera_name){
-	  current_camera_ptr = &(cameras[i]);
-	}
+    BOOST_FOREACH (string camera_name, S.camera_names)
+    {
+      CameraWithHistory* current_camera_ptr = NULL;
+      for (int i = 0; i < cameras.size(); i++)
+      {
+        if (cameras[i].camera_name_ == camera_name)
+        {
+          current_camera_ptr = &(cameras[i]);
+        }
       }
-      if(current_camera_ptr == NULL){
-	ROS_ERROR("Couldn't find camera %s",camera_name.c_str());
+      if (current_camera_ptr == NULL)
+      {
+        ROS_ERROR("Couldn't find camera %s", camera_name.c_str());
       }
-      for(int i=target_point_offset; i<(int)points.size(); i++){// for each new point
-	bool good_observation;
-	ObservationDataPoint obs =predictObservationOfPoint(*current_camera_ptr, points[i], S.target_pose, S.scene_id, i, image_noise, good_observation);
-	if(good_observation){
-	  observations.push_back(obs);
-	  current_camera_ptr->num_observations++;
-	  points[i].num_observations++;
-	}
+      for (int i = target_point_offset; i < (int)points.size(); i++)
+      {  // for each new point
+        bool good_observation;
+        ObservationDataPoint obs = predictObservationOfPoint(*current_camera_ptr, points[i], S.target_pose, S.scene_id,
+                                                             i, image_noise, good_observation);
+        if (good_observation)
+        {
+          observations.push_back(obs);
+          current_camera_ptr->num_observations++;
+          points[i].num_observations++;
+        }
       }
-    }// end for each camera in scene
-  }      // end for each scene
-}// end
+    }  // end for each camera in scene
+  }    // end for each scene
+}  // end
 
-ObservationDataPoint predictObservationOfPoint(CameraWithHistory &C,
-					       Point3dWithHistory &P, 
-					       Pose6d &target_pose, 
-					       int scene_id, 
-					       int point_id, 
-					       double image_noise,
-					       bool &results_within_image)
+ObservationDataPoint predictObservationOfPoint(CameraWithHistory& C, Point3dWithHistory& P, Pose6d& target_pose,
+                                               int scene_id, int point_id, double image_noise,
+                                               bool& results_within_image)
 {
-  double pnoise = image_noise/sqrt(1.58085);// magic number found by trial and error
-  double fx,fy,cx,cy,k1,k2,k3,p1,p2;
+  double pnoise = image_noise / sqrt(1.58085);  // magic number found by trial and error
+  double fx, fy, cx, cy, k1, k2, k3, p1, p2;
   double aa[3], tx[3];
   double ox, oy;
   double world_point[3];
@@ -1055,53 +1101,47 @@ ObservationDataPoint predictObservationOfPoint(CameraWithHistory &C,
   Pose6d dummy_intermediate_pose;
   std::string cost_type_string("CameraReprjErrorPK");
   Cost_function cost_type = string2CostType(cost_type_string);
-  
-  extractCameraIntrinsics(C.camera_parameters_.pb_intrinsics,  fx,  fy,  cx,  cy,  k1,  k2,  k3,  p1,  p2);
+
+  extractCameraIntrinsics(C.camera_parameters_.pb_intrinsics, fx, fy, cx, cy, k1, k2, k3, p1, p2);
   aa[0] = C.camera_parameters_.angle_axis[0];
   aa[1] = C.camera_parameters_.angle_axis[1];
   aa[2] = C.camera_parameters_.angle_axis[2];
   tx[0] = C.camera_parameters_.position[0];
   tx[1] = C.camera_parameters_.position[1];
   tx[2] = C.camera_parameters_.position[2];
-  transformPoint(aa, tx, P.point.pb, world_point);// move to world coordinates
-  projectPntNoDistortion(world_point,  fx,  fy,  cx,  cy,  ox,  oy); // project point into camera's image plane 
-  ox += pnoise*randn(); // add observation noise
-  oy += pnoise*randn();
+  transformPoint(aa, tx, P.point.pb, world_point);              // move to world coordinates
+  projectPntNoDistortion(world_point, fx, fy, cx, cy, ox, oy);  // project point into camera's image plane
+  ox += pnoise * randn();                                       // add observation noise
+  oy += pnoise * randn();
   results_within_image = true;
-  if(ox<0.0 || ox>C.camera_parameters_.width || oy<0.0 || oy>C.camera_parameters_.height){
+  if (ox < 0.0 || ox > C.camera_parameters_.width || oy < 0.0 || oy > C.camera_parameters_.height)
+  {
     results_within_image = false;
-  }    
+  }
   ObservationDataPoint obs(C.camera_name_,
-			   t_name, // target_name
-			   2, // target type
-			   scene_id,
-			   C.camera_parameters_.pb_intrinsics,
-			   C.camera_parameters_.pb_extrinsics,
-			   point_id,
-			   target_pose.pb_pose,
-			   P.point.pb,
-			   ox,
-			   oy,
-			   cost_type,
-			   dummy_intermediate_pose,
-			   0.0);
-  return(obs);
+                           t_name,  // target_name
+                           2,       // target type
+                           scene_id, C.camera_parameters_.pb_intrinsics, C.camera_parameters_.pb_extrinsics, point_id,
+                           target_pose.pb_pose, P.point.pb, ox, oy, cost_type, dummy_intermediate_pose, 0.0);
+  return (obs);
 }
 
-void addTargetPoints(int rows, int cols, double spacing, vector<Point3dWithHistory> &points, Pose6d &target_pose)
+void addTargetPoints(int rows, int cols, double spacing, vector< Point3dWithHistory >& points, Pose6d& target_pose)
 {
-  for(int i=0; i<rows; i++){
-    for(int j=0; j<cols; j++){
+  for (int i = 0; i < rows; i++)
+  {
+    for (int j = 0; j < cols; j++)
+    {
       double target_point[3];
       double world_point[3];
-      target_point[0] = j*spacing;
-      target_point[1] = (rows -1 -i)*spacing;
+      target_point[0] = j * spacing;
+      target_point[1] = (rows - 1 - i) * spacing;
       target_point[2] = 0.0;
-      poseTransformPoint(target_pose, target_point, world_point);// move to world coordinates
+      poseTransformPoint(target_pose, target_point, world_point);  // move to world coordinates
       Point3dWithHistory point;
-      point.point.x =world_point[0];
-      point.point.y =world_point[1];
-      point.point.z =world_point[2];
+      point.point.x = world_point[0];
+      point.point.y = world_point[1];
+      point.point.z = world_point[2];
       points.push_back(point);
     }
   }

--- a/industrial_extrinsic_cal/src/nodes/ros_robot_scene_trigger_action_server.cpp
+++ b/industrial_extrinsic_cal/src/nodes/ros_robot_scene_trigger_action_server.cpp
@@ -21,86 +21,74 @@
 #include <ros/console.h>
 #include <moveit/move_group_interface/move_group.h>
 #include <actionlib/server/simple_action_server.h>
-#include <industrial_extrinsic_cal/robot_joint_values_triggerAction.h> // one of the ros action messages
-#include <industrial_extrinsic_cal/robot_pose_triggerAction.h> // the other ros action message
+#include <industrial_extrinsic_cal/robot_joint_values_triggerAction.h>  // one of the ros action messages
+#include <industrial_extrinsic_cal/robot_pose_triggerAction.h>          // the other ros action message
 
-class ServersNode {
+class ServersNode
+{
 protected:
   ros::NodeHandle nh_;
 
 public:
-  
-  typedef actionlib::SimpleActionServer<industrial_extrinsic_cal::robot_joint_values_triggerAction> JointValuesServer;
-  typedef actionlib::SimpleActionServer<industrial_extrinsic_cal::robot_pose_triggerAction> PoseServer;
+  typedef actionlib::SimpleActionServer< industrial_extrinsic_cal::robot_joint_values_triggerAction > JointValuesServer;
+  typedef actionlib::SimpleActionServer< industrial_extrinsic_cal::robot_pose_triggerAction > PoseServer;
 
-  ServersNode(std::string name) :
-    joint_value_server_(nh_,name + "_joint_values",boost::bind(&ServersNode::jointValueCallBack, this, _1), false),
-    pose_server_(nh_,name +"_pose",boost::bind(&ServersNode::poseCallBack, this, _1), false),
-    action_name_(name)
+  ServersNode(std::string name)
+    : joint_value_server_(nh_, name + "_joint_values", boost::bind(&ServersNode::jointValueCallBack, this, _1), false)
+    , pose_server_(nh_, name + "_pose", boost::bind(&ServersNode::poseCallBack, this, _1), false)
+    , action_name_(name)
   {
     joint_value_server_.start();
     pose_server_.start();
     move_group_ = new moveit::planning_interface::MoveGroup("manipulator");
-    move_group_->setPlanningTime(10.0); // give it 10 seconds to plan
-    move_group_->setNumPlanningAttempts(30.0); // Allow parallel planner to hybridize this many plans
-    move_group_->setPlannerId("RRTConnectkConfigDefault"); // use this planner
-  
+    move_group_->setPlanningTime(10.0);                     // give it 10 seconds to plan
+    move_group_->setNumPlanningAttempts(30.0);              // Allow parallel planner to hybridize this many plans
+    move_group_->setPlannerId("RRTConnectkConfigDefault");  // use this planner
   };
 
-  ~ServersNode() 
+  ~ServersNode()
   {
-    delete(move_group_);
+    delete (move_group_);
   };
 
   void jointValueCallBack(const industrial_extrinsic_cal::robot_joint_values_triggerGoalConstPtr& goal)
   {
     // TODO send both values and names and make sure they match. This is critical or else robots will crash into stuff
-    std::vector<double> group_variable_values;
+    std::vector< double > group_variable_values;
     moveit::core::RobotStatePtr current_state = move_group_->getCurrentState();
-    double *joint_value = current_state->getVariablePositions();
-    std::vector<std::string> var_names = current_state->getVariableNames();
-    if(var_names.size() == 7){
-      ROS_INFO("%d variables %s %s %s %s %s %s %s", (int)var_names.size(),
-		var_names[0].c_str(),
-		var_names[1].c_str(),
-		var_names[2].c_str(),
-		var_names[3].c_str(),
-		var_names[4].c_str(),
-		var_names[5].c_str(),
-		var_names[6].c_str());
+    double* joint_value = current_state->getVariablePositions();
+    std::vector< std::string > var_names = current_state->getVariableNames();
+    if (var_names.size() == 7)
+    {
+      ROS_INFO("%d variables %s %s %s %s %s %s %s", (int)var_names.size(), var_names[0].c_str(), var_names[1].c_str(),
+               var_names[2].c_str(), var_names[3].c_str(), var_names[4].c_str(), var_names[5].c_str(),
+               var_names[6].c_str());
     }
-    if(var_names.size() == 6){
-      ROS_INFO("%d variables %s %s %s %s %s %s", (int)var_names.size(),
-		var_names[0].c_str(),
-		var_names[1].c_str(),
-		var_names[2].c_str(),
-		var_names[3].c_str(),
-		var_names[4].c_str(),
-		var_names[5].c_str());
+    if (var_names.size() == 6)
+    {
+      ROS_INFO("%d variables %s %s %s %s %s %s", (int)var_names.size(), var_names[0].c_str(), var_names[1].c_str(),
+               var_names[2].c_str(), var_names[3].c_str(), var_names[4].c_str(), var_names[5].c_str());
     }
-    if(var_names.size()>7){
-      ROS_INFO("%d variables %s %s %s %s %s %s", (int)var_names.size(),
-		var_names[0].c_str(),
-		var_names[1].c_str(),
-		var_names[2].c_str(),
-		var_names[3].c_str(),
-		var_names[4].c_str(),
-		var_names[5].c_str());
+    if (var_names.size() > 7)
+    {
+      ROS_INFO("%d variables %s %s %s %s %s %s", (int)var_names.size(), var_names[0].c_str(), var_names[1].c_str(),
+               var_names[2].c_str(), var_names[3].c_str(), var_names[4].c_str(), var_names[5].c_str());
     }
     move_group_->setStartState(*current_state);
     move_group_->setJointValueTarget(goal->joint_values);
-    if(move_group_->move()){
+    if (move_group_->move())
+    {
       sleep(1);
       joint_value_server_.setSucceeded();
     }
-    else{
+    else
+    {
       ROS_ERROR("move in jointValueCallBack failed");
     }
   };
-  
+
   void poseCallBack(const industrial_extrinsic_cal::robot_pose_triggerGoalConstPtr& goal)
   {
-
     move_group_->setPoseReferenceFrame("world");
     move_group_->setEndEffectorLink("ee_link");
     move_group_->setGoalPositionTolerance(0.005);
@@ -108,45 +96,39 @@ public:
     move_group_->setStartStateToCurrentState();
 
     geometry_msgs::PoseStamped current_pose = move_group_->getCurrentPose();
-    ROS_ERROR("starting pose = %lf  %lf  %lf  %lf  %lf  %lf  %lf",
-	      current_pose.pose.position.x,
-	      current_pose.pose.position.y,
-	      current_pose.pose.position.z,
-	      current_pose.pose.orientation.x,
-	      current_pose.pose.orientation.y,
-	      current_pose.pose.orientation.z,
-	      current_pose.pose.orientation.w);
+    ROS_ERROR("starting pose = %lf  %lf  %lf  %lf  %lf  %lf  %lf", current_pose.pose.position.x,
+              current_pose.pose.position.y, current_pose.pose.position.z, current_pose.pose.orientation.x,
+              current_pose.pose.orientation.y, current_pose.pose.orientation.z, current_pose.pose.orientation.w);
     geometry_msgs::Pose target_pose;
-    std::vector<geometry_msgs::Pose> poses;
+    std::vector< geometry_msgs::Pose > poses;
     target_pose.position.x = goal->pose.position.x;
     target_pose.position.y = goal->pose.position.y;
     target_pose.position.z = goal->pose.position.z;
-    target_pose.orientation.x= goal->pose.orientation.x;
+    target_pose.orientation.x = goal->pose.orientation.x;
     target_pose.orientation.y = goal->pose.orientation.y;
     target_pose.orientation.z = goal->pose.orientation.z;
     target_pose.orientation.w = goal->pose.orientation.w;
-    ROS_ERROR("target   pose = %lf  %lf  %lf  %lf  %lf  %lf  %lf",
-	      target_pose.position.x,
-	      target_pose.position.y,
-	      target_pose.position.z,
-	      target_pose.orientation.x,
-	      target_pose.orientation.y,
-	      target_pose.orientation.z,
-	      target_pose.orientation.w);
+    ROS_ERROR("target   pose = %lf  %lf  %lf  %lf  %lf  %lf  %lf", target_pose.position.x, target_pose.position.y,
+              target_pose.position.z, target_pose.orientation.x, target_pose.orientation.y, target_pose.orientation.z,
+              target_pose.orientation.w);
 
     poses.push_back(target_pose);
     move_group_->setPoseTargets(poses, "ee_link");
 
     moveit::planning_interface::MoveGroup::Plan plan;
-    if(move_group_->plan(plan)){
-      if(move_group_->execute(plan)){
-	pose_server_.setSucceeded();
+    if (move_group_->plan(plan))
+    {
+      if (move_group_->execute(plan))
+      {
+        pose_server_.setSucceeded();
       }
-      else{
-	ROS_ERROR("execute in poseCallBack failed");
+      else
+      {
+        ROS_ERROR("execute in poseCallBack failed");
       }
     }
-    else {
+    else
+    {
       ROS_ERROR("plan in poseCallBack failed");
     }
   };
@@ -155,7 +137,7 @@ private:
   JointValuesServer joint_value_server_;
   PoseServer pose_server_;
   std::string action_name_;
-  moveit::planning_interface::MoveGroup *move_group_;
+  moveit::planning_interface::MoveGroup* move_group_;
 };
 
 int main(int argc, char** argv)

--- a/industrial_extrinsic_cal/src/nodes/ros_scene_trigger_server.cpp
+++ b/industrial_extrinsic_cal/src/nodes/ros_scene_trigger_server.cpp
@@ -22,17 +22,18 @@
 #include <actionlib/server/simple_action_server.h>
 #include <industrial_extrinsic_cal/manual_triggerAction.h>
 
-typedef actionlib::SimpleActionServer<industrial_extrinsic_cal::manual_triggerAction> Server;
+typedef actionlib::SimpleActionServer< industrial_extrinsic_cal::manual_triggerAction > Server;
 
 void execute(const industrial_extrinsic_cal::manual_triggerGoalConstPtr& goal, Server* as)
 {
   // Do lots of awesome groundbreaking robot stuff here
   ROS_ERROR("Scene Action Trigger is waiting for you to type: rosparam set test_scene_trigger true");
-  bool test_scene_trigger_bool=false;
+  bool test_scene_trigger_bool = false;
   ros::NodeHandle nh;
-  nh.setParam("test_scene_trigger",false);
-  while(test_scene_trigger_bool == false){
-    nh.getParam("test_scene_trigger",test_scene_trigger_bool);
+  nh.setParam("test_scene_trigger", false);
+  while (test_scene_trigger_bool == false)
+  {
+    nh.getParam("test_scene_trigger", test_scene_trigger_bool);
   }
   ROS_ERROR("Scene Action Trigger has executed successfully");
   as->setSucceeded();

--- a/industrial_extrinsic_cal/src/observation_data_point.cpp
+++ b/industrial_extrinsic_cal/src/observation_data_point.cpp
@@ -20,25 +20,16 @@
 
 namespace industrial_extrinsic_cal
 {
-
-
-ObservationDataPointList::ObservationDataPointList()
-{
-}
-;
+ObservationDataPointList::ObservationDataPointList(){};
 
 ObservationDataPointList::~ObservationDataPointList()
 {
-      items_.clear();
+  items_.clear();
 }
-
 
 void ObservationDataPointList::addObservationPoint(ObservationDataPoint new_data_point)
 {
   items_.push_back(new_data_point);
 }
 
-}//end namespace industrial_extrinsic_cal
-
-
-
+}  // end namespace industrial_extrinsic_cal

--- a/industrial_extrinsic_cal/src/observation_scene.cpp
+++ b/industrial_extrinsic_cal/src/observation_scene.cpp
@@ -16,24 +16,20 @@
  * limitations under the License.
  */
 
-
 #include <industrial_extrinsic_cal/observation_scene.h>
 #include <boost/shared_ptr.hpp>
-
 
 using boost::shared_ptr;
 
 namespace industrial_extrinsic_cal
 {
-
-
 void ObservationScene::addObservationToScene(ObservationCmd new_obs_cmd)
 {
   // this next block of code maintains a list of the cameras in a scene
   bool camera_already_in_scene = false;
-  BOOST_FOREACH(ObservationCmd command, observation_command_list_)
+  BOOST_FOREACH (ObservationCmd command, observation_command_list_)
   {
-    BOOST_FOREACH(shared_ptr<Camera> camera, cameras_in_scene_)
+    BOOST_FOREACH (shared_ptr< Camera > camera, cameras_in_scene_)
     {
       if (camera->camera_name_ == new_obs_cmd.camera->camera_name_)
       {
@@ -51,23 +47,22 @@ void ObservationScene::addObservationToScene(ObservationCmd new_obs_cmd)
   observation_command_list_.push_back(new_obs_cmd);
 }
 
-void ObservationScene::addCameraToScene(boost::shared_ptr<Camera> camera_in_scene)
+void ObservationScene::addCameraToScene(boost::shared_ptr< Camera > camera_in_scene)
 {
   cameras_in_scene_.push_back(camera_in_scene);
-  ROS_DEBUG_STREAM("Added camera "<<camera_in_scene->camera_name_<<" to cameras_in_scene list of size: "<<cameras_in_scene_.size());
+  ROS_DEBUG_STREAM("Added camera " << camera_in_scene->camera_name_
+                                   << " to cameras_in_scene list of size: " << cameras_in_scene_.size());
 }
 
-void ObservationScene::populateObsCmdList(boost::shared_ptr<Camera> camera, 
-					  boost::shared_ptr<Target> target, 
-					  Roi roi, 
-					  Cost_function cost_type)
+void ObservationScene::populateObsCmdList(boost::shared_ptr< Camera > camera, boost::shared_ptr< Target > target,
+                                          Roi roi, Cost_function cost_type)
 {
   ObservationCmd current_obs_cmd;
-  current_obs_cmd.camera=camera;
-  current_obs_cmd.target=target;
-  current_obs_cmd.roi=roi;
+  current_obs_cmd.camera = camera;
+  current_obs_cmd.target = target;
+  current_obs_cmd.roi = roi;
   current_obs_cmd.cost_type = cost_type;
   observation_command_list_.push_back(current_obs_cmd);
 }
 
-}//end namespace industrial_extrinsic_cal
+}  // end namespace industrial_extrinsic_cal

--- a/industrial_extrinsic_cal/src/points_yaml_parser.cpp
+++ b/industrial_extrinsic_cal/src/points_yaml_parser.cpp
@@ -13,37 +13,40 @@ using std::string;
 using std::vector;
 using YAML::Node;
 
-namespace industrial_extrinsic_cal {
-
-  bool parsePoints(std::string &points_input_file,vector<Point3d> &points)
+namespace industrial_extrinsic_cal
+{
+bool parsePoints(std::string& points_input_file, vector< Point3d >& points)
+{
+  // parse points
+  bool return_value = true;
+  try
   {
-    // parse points
-    bool return_value = true;
-    try
-      {
-	YAML::Node points_doc;
-	if(!yamlNodeFromFileName(points_input_file, points_doc)){
-	  ROS_ERROR("Can't parse yaml file %s", points_input_file.c_str());
-	}
-	// read in all points
-	points.clear();
-	const YAML::Node& points_node = parseNode(points_doc, "points");
-	for (int j = 0; j < points_node.size(); j++){
-	  vector<double> temp_pnt;
-	  parseVectorD(points_node[j], "pnt", temp_pnt);
-	  Point3d temp_pnt3d;
-	  temp_pnt3d.x = temp_pnt[0];
-	  temp_pnt3d.y = temp_pnt[1];
-	  temp_pnt3d.z = temp_pnt[2];
-	  points.push_back(temp_pnt3d);
-	}
-      }
-    catch (YAML::ParserException& e){
-      ROS_INFO_STREAM("Failed to read points file ");
-      return_value = false;
+    YAML::Node points_doc;
+    if (!yamlNodeFromFileName(points_input_file, points_doc))
+    {
+      ROS_ERROR("Can't parse yaml file %s", points_input_file.c_str());
     }
-    ROS_INFO_STREAM("Successfully read in " <<(int) points.size() << " points");
-    return(return_value);
-  }// end of parse_points()
+    // read in all points
+    points.clear();
+    const YAML::Node& points_node = parseNode(points_doc, "points");
+    for (int j = 0; j < points_node.size(); j++)
+    {
+      vector< double > temp_pnt;
+      parseVectorD(points_node[j], "pnt", temp_pnt);
+      Point3d temp_pnt3d;
+      temp_pnt3d.x = temp_pnt[0];
+      temp_pnt3d.y = temp_pnt[1];
+      temp_pnt3d.z = temp_pnt[2];
+      points.push_back(temp_pnt3d);
+    }
+  }
+  catch (YAML::ParserException& e)
+  {
+    ROS_INFO_STREAM("Failed to read points file ");
+    return_value = false;
+  }
+  ROS_INFO_STREAM("Successfully read in " << (int)points.size() << " points");
+  return (return_value);
+}  // end of parse_points()
 
-}// end of namespace industrial_extrinsic_cal
+}  // end of namespace industrial_extrinsic_cal

--- a/industrial_extrinsic_cal/src/points_yaml_parser_indigo.cpp
+++ b/industrial_extrinsic_cal/src/points_yaml_parser_indigo.cpp
@@ -13,33 +13,35 @@ using std::string;
 using std::vector;
 using YAML::Node;
 
-namespace industrial_extrinsic_cal {
-
-  void parsePoints(ifstream &points_input_file,vector<Point3d> &points)
+namespace industrial_extrinsic_cal
+{
+void parsePoints(ifstream& points_input_file, vector< Point3d >& points)
+{
+  // parse points
+  try
   {
-    // parse points
-    try
-      {
-	YAML::Node points_doc = YAML::LoadFile(points_input_file.c_str());
+    YAML::Node points_doc = YAML::LoadFile(points_input_file.c_str());
 
-	// read in all points
-	points.clear();
-	const YAML::Node points_node = points_doc("points");
-	for (int j = 0; j < points_node.size(); j++){
-	  const YAML::Node pnt_node = points_node[j]("pnt");
-	  vector<float> temp_pnt;
-	  temp_pnt =t_node.at< vector<float> >();
-	  Point3d temp_pnt3d;
-	  temp_pnt3d.x = temp_pnt[0];
-	  temp_pnt3d.y = temp_pnt[1];
-	  temp_pnt3d.z = temp_pnt[2];
-	  points.push_back(temp_pnt3d);
-	}
-      }
-    catch (YAML::ParserException& e){
-      ROS_INFO_STREAM("Failed to read points file ");
+    // read in all points
+    points.clear();
+    const YAML::Node points_node = points_doc("points");
+    for (int j = 0; j < points_node.size(); j++)
+    {
+      const YAML::Node pnt_node = points_node[j]("pnt");
+      vector< float > temp_pnt;
+      temp_pnt = t_node.at< vector< float > >();
+      Point3d temp_pnt3d;
+      temp_pnt3d.x = temp_pnt[0];
+      temp_pnt3d.y = temp_pnt[1];
+      temp_pnt3d.z = temp_pnt[2];
+      points.push_back(temp_pnt3d);
     }
-    ROS_INFO_STREAM("Successfully read in " <<(int) points.size() << " points");
-  }// end of parse_points()
+  }
+  catch (YAML::ParserException& e)
+  {
+    ROS_INFO_STREAM("Failed to read points file ");
+  }
+  ROS_INFO_STREAM("Successfully read in " << (int)points.size() << " points");
+}  // end of parse_points()
 
-}// end of namespace industrial_extrinsic_cal
+}  // end of namespace industrial_extrinsic_cal

--- a/industrial_extrinsic_cal/src/ros_camera_observer.cpp
+++ b/industrial_extrinsic_cal/src/ros_camera_observer.cpp
@@ -18,28 +18,29 @@
 
 #include <industrial_extrinsic_cal/ros_camera_observer.h>
 #include <industrial_extrinsic_cal/circle_detector.hpp>
-#include <image_transport/image_transport.h> 
+#include <image_transport/image_transport.h>
 
 using cv::CircleDetector;
 namespace industrial_extrinsic_cal
 {
-
-ROSCameraObserver::ROSCameraObserver(const std::string &camera_topic, const std::string &camera_name) :
-  sym_circle_(true),
-  pattern_(pattern_options::Chessboard), pattern_rows_(0), pattern_cols_(0),
-  new_image_collected_(false),
-  store_observation_images_(false),
-  load_observation_images_(false),
-  normalize_calibration_image_(false),
-  image_directory_(""),
-  image_number_(0),
-  camera_name_(camera_name)
+ROSCameraObserver::ROSCameraObserver(const std::string& camera_topic, const std::string& camera_name)
+  : sym_circle_(true)
+  , pattern_(pattern_options::Chessboard)
+  , pattern_rows_(0)
+  , pattern_cols_(0)
+  , new_image_collected_(false)
+  , store_observation_images_(false)
+  , load_observation_images_(false)
+  , normalize_calibration_image_(false)
+  , image_directory_("")
+  , image_number_(0)
+  , camera_name_(camera_name)
 {
-  image_topic_ = camera_topic;  
-  results_pub_ = nh_.advertise<sensor_msgs::Image>("observer_results_image", 100);
-  debug_pub_ = nh_.advertise<sensor_msgs::Image>("observer_raw_image", 100);
+  image_topic_ = camera_topic;
+  results_pub_ = nh_.advertise< sensor_msgs::Image >("observer_results_image", 100);
+  debug_pub_ = nh_.advertise< sensor_msgs::Image >("observer_raw_image", 100);
   std::string set_camera_info_service = camera_name_ + "/set_camera_info";
-  client_ = nh_.serviceClient<sensor_msgs::SetCameraInfo>(set_camera_info_service); 
+  client_ = nh_.serviceClient< sensor_msgs::SetCameraInfo >(set_camera_info_service);
 
   ros::NodeHandle pnh("~");
   pnh.getParam("image_directory", image_directory_);
@@ -49,36 +50,37 @@ ROSCameraObserver::ROSCameraObserver(const std::string &camera_topic, const std:
 
   // set up blob/circle detectors parameters are dynamic
   cv::SimpleBlobDetector::Params simple_blob_params;
-  if(!pnh.getParam("white_blobs", white_blobs_)){
+  if (!pnh.getParam("white_blobs", white_blobs_))
+  {
     white_blobs_ = false;
   }
-  if(!pnh.getParam("use_circle_detector", use_circle_detector_)){
+  if (!pnh.getParam("use_circle_detector", use_circle_detector_))
+  {
     use_circle_detector_ = false;
   }
 
   circle_detector_ptr_ = cv::CircleDetector::create();
   blob_detector_ptr_ = cv::SimpleBlobDetector::create(simple_blob_params);
 
-
   std::string recon_node_name = "~/" + camera_name;
   rnh_ = new ros::NodeHandle(recon_node_name.c_str());
-  server_ = new dynamic_reconfigure::Server<industrial_extrinsic_cal::circle_grid_finderConfig> (*rnh_);
+  server_ = new dynamic_reconfigure::Server< industrial_extrinsic_cal::circle_grid_finderConfig >(*rnh_);
 
-  dynamic_reconfigure::Server<industrial_extrinsic_cal::circle_grid_finderConfig>::CallbackType f;
+  dynamic_reconfigure::Server< industrial_extrinsic_cal::circle_grid_finderConfig >::CallbackType f;
 
   f = boost::bind(&ROSCameraObserver::dynReConfCallBack, this, _1, _2);
   server_->setCallback(f);
 }
 
-bool ROSCameraObserver::addTarget(boost::shared_ptr<Target> targ, Roi &roi, Cost_function cost_type)
+bool ROSCameraObserver::addTarget(boost::shared_ptr< Target > targ, Roi& roi, Cost_function cost_type)
 {
   // TODO make a list of targets so that the camera may make more than one set of observations at a time
   // This was what was inteneded by the interface definition, I'm not sure why the first implementation didn't do it.
 
-  cost_type_ = cost_type; 
+  cost_type_ = cost_type;
 
-  //set pattern based on target
-  ROS_DEBUG_STREAM("Target type: "<<targ->target_type_);
+  // set pattern based on target
+  ROS_DEBUG_STREAM("Target type: " << targ->target_type_);
   instance_target_ = targ;
   switch (targ->target_type_)
   {
@@ -96,8 +98,8 @@ bool ROSCameraObserver::addTarget(boost::shared_ptr<Target> targ, Roi &roi, Cost
     case pattern_options::ModifiedCircleGrid:
       pattern_ = pattern_options::ModifiedCircleGrid;
       pattern_rows_ = targ->circle_grid_parameters_.pattern_rows;
-      pattern_cols_  = targ->circle_grid_parameters_.pattern_cols;
-      sym_circle_    = targ->circle_grid_parameters_.is_symmetric;
+      pattern_cols_ = targ->circle_grid_parameters_.pattern_cols;
+      sym_circle_ = targ->circle_grid_parameters_.is_symmetric;
       break;
     case pattern_options::ARtag:
       pattern_ = pattern_options::ARtag;
@@ -106,23 +108,24 @@ bool ROSCameraObserver::addTarget(boost::shared_ptr<Target> targ, Roi &roi, Cost
     case pattern_options::Balls:
       pattern_ = pattern_options::Balls;
       pattern_rows_ = 1;
-      pattern_cols_  = targ->num_points_;
+      pattern_cols_ = targ->num_points_;
       break;
     case pattern_options::SingleBall:
       pattern_ = pattern_options::SingleBall;
       pattern_rows_ = 1;
-      pattern_cols_  = 1;
+      pattern_cols_ = 1;
       break;
     default:
-      ROS_ERROR_STREAM("target_type does not correlate to a known pattern option (Chessboard, CircleGrid, Balls, SingleBall or ARTag)");
+      ROS_ERROR_STREAM("target_type does not correlate to a known pattern option (Chessboard, CircleGrid, Balls, "
+                       "SingleBall or ARTag)");
       return false;
       break;
   }
 
-  input_roi_.x=roi.x_min;
-  input_roi_.y= roi.y_min;
-  input_roi_.width= roi.x_max - roi.x_min;
-  input_roi_.height= roi.y_max - roi.y_min;
+  input_roi_.x = roi.x_min;
+  input_roi_.y = roi.y_min;
+  input_roi_.width = roi.x_max - roi.x_min;
+  input_roi_.height = roi.y_max - roi.y_min;
   ROS_DEBUG("ROSCameraObserver added target and roi");
 
   return true;
@@ -139,24 +142,23 @@ void ROSCameraObserver::clearObservations()
   new_image_collected_ = false;
 }
 
-int ROSCameraObserver::getObservations(CameraObservations &cam_obs)
+int ROSCameraObserver::getObservations(CameraObservations& cam_obs)
 {
   bool successful_find = false;
   bool flipped_successful_find = false;
 
-
   if (input_bridge_->image.cols < input_roi_.width || input_bridge_->image.rows < input_roi_.height)
   {
-    ROS_ERROR("ROI too big for image size ( image = %d by %d roi= %d %d )", 
-	      input_bridge_->image.cols, input_bridge_->image.rows, input_roi_.width, input_roi_.height );
+    ROS_ERROR("ROI too big for image size ( image = %d by %d roi= %d %d )", input_bridge_->image.cols,
+              input_bridge_->image.rows, input_roi_.width, input_roi_.height);
     return 0;
   }
   ROS_DEBUG("roi size = %d %d", input_roi_.height, input_roi_.width);
   ROS_DEBUG("image size = %d %d", input_bridge_->image.rows, input_bridge_->image.cols);
   image_roi_ = input_bridge_->image(input_roi_);
 
-  //Do a min/max normalization for maximum contrast
-  //input_bridge_ is known to be a mono8 image (max = 255)
+  // Do a min/max normalization for maximum contrast
+  // input_bridge_ is known to be a mono8 image (max = 255)
   if (normalize_calibration_image_)
   {
     cv::Mat norm_img = image_roi_.clone();
@@ -166,397 +168,461 @@ int ROSCameraObserver::getObservations(CameraObservations &cam_obs)
 
   ROS_DEBUG("image_roi_ size = %d %d", image_roi_.rows, image_roi_.cols);
   observation_pts_.clear();
-  std::vector<cv::KeyPoint> key_points;
-  ROS_DEBUG("Pattern type %d, rows %d, cols %d",pattern_,pattern_rows_,pattern_cols_);
-  
-  cv::Point large_point;
-  cv::Size pattern_size(pattern_cols_, pattern_rows_); // note they use cols then rows for some unknown reason
-  int start_1st_row = 0;
-  int end_1st_row = pattern_cols_-1;
-  int start_last_row = pattern_rows_*pattern_cols_ - pattern_cols_;
-  int end_last_row = pattern_rows_*pattern_cols_ -1;
+  std::vector< cv::KeyPoint > key_points;
+  ROS_DEBUG("Pattern type %d, rows %d, cols %d", pattern_, pattern_rows_, pattern_cols_);
 
-  cv::Size pattern_size_flipped(pattern_rows_, pattern_cols_); // note they use cols then rows for some unknown reason
+  cv::Point large_point;
+  cv::Size pattern_size(pattern_cols_, pattern_rows_);  // note they use cols then rows for some unknown reason
+  int start_1st_row = 0;
+  int end_1st_row = pattern_cols_ - 1;
+  int start_last_row = pattern_rows_ * pattern_cols_ - pattern_cols_;
+  int end_last_row = pattern_rows_ * pattern_cols_ - 1;
+
+  cv::Size pattern_size_flipped(pattern_rows_, pattern_cols_);  // note they use cols then rows for some unknown reason
   switch (pattern_)
-    {
+  {
     case pattern_options::Chessboard:
       ROS_DEBUG_STREAM("Finding Chessboard Corners...");
-      successful_find = cv::findChessboardCorners(image_roi_, pattern_size, observation_pts_, cv::CALIB_CB_ADAPTIVE_THRESH);
+      successful_find =
+          cv::findChessboardCorners(image_roi_, pattern_size, observation_pts_, cv::CALIB_CB_ADAPTIVE_THRESH);
       break;
     case pattern_options::CircleGrid:
-      if (sym_circle_) // symetric circle grid
+      if (sym_circle_)  // symetric circle grid
       {
         ROS_DEBUG_STREAM("Finding Circles in grid, symmetric...");
 
-        if(use_circle_detector_){
-          successful_find = cv::findCirclesGrid(image_roi_, pattern_size, observation_pts_,
-              cv::CALIB_CB_SYMMETRIC_GRID, circle_detector_ptr_);
-          if(!successful_find)
+        if (use_circle_detector_)
+        {
+          successful_find = cv::findCirclesGrid(image_roi_, pattern_size, observation_pts_, cv::CALIB_CB_SYMMETRIC_GRID,
+                                                circle_detector_ptr_);
+          if (!successful_find)
           {
             successful_find = cv::findCirclesGrid(image_roi_, pattern_size_flipped, observation_pts_,
-                cv::CALIB_CB_SYMMETRIC_GRID, circle_detector_ptr_);
+                                                  cv::CALIB_CB_SYMMETRIC_GRID, circle_detector_ptr_);
             flipped_successful_find = successful_find;
           }
         }
-        else{
-          successful_find = cv::findCirclesGrid(image_roi_, pattern_size, observation_pts_, cv::CALIB_CB_SYMMETRIC_GRID);
-          if(!successful_find){
-            successful_find = cv::findCirclesGrid(image_roi_, pattern_size_flipped, observation_pts_, cv::CALIB_CB_SYMMETRIC_GRID);
+        else
+        {
+          successful_find =
+              cv::findCirclesGrid(image_roi_, pattern_size, observation_pts_, cv::CALIB_CB_SYMMETRIC_GRID);
+          if (!successful_find)
+          {
+            successful_find =
+                cv::findCirclesGrid(image_roi_, pattern_size_flipped, observation_pts_, cv::CALIB_CB_SYMMETRIC_GRID);
             flipped_successful_find = successful_find;
           }
         }
       }
-      else         // asymetric circle grid
+      else  // asymetric circle grid
       {
         ROS_DEBUG_STREAM("Finding Circles in grid, asymmetric...");
-        if(use_circle_detector_){
-          successful_find = cv::findCirclesGrid(image_roi_, pattern_size, observation_pts_,
-           cv::CALIB_CB_ASYMMETRIC_GRID | cv::CALIB_CB_CLUSTERING, circle_detector_ptr_);
-          if(!successful_find){
-            successful_find = cv::findCirclesGrid(image_roi_, pattern_size_flipped, observation_pts_,
-             cv::CALIB_CB_ASYMMETRIC_GRID | cv::CALIB_CB_CLUSTERING, circle_detector_ptr_);
+        if (use_circle_detector_)
+        {
+          successful_find =
+              cv::findCirclesGrid(image_roi_, pattern_size, observation_pts_,
+                                  cv::CALIB_CB_ASYMMETRIC_GRID | cv::CALIB_CB_CLUSTERING, circle_detector_ptr_);
+          if (!successful_find)
+          {
+            successful_find =
+                cv::findCirclesGrid(image_roi_, pattern_size_flipped, observation_pts_,
+                                    cv::CALIB_CB_ASYMMETRIC_GRID | cv::CALIB_CB_CLUSTERING, circle_detector_ptr_);
             flipped_successful_find = successful_find;
           }
         }
-        else{
-            successful_find = cv::findCirclesGrid(image_roi_, pattern_size , observation_pts_,
-              cv::CALIB_CB_ASYMMETRIC_GRID | cv::CALIB_CB_CLUSTERING);
-            if(!successful_find){
-              successful_find = cv::findCirclesGrid(image_roi_, pattern_size_flipped, observation_pts_,
-               cv::CALIB_CB_ASYMMETRIC_GRID | cv::CALIB_CB_CLUSTERING);
-              flipped_successful_find = successful_find;
-            }
+        else
+        {
+          successful_find = cv::findCirclesGrid(image_roi_, pattern_size, observation_pts_,
+                                                cv::CALIB_CB_ASYMMETRIC_GRID | cv::CALIB_CB_CLUSTERING);
+          if (!successful_find)
+          {
+            successful_find = cv::findCirclesGrid(image_roi_, pattern_size_flipped, observation_pts_,
+                                                  cv::CALIB_CB_ASYMMETRIC_GRID | cv::CALIB_CB_CLUSTERING);
+            flipped_successful_find = successful_find;
+          }
         }
-
       }
       break;
     case pattern_options::ModifiedCircleGrid:
-      { //contain the scope of automatic variables
-        // modified circle grids have one circle at the origin which is 1.5 times larger in diameter than the rest
-        std::vector<cv::Point2f> centers;
-        if(use_circle_detector_){
-          ROS_DEBUG("using circle_detector, to find %dx%d modified circle grid", pattern_rows_, pattern_cols_);
-          successful_find = cv::findCirclesGrid(image_roi_, pattern_size, centers,
-            cv::CALIB_CB_SYMMETRIC_GRID | cv::CALIB_CB_CLUSTERING, circle_detector_ptr_);
-          if(!successful_find)
-          {
-            successful_find = cv::findCirclesGrid(image_roi_, pattern_size_flipped, centers,
-              cv::CALIB_CB_SYMMETRIC_GRID | cv::CALIB_CB_CLUSTERING, circle_detector_ptr_);
-            flipped_successful_find = successful_find;
-          }
-        }
-        else{
-          ROS_DEBUG("using simple_blob_detector, to find %dx%d modified grid", pattern_rows_, pattern_cols_);
-          successful_find = cv::findCirclesGrid(
-                  image_roi_, pattern_size, centers,
-                  cv::CALIB_CB_SYMMETRIC_GRID | cv::CALIB_CB_CLUSTERING,
-                  blob_detector_ptr_);
-          if(!successful_find)
-          {
-            successful_find = cv::findCirclesGrid(
-                    image_roi_, pattern_size_flipped, centers,
-                    cv::CALIB_CB_SYMMETRIC_GRID | cv::CALIB_CB_CLUSTERING,
-                    blob_detector_ptr_);
-            flipped_successful_find = successful_find;
-          }
-        }
-        if(!successful_find){
-          ROS_ERROR("couldn't find %dx%d modified circle target in %s, found only %zu pts",
-            pattern_rows_, pattern_cols_,
-            image_topic_.c_str(),
-            centers.size());
-        }
-        else{
-          // Note, this is the same method called in the beginning of findCirclesGrid, unfortunately, they don't return their keypoints
-          // Should OpenCV change their method, the keypoint locations may not match, this has a risk of failing with
-          // updates to OpenCV
-          std::vector<cv::KeyPoint> keypoints;
-
-          if(use_circle_detector_)circle_detector_ptr_->detect(image_roi_, keypoints);
-          if(!use_circle_detector_)blob_detector_ptr_->detect(image_roi_, keypoints);
-
-          ROS_DEBUG("found %d keypoints", (int) keypoints.size());
-
-          // if a flipped pattern is found, flip the rows/columns
-          int temp_rows = flipped_successful_find ? pattern_cols_ : pattern_rows_ ;
-          int temp_cols = flipped_successful_find ? pattern_rows_ : pattern_cols_ ;
-
-          // determine which circle is the largest,
-          double start_last_row_size = -1.0;
-          double start_1st_row_size = -1.0;
-          double end_1st_row_size = -1.0;
-          double end_last_row_size = -1.0;
-          for(int i=0; i<(int)keypoints.size(); i++){
-            double x = keypoints[i].pt.x;
-            double y = keypoints[i].pt.y;
-            double ksize = keypoints[i].size;
-            if(x == centers[start_last_row].x && y == centers[start_last_row].y) start_last_row_size = ksize;
-            if(x == centers[end_last_row].x && y == centers[end_last_row].y) end_last_row_size = ksize;
-            if(x == centers[start_1st_row].x && y == centers[start_1st_row].y) start_1st_row_size = ksize;
-            if(x == centers[end_1st_row].x && y == centers[end_1st_row].y) end_1st_row_size = ksize;
-          }
-          ROS_DEBUG("start_last_row  %f %f %f", centers[start_last_row].x, centers[start_last_row].y, start_last_row_size);
-          ROS_DEBUG("end_last_row %f %f %f", centers[end_last_row].x, centers[end_last_row].y, end_last_row_size);
-          ROS_DEBUG("start_1st_row %f %f %f", centers[start_1st_row].x, centers[start_1st_row].y, start_1st_row_size);
-          ROS_DEBUG("end_1st_row %f %f %f", centers[end_1st_row].x, centers[end_1st_row].y, end_1st_row_size);
-          if(start_last_row_size <0.0 || start_1st_row_size < 0.0 || end_1st_row_size <0.0 || end_last_row_size < 0.0){
-            ROS_ERROR("No keypoint match for one or more corners");
-              return(false);
-          }
-
-          // determine if ordering is usual by computing cross product of two vectors normal ordering has z axis positive in cross
-          bool usual_ordering = true; // the most common ordering is with points going from left to right then top to bottom
-          double v1x, v1y, v2x, v2y;
-          v1x = centers[end_last_row].x - centers[start_last_row].x;
-          v1y = -centers[end_last_row].y + centers[start_last_row].y; // reverse because y is positive going down
-          v2x = centers[end_1st_row].x - centers[end_last_row].x;
-          v2y = -centers[end_1st_row].y + centers[end_last_row].y;
-          double cross = v1x*v2y - v1y*v2x;
-          if(cross <0.0){
-            usual_ordering = false;
-          }
-          observation_pts_.clear();
-
-          // largest circle at start of last row
-          //       ......   This is a simple picture of the grid with the largest circle indicated by the letter o
-          //       o....
-          if(start_last_row_size >start_1st_row_size && start_last_row_size > end_1st_row_size && start_last_row_size > end_last_row_size){
-            ROS_DEBUG("large circle at start of last row");
-            large_point.x = centers[start_last_row].x;
-            large_point.y = centers[start_last_row].y;
-            if(usual_ordering){ // right side up, no rotation, order is natural, starting from upper left, reads like book
-              for(int i=0; i<(int) centers.size(); i++) observation_pts_.push_back(centers[i]);
-            }
-            else{ // unusual ordering
-            for(int c=temp_cols-1; c>=0; c--){
-              for(int r=temp_rows-1; r>=0; r--){
-                observation_pts_.push_back(centers[r*temp_cols +c]);
-                }
-              }
-            } // end unusual ordering
-          }// end largest circle at start
-          // largest circle at end of 1st row
-          //       .....o
-          //       ......
-          else if( end_1st_row_size > end_last_row_size && end_1st_row_size > start_last_row_size && end_1st_row_size > start_1st_row_size){
-            ROS_DEBUG("large circle at end of 1st row");
-            large_point.x = centers[end_1st_row].x;
-            large_point.y = centers[end_1st_row].y;
-            if(usual_ordering){ // reversed points
-              for(int i=(int) centers.size()-1; i>= 0; i--){
-                observation_pts_.push_back(centers[i]);
-              }
-            }
-            else{// unusual ordering
-              for(int c=0; c<temp_cols; c++){
-                for(int r=0; r<temp_rows; r++){
-                  observation_pts_.push_back(centers[r*temp_cols +c]);
-                }
-              }
-            }// end unusual ordering
-          }// end largest circle at end of 1st row
-
-          // largest_circle at end of last row
-          //       ......
-          //       ....o
-          else if( end_last_row_size > start_last_row_size && end_last_row_size > end_1st_row_size && end_last_row_size > start_1st_row_size){
-            ROS_DEBUG("large circle at end of last row");
-            large_point.x = centers[end_last_row].x;
-            large_point.y = centers[end_last_row].y;
-
-            if(usual_ordering){ // 90 80 ... 0, 91 81 ... 1
-              for(int c=0; c<temp_cols; c++){
-                for(int r=temp_rows-1; r>=0; r--){
-                    observation_pts_.push_back(centers[r*temp_cols +c]);
-                  }
-                }
-              }// end normal ordering
-                else{ // unusual ordering 9 8 7 .. 0, 19 18 17 10, 29 28
-                  for(int c=0; c<temp_cols; c++){
-                    for(int r=0; r<temp_rows; r++){
-                      observation_pts_.push_back(centers[r*temp_cols +c]);
-                    }
-                  }
-                }// end unusual ordering
-              }// end large at end of last row
-
-              // largest circle at start of first row
-              // largest_circle at end of last row
-              //       o.....
-              //       .......
-              else if(start_1st_row_size > end_last_row_size && start_1st_row_size > end_1st_row_size && start_1st_row_size > start_last_row_size){
-                ROS_DEBUG("large circle at start of 1st row");
-                large_point.x = centers[start_1st_row].x;
-                large_point.y = centers[start_1st_row].y;
-                if(usual_ordering){ // 9 19 29 ... 99, 8 18 ... 98,
-                  for(int c = temp_cols -1; c>=0; c--){
-                    for(int r=0; r<temp_rows; r++){
-                      observation_pts_.push_back(centers[r*temp_cols + c]);
-                    }
-                  }
-                }// end normal ordering
-                else{ // unusual ordering  90 91 92 ... 99, 80 81 ... 89
-                  for(int c =temp_cols-1; c>=0; c--){
-                    for(int r=temp_rows-1; r>=0; r--){
-                      observation_pts_.push_back(centers[r*temp_cols + c]);
-                    }
-                  }
-                }
-              } // end large at start of 1st row
-              else
-                {
-                  ROS_ERROR("None of the observed corner circles are bigger than all the others");
-                  successful_find = false;
-                }
-            }
-      }
-      break;// end modified circle grid case
-    case pattern_options::ARtag:
+    {  // contain the scope of automatic variables
+      // modified circle grids have one circle at the origin which is 1.5 times larger in diameter than the rest
+      std::vector< cv::Point2f > centers;
+      if (use_circle_detector_)
       {
-        ROS_ERROR_STREAM("AR Tag recognized but pattern not supported yet");
+        ROS_DEBUG("using circle_detector, to find %dx%d modified circle grid", pattern_rows_, pattern_cols_);
+        successful_find =
+            cv::findCirclesGrid(image_roi_, pattern_size, centers,
+                                cv::CALIB_CB_SYMMETRIC_GRID | cv::CALIB_CB_CLUSTERING, circle_detector_ptr_);
+        if (!successful_find)
+        {
+          successful_find =
+              cv::findCirclesGrid(image_roi_, pattern_size_flipped, centers,
+                                  cv::CALIB_CB_SYMMETRIC_GRID | cv::CALIB_CB_CLUSTERING, circle_detector_ptr_);
+          flipped_successful_find = successful_find;
+        }
       }
-      break;
+      else
+      {
+        ROS_DEBUG("using simple_blob_detector, to find %dx%d modified grid", pattern_rows_, pattern_cols_);
+        successful_find =
+            cv::findCirclesGrid(image_roi_, pattern_size, centers,
+                                cv::CALIB_CB_SYMMETRIC_GRID | cv::CALIB_CB_CLUSTERING, blob_detector_ptr_);
+        if (!successful_find)
+        {
+          successful_find =
+              cv::findCirclesGrid(image_roi_, pattern_size_flipped, centers,
+                                  cv::CALIB_CB_SYMMETRIC_GRID | cv::CALIB_CB_CLUSTERING, blob_detector_ptr_);
+          flipped_successful_find = successful_find;
+        }
+      }
+      if (!successful_find)
+      {
+        ROS_ERROR("couldn't find %dx%d modified circle target in %s, found only %zu pts", pattern_rows_, pattern_cols_,
+                  image_topic_.c_str(), centers.size());
+      }
+      else
+      {
+        // Note, this is the same method called in the beginning of findCirclesGrid, unfortunately, they don't return
+        // their keypoints
+        // Should OpenCV change their method, the keypoint locations may not match, this has a risk of failing with
+        // updates to OpenCV
+        std::vector< cv::KeyPoint > keypoints;
+
+        if (use_circle_detector_) circle_detector_ptr_->detect(image_roi_, keypoints);
+        if (!use_circle_detector_) blob_detector_ptr_->detect(image_roi_, keypoints);
+
+        ROS_DEBUG("found %d keypoints", (int)keypoints.size());
+
+        // if a flipped pattern is found, flip the rows/columns
+        int temp_rows = flipped_successful_find ? pattern_cols_ : pattern_rows_;
+        int temp_cols = flipped_successful_find ? pattern_rows_ : pattern_cols_;
+
+        // determine which circle is the largest,
+        double start_last_row_size = -1.0;
+        double start_1st_row_size = -1.0;
+        double end_1st_row_size = -1.0;
+        double end_last_row_size = -1.0;
+        for (int i = 0; i < (int)keypoints.size(); i++)
+        {
+          double x = keypoints[i].pt.x;
+          double y = keypoints[i].pt.y;
+          double ksize = keypoints[i].size;
+          if (x == centers[start_last_row].x && y == centers[start_last_row].y) start_last_row_size = ksize;
+          if (x == centers[end_last_row].x && y == centers[end_last_row].y) end_last_row_size = ksize;
+          if (x == centers[start_1st_row].x && y == centers[start_1st_row].y) start_1st_row_size = ksize;
+          if (x == centers[end_1st_row].x && y == centers[end_1st_row].y) end_1st_row_size = ksize;
+        }
+        ROS_DEBUG("start_last_row  %f %f %f", centers[start_last_row].x, centers[start_last_row].y,
+                  start_last_row_size);
+        ROS_DEBUG("end_last_row %f %f %f", centers[end_last_row].x, centers[end_last_row].y, end_last_row_size);
+        ROS_DEBUG("start_1st_row %f %f %f", centers[start_1st_row].x, centers[start_1st_row].y, start_1st_row_size);
+        ROS_DEBUG("end_1st_row %f %f %f", centers[end_1st_row].x, centers[end_1st_row].y, end_1st_row_size);
+        if (start_last_row_size < 0.0 || start_1st_row_size < 0.0 || end_1st_row_size < 0.0 || end_last_row_size < 0.0)
+        {
+          ROS_ERROR("No keypoint match for one or more corners");
+          return (false);
+        }
+
+        // determine if ordering is usual by computing cross product of two vectors normal ordering has z axis positive
+        // in cross
+        bool usual_ordering =
+            true;  // the most common ordering is with points going from left to right then top to bottom
+        double v1x, v1y, v2x, v2y;
+        v1x = centers[end_last_row].x - centers[start_last_row].x;
+        v1y = -centers[end_last_row].y + centers[start_last_row].y;  // reverse because y is positive going down
+        v2x = centers[end_1st_row].x - centers[end_last_row].x;
+        v2y = -centers[end_1st_row].y + centers[end_last_row].y;
+        double cross = v1x * v2y - v1y * v2x;
+        if (cross < 0.0)
+        {
+          usual_ordering = false;
+        }
+        observation_pts_.clear();
+
+        // largest circle at start of last row
+        //       ......   This is a simple picture of the grid with the largest circle indicated by the letter o
+        //       o....
+        if (start_last_row_size > start_1st_row_size && start_last_row_size > end_1st_row_size &&
+            start_last_row_size > end_last_row_size)
+        {
+          ROS_DEBUG("large circle at start of last row");
+          large_point.x = centers[start_last_row].x;
+          large_point.y = centers[start_last_row].y;
+          if (usual_ordering)
+          {  // right side up, no rotation, order is natural, starting from upper left, reads like book
+            for (int i = 0; i < (int)centers.size(); i++)
+              observation_pts_.push_back(centers[i]);
+          }
+          else
+          {  // unusual ordering
+            for (int c = temp_cols - 1; c >= 0; c--)
+            {
+              for (int r = temp_rows - 1; r >= 0; r--)
+              {
+                observation_pts_.push_back(centers[r * temp_cols + c]);
+              }
+            }
+          }  // end unusual ordering
+        }    // end largest circle at start
+        // largest circle at end of 1st row
+        //       .....o
+        //       ......
+        else if (end_1st_row_size > end_last_row_size && end_1st_row_size > start_last_row_size &&
+                 end_1st_row_size > start_1st_row_size)
+        {
+          ROS_DEBUG("large circle at end of 1st row");
+          large_point.x = centers[end_1st_row].x;
+          large_point.y = centers[end_1st_row].y;
+          if (usual_ordering)
+          {  // reversed points
+            for (int i = (int)centers.size() - 1; i >= 0; i--)
+            {
+              observation_pts_.push_back(centers[i]);
+            }
+          }
+          else
+          {  // unusual ordering
+            for (int c = 0; c < temp_cols; c++)
+            {
+              for (int r = 0; r < temp_rows; r++)
+              {
+                observation_pts_.push_back(centers[r * temp_cols + c]);
+              }
+            }
+          }  // end unusual ordering
+        }    // end largest circle at end of 1st row
+
+        // largest_circle at end of last row
+        //       ......
+        //       ....o
+        else if (end_last_row_size > start_last_row_size && end_last_row_size > end_1st_row_size &&
+                 end_last_row_size > start_1st_row_size)
+        {
+          ROS_DEBUG("large circle at end of last row");
+          large_point.x = centers[end_last_row].x;
+          large_point.y = centers[end_last_row].y;
+
+          if (usual_ordering)
+          {  // 90 80 ... 0, 91 81 ... 1
+            for (int c = 0; c < temp_cols; c++)
+            {
+              for (int r = temp_rows - 1; r >= 0; r--)
+              {
+                observation_pts_.push_back(centers[r * temp_cols + c]);
+              }
+            }
+          }  // end normal ordering
+          else
+          {  // unusual ordering 9 8 7 .. 0, 19 18 17 10, 29 28
+            for (int c = 0; c < temp_cols; c++)
+            {
+              for (int r = 0; r < temp_rows; r++)
+              {
+                observation_pts_.push_back(centers[r * temp_cols + c]);
+              }
+            }
+          }  // end unusual ordering
+        }    // end large at end of last row
+
+        // largest circle at start of first row
+        // largest_circle at end of last row
+        //       o.....
+        //       .......
+        else if (start_1st_row_size > end_last_row_size && start_1st_row_size > end_1st_row_size &&
+                 start_1st_row_size > start_last_row_size)
+        {
+          ROS_DEBUG("large circle at start of 1st row");
+          large_point.x = centers[start_1st_row].x;
+          large_point.y = centers[start_1st_row].y;
+          if (usual_ordering)
+          {  // 9 19 29 ... 99, 8 18 ... 98,
+            for (int c = temp_cols - 1; c >= 0; c--)
+            {
+              for (int r = 0; r < temp_rows; r++)
+              {
+                observation_pts_.push_back(centers[r * temp_cols + c]);
+              }
+            }
+          }  // end normal ordering
+          else
+          {  // unusual ordering  90 91 92 ... 99, 80 81 ... 89
+            for (int c = temp_cols - 1; c >= 0; c--)
+            {
+              for (int r = temp_rows - 1; r >= 0; r--)
+              {
+                observation_pts_.push_back(centers[r * temp_cols + c]);
+              }
+            }
+          }
+        }  // end large at start of 1st row
+        else
+        {
+          ROS_ERROR("None of the observed corner circles are bigger than all the others");
+          successful_find = false;
+        }
+      }
+    }
+    break;  // end modified circle grid case
+    case pattern_options::ARtag:
+    {
+      ROS_ERROR_STREAM("AR Tag recognized but pattern not supported yet");
+    }
+    break;
     case pattern_options::Balls:
-      {// needed to contain scope of automatic variables to this case
-        int rows = last_raw_image_.rows;
-        int cols = last_raw_image_.cols;
-        const cv::Mat sub_image = last_raw_image_(input_roi_);
-        cv::Mat hsv_image;
-        cv::cvtColor(sub_image, hsv_image, CV_BGR2HSV);
-        cv::Mat red_binary_image(rows, cols, CV_8UC1);
-        cv::Mat green_binary_image(rows, cols, CV_8UC1);
-        cv::Mat yellow_binary_image(rows, cols, CV_8UC1);
-        ros::NodeHandle pnh("~");
-        int red_h_max, red_h_min;
-        int red_s_min, red_s_max;
-        int red_v_min, red_v_max;
-        int yellow_h_max, yellow_h_min;
-        int yellow_s_min, yellow_s_max;
-        int yellow_v_min, yellow_v_max;
-        int green_h_max, green_h_min;
-        int green_s_min, green_s_max;
-        int green_v_min, green_v_max;
-        pnh.getParam("red_h_max", red_h_max);
-        pnh.getParam("red_h_min", red_h_min);
-        pnh.getParam("red_s_min", red_s_min);
-        pnh.getParam("red_s_max", red_s_max);
-        pnh.getParam("red_v_min", red_v_min);
-        pnh.getParam("red_v_max", red_v_max);
-        pnh.getParam("yellow_h_max", yellow_h_max);
-        pnh.getParam("yellow_h_min", yellow_h_min);
-        pnh.getParam("yellow_s_min", yellow_s_min);
-        pnh.getParam("yellow_s_max", yellow_s_max);
-        pnh.getParam("yellow_v_min", yellow_v_min);
-        pnh.getParam("yellow_v_max", yellow_v_max);
-        pnh.getParam("green_h_max", green_h_max);
-        pnh.getParam("green_h_min", green_h_min);
-        pnh.getParam("green_s_min", green_s_min);
-        pnh.getParam("green_s_max", green_s_max);
-        pnh.getParam("green_v_min", green_v_min);
-        pnh.getParam("green_v_max", green_v_max);
-        cv::Scalar R_min(red_h_min, red_s_min, red_v_min);
-        cv::Scalar R_max(red_h_max, red_s_max, red_v_max);
-        cv::Scalar Y_min(yellow_h_min, yellow_s_min, yellow_v_min);
-        cv::Scalar Y_max(yellow_h_max, yellow_s_max, yellow_v_max);
-        cv::Scalar G_min(green_h_min, green_s_min, green_v_min);
-        cv::Scalar G_max(green_h_max, green_s_max, green_v_max);
-        cv::inRange(sub_image, R_min, R_max, red_binary_image);
-        cv::inRange(sub_image, Y_min, Y_max, yellow_binary_image);
-        cv::inRange(sub_image, G_min, G_max, green_binary_image);
+    {  // needed to contain scope of automatic variables to this case
+      int rows = last_raw_image_.rows;
+      int cols = last_raw_image_.cols;
+      const cv::Mat sub_image = last_raw_image_(input_roi_);
+      cv::Mat hsv_image;
+      cv::cvtColor(sub_image, hsv_image, CV_BGR2HSV);
+      cv::Mat red_binary_image(rows, cols, CV_8UC1);
+      cv::Mat green_binary_image(rows, cols, CV_8UC1);
+      cv::Mat yellow_binary_image(rows, cols, CV_8UC1);
+      ros::NodeHandle pnh("~");
+      int red_h_max, red_h_min;
+      int red_s_min, red_s_max;
+      int red_v_min, red_v_max;
+      int yellow_h_max, yellow_h_min;
+      int yellow_s_min, yellow_s_max;
+      int yellow_v_min, yellow_v_max;
+      int green_h_max, green_h_min;
+      int green_s_min, green_s_max;
+      int green_v_min, green_v_max;
+      pnh.getParam("red_h_max", red_h_max);
+      pnh.getParam("red_h_min", red_h_min);
+      pnh.getParam("red_s_min", red_s_min);
+      pnh.getParam("red_s_max", red_s_max);
+      pnh.getParam("red_v_min", red_v_min);
+      pnh.getParam("red_v_max", red_v_max);
+      pnh.getParam("yellow_h_max", yellow_h_max);
+      pnh.getParam("yellow_h_min", yellow_h_min);
+      pnh.getParam("yellow_s_min", yellow_s_min);
+      pnh.getParam("yellow_s_max", yellow_s_max);
+      pnh.getParam("yellow_v_min", yellow_v_min);
+      pnh.getParam("yellow_v_max", yellow_v_max);
+      pnh.getParam("green_h_max", green_h_max);
+      pnh.getParam("green_h_min", green_h_min);
+      pnh.getParam("green_s_min", green_s_min);
+      pnh.getParam("green_s_max", green_s_max);
+      pnh.getParam("green_v_min", green_v_min);
+      pnh.getParam("green_v_max", green_v_max);
+      cv::Scalar R_min(red_h_min, red_s_min, red_v_min);
+      cv::Scalar R_max(red_h_max, red_s_max, red_v_max);
+      cv::Scalar Y_min(yellow_h_min, yellow_s_min, yellow_v_min);
+      cv::Scalar Y_max(yellow_h_max, yellow_s_max, yellow_v_max);
+      cv::Scalar G_min(green_h_min, green_s_min, green_v_min);
+      cv::Scalar G_max(green_h_max, green_s_max, green_v_max);
+      cv::inRange(sub_image, R_min, R_max, red_binary_image);
+      cv::inRange(sub_image, Y_min, Y_max, yellow_binary_image);
+      cv::inRange(sub_image, G_min, G_max, green_binary_image);
 
-        int erosion_type = cv::MORPH_RECT; // MORPH_RECT MORPH_CROSS MORPH_ELLIPSE
-        int dilation_type = cv::MORPH_RECT; // MORPH_RECT MORPH_CROSS MORPH_ELLIPSE
-        int morph_size;
-        pnh.getParam("morph_size", morph_size);
-        int erosion_size = morph_size;
-        int dilation_size = morph_size;
-        cv::Mat erosion_element = getStructuringElement( erosion_type,
-                     cv::Size( 2*erosion_size + 1, 2*erosion_size+1 ),
-                     cv::Point( erosion_size, erosion_size ) );
-        cv::Mat dilation_element = getStructuringElement( erosion_type,
-                      cv::Size( 2*erosion_size + 1, 2*erosion_size+1 ),
-                      cv::Point( erosion_size, erosion_size ) );
+      int erosion_type = cv::MORPH_RECT;   // MORPH_RECT MORPH_CROSS MORPH_ELLIPSE
+      int dilation_type = cv::MORPH_RECT;  // MORPH_RECT MORPH_CROSS MORPH_ELLIPSE
+      int morph_size;
+      pnh.getParam("morph_size", morph_size);
+      int erosion_size = morph_size;
+      int dilation_size = morph_size;
+      cv::Mat erosion_element = getStructuringElement(
+          erosion_type, cv::Size(2 * erosion_size + 1, 2 * erosion_size + 1), cv::Point(erosion_size, erosion_size));
+      cv::Mat dilation_element = getStructuringElement(
+          erosion_type, cv::Size(2 * erosion_size + 1, 2 * erosion_size + 1), cv::Point(erosion_size, erosion_size));
 
-        // Apply the erosion operation
-        erode( red_binary_image, red_binary_image, erosion_element);
-        erode( yellow_binary_image, yellow_binary_image, erosion_element);
-        erode( green_binary_image, green_binary_image, erosion_element);
-        dilate( red_binary_image, red_binary_image, dilation_element);
-        dilate( yellow_binary_image, yellow_binary_image, dilation_element);
-        dilate( green_binary_image, green_binary_image, dilation_element);
-        std::vector<cv::Point2f> centers;
-        std::vector<cv::KeyPoint> keypoints;
-        if(!use_circle_detector_)blob_detector_ptr_->detect(red_binary_image, keypoints);
-        if( use_circle_detector_)circle_detector_ptr_->detect(red_binary_image, keypoints);
-        ROS_ERROR("Red keypoints: %d", (int) keypoints.size());
-        if(keypoints.size() == 1 ){
-            observation_pts_.push_back(keypoints[0].pt);
-            large_point.x = keypoints[0].pt.x;
-            large_point.y = keypoints[0].pt.y;
-        }
-        else{
-          ROS_ERROR("found %d red blobs, expected one", (int) keypoints.size());
-        }
-        if(!use_circle_detector_)blob_detector_ptr_->detect(green_binary_image, keypoints);
-        if( use_circle_detector_)circle_detector_ptr_->detect(green_binary_image, keypoints);
-        ROS_ERROR("Green keypoints: %d",(int)keypoints.size());
-        if(keypoints.size() == 1){
-            observation_pts_.push_back(keypoints[0].pt);
-        }// end of outer loop
-        else{
-          ROS_ERROR("found %d green blobs, expected one", (int) keypoints.size());
-        }
-        if(!use_circle_detector_)blob_detector_ptr_->detect(yellow_binary_image, keypoints);
-        if( use_circle_detector_)circle_detector_ptr_->detect(yellow_binary_image, keypoints);
-        ROS_ERROR("Blue keypoints: %d", (int)keypoints.size());
-        if(keypoints.size() == 1){
-            observation_pts_.push_back(keypoints[0].pt);
-        }// end of outer loop
-        else{
-          ROS_ERROR("found %d yellow blobs, expected  one", (int) keypoints.size());
-        }
-        if(observation_pts_.size() != 3){
-          bool debug_green, debug_red, debug_yellow;
-          pnh.getParam("debug_red", debug_red);
-          pnh.getParam("debug_green", debug_green);
-          pnh.getParam("debug_yellow", debug_yellow);
-          if(debug_yellow && debug_red && debug_green){
-            out_bridge_->image = yellow_binary_image | red_binary_image | green_binary_image;
-          }
-          else if(debug_yellow && debug_red){
-            out_bridge_->image = yellow_binary_image | red_binary_image;
-          }
-          else if(debug_yellow && debug_green){
-            out_bridge_->image = yellow_binary_image | green_binary_image;
-          }
-          else if(debug_red && debug_green){
-            out_bridge_->image = red_binary_image | green_binary_image;
-          }
-          else if(debug_red )  out_bridge_->image = red_binary_image ;
-          else if(debug_green )  out_bridge_->image = green_binary_image ;
-          else if(debug_yellow)  out_bridge_->image = yellow_binary_image;
-          if(debug_red | debug_green | debug_yellow) debug_pub_.publish(out_bridge_->toImageMsg());
-          return false;
-        }
-        else{
-          successful_find = true;
-        }
+      // Apply the erosion operation
+      erode(red_binary_image, red_binary_image, erosion_element);
+      erode(yellow_binary_image, yellow_binary_image, erosion_element);
+      erode(green_binary_image, green_binary_image, erosion_element);
+      dilate(red_binary_image, red_binary_image, dilation_element);
+      dilate(yellow_binary_image, yellow_binary_image, dilation_element);
+      dilate(green_binary_image, green_binary_image, dilation_element);
+      std::vector< cv::Point2f > centers;
+      std::vector< cv::KeyPoint > keypoints;
+      if (!use_circle_detector_) blob_detector_ptr_->detect(red_binary_image, keypoints);
+      if (use_circle_detector_) circle_detector_ptr_->detect(red_binary_image, keypoints);
+      ROS_ERROR("Red keypoints: %d", (int)keypoints.size());
+      if (keypoints.size() == 1)
+      {
+        observation_pts_.push_back(keypoints[0].pt);
+        large_point.x = keypoints[0].pt.x;
+        large_point.y = keypoints[0].pt.y;
       }
-
-      break;
-    case pattern_options::SingleBall:
-      {// needed to contain scope of automatic variables to this case
+      else
+      {
+        ROS_ERROR("found %d red blobs, expected one", (int)keypoints.size());
       }
-      default:
-        ROS_ERROR_STREAM("target_type does not correlate to a known pattern option ");
+      if (!use_circle_detector_) blob_detector_ptr_->detect(green_binary_image, keypoints);
+      if (use_circle_detector_) circle_detector_ptr_->detect(green_binary_image, keypoints);
+      ROS_ERROR("Green keypoints: %d", (int)keypoints.size());
+      if (keypoints.size() == 1)
+      {
+        observation_pts_.push_back(keypoints[0].pt);
+      }  // end of outer loop
+      else
+      {
+        ROS_ERROR("found %d green blobs, expected one", (int)keypoints.size());
+      }
+      if (!use_circle_detector_) blob_detector_ptr_->detect(yellow_binary_image, keypoints);
+      if (use_circle_detector_) circle_detector_ptr_->detect(yellow_binary_image, keypoints);
+      ROS_ERROR("Blue keypoints: %d", (int)keypoints.size());
+      if (keypoints.size() == 1)
+      {
+        observation_pts_.push_back(keypoints[0].pt);
+      }  // end of outer loop
+      else
+      {
+        ROS_ERROR("found %d yellow blobs, expected  one", (int)keypoints.size());
+      }
+      if (observation_pts_.size() != 3)
+      {
+        bool debug_green, debug_red, debug_yellow;
+        pnh.getParam("debug_red", debug_red);
+        pnh.getParam("debug_green", debug_green);
+        pnh.getParam("debug_yellow", debug_yellow);
+        if (debug_yellow && debug_red && debug_green)
+        {
+          out_bridge_->image = yellow_binary_image | red_binary_image | green_binary_image;
+        }
+        else if (debug_yellow && debug_red)
+        {
+          out_bridge_->image = yellow_binary_image | red_binary_image;
+        }
+        else if (debug_yellow && debug_green)
+        {
+          out_bridge_->image = yellow_binary_image | green_binary_image;
+        }
+        else if (debug_red && debug_green)
+        {
+          out_bridge_->image = red_binary_image | green_binary_image;
+        }
+        else if (debug_red)
+          out_bridge_->image = red_binary_image;
+        else if (debug_green)
+          out_bridge_->image = green_binary_image;
+        else if (debug_yellow)
+          out_bridge_->image = yellow_binary_image;
+        if (debug_red | debug_green | debug_yellow) debug_pub_.publish(out_bridge_->toImageMsg());
         return false;
-        break;
-      }// end of main switch
-      
+      }
+      else
+      {
+        successful_find = true;
+      }
+    }
+
+    break;
+    case pattern_options::SingleBall:
+    {  // needed to contain scope of automatic variables to this case
+    }
+    default:
+      ROS_ERROR_STREAM("target_type does not correlate to a known pattern option ");
+      return false;
+      break;
+  }  // end of main switch
+
   ROS_DEBUG("Number of keypoints found: %d ", (int)observation_pts_.size());
 
   // account for shift due to input_roi_
-  for(int i=0; i<(int)observation_pts_.size(); i++){
+  for (int i = 0; i < (int)observation_pts_.size(); i++)
+  {
     observation_pts_[i].x += input_roi_.x;
     observation_pts_[i].y += input_roi_.y;
   }
@@ -566,50 +632,56 @@ int ROSCameraObserver::getObservations(CameraObservations &cam_obs)
   large_point.y += input_roi_.y;
   circle(input_bridge_->image, large_point, 3.0, 255, 5);
 
-  // next block of code for publishing the roi as an image, when target is found, circles are placed on image, with a line between pt1 and pt2
-  for(int i=0;i<(int)observation_pts_.size();i++){
+  // next block of code for publishing the roi as an image, when target is found, circles are placed on image, with a
+  // line between pt1 and pt2
+  for (int i = 0; i < (int)observation_pts_.size(); i++)
+  {
     cv::Point p;
     p.x = observation_pts_[i].x;
     p.y = observation_pts_[i].y;
-    if(i==0){
-      circle(input_bridge_->image, p, 2.0, cv::Scalar(0,0,0), 5);
+    if (i == 0)
+    {
+      circle(input_bridge_->image, p, 2.0, cv::Scalar(0, 0, 0), 5);
     }
-    else{
-      circle(input_bridge_->image,p,1.0,255,5);
+    else
+    {
+      circle(input_bridge_->image, p, 1.0, 255, 5);
     }
   }
-  
+
   // Draw line through first column of observe points. These correspond to the first set of point in the target
-  if(observation_pts_.size()>=pattern_cols_){
-    cv::Point p1,p2;
+  if (observation_pts_.size() >= pattern_cols_)
+  {
+    cv::Point p1, p2;
     p1.x = observation_pts_[start_1st_row].x;
     p1.y = observation_pts_[start_1st_row].y;
     p2.x = observation_pts_[end_1st_row].x;
     p2.y = observation_pts_[end_1st_row].y;
-    line(input_bridge_->image,p1,p2,255,3);
+    line(input_bridge_->image, p1, p2, 255, 3);
   }
 
-  if(successful_find){    // copy the points found into a camera observation structure indicating their corresponece with target points
+  if (successful_find)
+  {  // copy the points found into a camera observation structure indicating their corresponece with target points
     camera_obs_.resize(observation_pts_.size());
     for (int i = 0; i < observation_pts_.size(); i++)
-      {
-        camera_obs_.at(i).target = instance_target_;
-        camera_obs_.at(i).point_id = i;
-        camera_obs_.at(i).image_loc_x = observation_pts_.at(i).x;
-        camera_obs_.at(i).image_loc_y = observation_pts_.at(i).y;
-        camera_obs_.at(i).cost_type = cost_type_;
-      }
+    {
+      camera_obs_.at(i).target = instance_target_;
+      camera_obs_.at(i).point_id = i;
+      camera_obs_.at(i).image_loc_x = observation_pts_.at(i).x;
+      camera_obs_.at(i).image_loc_y = observation_pts_.at(i).y;
+      camera_obs_.at(i).cost_type = cost_type_;
+    }
     cam_obs = camera_obs_;
-
   }
-  else{
-    ROS_WARN_STREAM("Pattern not found for pattern: "<<pattern_);
-    if(!sym_circle_) ROS_ERROR("not a symetric target????");
+  else
+  {
+    ROS_WARN_STREAM("Pattern not found for pattern: " << pattern_);
+    if (!sym_circle_) ROS_ERROR("not a symetric target????");
     cv::Point p;
-    p.x = image_roi_.cols/2;
-    p.y = image_roi_.rows/2;
-    circle(input_bridge_->image,p,1.0,255,10);
-  }  
+    p.x = image_roi_.cols / 2;
+    p.y = image_roi_.rows / 2;
+    circle(input_bridge_->image, p, 1.0, 255, 10);
+  }
 
   debug_pub_.publish(input_bridge_->toImageMsg());
   out_bridge_->image = image_roi_;
@@ -618,11 +690,11 @@ int ROSCameraObserver::getObservations(CameraObservations &cam_obs)
   return successful_find;
 }
 
-
 void ROSCameraObserver::triggerCamera()
 {
-  if(load_observation_images_){
-    char  number_string[100];
+  if (load_observation_images_)
+  {
+    char number_string[100];
     sprintf(number_string, "%d", image_number_);
     std::string image_name = image_directory_ + "/" + image_topic_ + number_string;
     cv::Mat loaded_color_image = cv::imread(image_name.c_str(), CV_LOAD_IMAGE_COLOR);
@@ -631,22 +703,26 @@ void ROSCameraObserver::triggerCamera()
     input_bridge_->image = loaded_mono_image;
     output_bridge_->image = loaded_color_image;
     out_bridge_->image = loaded_mono_image;
-    if(loaded_color_image.data && loaded_mono_image.data){
+    if (loaded_color_image.data && loaded_mono_image.data)
+    {
       ROS_DEBUG("Loaded it");
     }
     image_number_++;
   }
-  else{
-    ROS_DEBUG("rosCameraObserver, waiting for image from topic %s",image_topic_.c_str());
-    bool done=false;
-    while(!done){
-      sensor_msgs::ImageConstPtr recent_image = ros::topic::waitForMessage<sensor_msgs::Image>(image_topic_, ros::Duration(5.0));
-      if (! recent_image)
+  else
+  {
+    ROS_DEBUG("rosCameraObserver, waiting for image from topic %s", image_topic_.c_str());
+    bool done = false;
+    while (!done)
+    {
+      sensor_msgs::ImageConstPtr recent_image =
+          ros::topic::waitForMessage< sensor_msgs::Image >(image_topic_, ros::Duration(5.0));
+      if (!recent_image)
       {
         ROS_ERROR("No image acquired on topic '%s'", image_topic_.c_str());
         break;
       }
-      
+
       ROS_DEBUG("captured image in trigger");
       try
       {
@@ -657,32 +733,24 @@ void ROSCameraObserver::triggerCamera()
         new_image_collected_ = true;
         ROS_DEBUG("cv image created based on ros image");
         done = true;
-        ROS_DEBUG("height = %d width=%d step=%d encoding=%s", 
-                  recent_image->height, 
-                  recent_image->width, 
-                  recent_image->step,  
-                  recent_image->encoding.c_str());
-        
+        ROS_DEBUG("height = %d width=%d step=%d encoding=%s", recent_image->height, recent_image->width,
+                  recent_image->step, recent_image->encoding.c_str());
       }
       catch (cv_bridge::Exception& ex)
       {
         ROS_ERROR("Failed to convert image");
-	  ROS_ERROR("height = %d width=%d step=%d encoding=%s", 
-		    recent_image->height, 
-		    recent_image->width, 
-		    recent_image->step,  
-		    recent_image->encoding.c_str());
-	  ROS_WARN_STREAM("cv_bridge exception: "<<ex.what());
-	}
+        ROS_ERROR("height = %d width=%d step=%d encoding=%s", recent_image->height, recent_image->width,
+                  recent_image->step, recent_image->encoding.c_str());
+        ROS_WARN_STREAM("cv_bridge exception: " << ex.what());
+      }
     }
-    if (done)
-      image_number_++;
+    if (done) image_number_++;
   }
 }
 
 bool ROSCameraObserver::observationsDone()
 {
-  if(!new_image_collected_)
+  if (!new_image_collected_)
   {
     return false;
   }
@@ -690,34 +758,29 @@ bool ROSCameraObserver::observationsDone()
 }
 cv::Mat ROSCameraObserver::getLastImage()
 {
-  return(last_raw_image_);
+  return (last_raw_image_);
 }
-bool ROSCameraObserver::pushCameraInfo(double &fx,
-					 double &fy,
-					 double &cx, 
-					 double &cy, 
-					 double &k1,
-					 double &k2,
-					 double &k3, 
-					 double &p1,
-					 double &p2)
+bool ROSCameraObserver::pushCameraInfo(double& fx, double& fy, double& cx, double& cy, double& k1, double& k2,
+                                       double& k3, double& p1, double& p2)
 
 {
-  if(camera_name_.empty()){
+  if (camera_name_.empty())
+  {
     ROS_ERROR("camera name is not set, not pushing camera info to topic");
-    return(false);
+    return (false);
   }
   // must pull to get all the header information that we don't compute
-  std::string camera_info_topic = camera_name_+"/camera_info";
-  const sensor_msgs::CameraInfoConstPtr& info_msg = ros::topic::waitForMessage<sensor_msgs::CameraInfo>(camera_info_topic);
+  std::string camera_info_topic = camera_name_ + "/camera_info";
+  const sensor_msgs::CameraInfoConstPtr& info_msg =
+      ros::topic::waitForMessage< sensor_msgs::CameraInfo >(camera_info_topic);
   srv_.request.camera_info.distortion_model = info_msg->distortion_model;
   srv_.request.camera_info.header = info_msg->header;
-  srv_.request.camera_info.height  = info_msg->height;
-  srv_.request.camera_info.width   = info_msg->width;
-  srv_.request.camera_info.D         =  info_msg->D;
-  srv_.request.camera_info.K         =  info_msg->K;
-  srv_.request.camera_info.R         =  info_msg->R;
-  srv_.request.camera_info.P         =  info_msg->P;
+  srv_.request.camera_info.height = info_msg->height;
+  srv_.request.camera_info.width = info_msg->width;
+  srv_.request.camera_info.D = info_msg->D;
+  srv_.request.camera_info.K = info_msg->K;
+  srv_.request.camera_info.R = info_msg->R;
+  srv_.request.camera_info.P = info_msg->P;
 
   // set distortion parameters
   srv_.request.camera_info.D[0] = k1;
@@ -737,7 +800,7 @@ bool ROSCameraObserver::pushCameraInfo(double &fx,
   srv_.request.camera_info.K[7] = 0.0;
   srv_.request.camera_info.K[8] = 1.0;
 
-  // set projection matrix for rectified image 
+  // set projection matrix for rectified image
   srv_.request.camera_info.P[0] = fx;
   srv_.request.camera_info.P[1] = 0.0;
   srv_.request.camera_info.P[2] = cx;
@@ -752,39 +815,37 @@ bool ROSCameraObserver::pushCameraInfo(double &fx,
   srv_.request.camera_info.P[11] = 0.0;
 
   client_.call(srv_);
-  if(!srv_.response.success){
+  if (!srv_.response.success)
+  {
     ROS_ERROR("set request failed: %s", srv_.response.status_message.c_str());
-    return(false);
+    return (false);
   }
-  return(true);
+  return (true);
 }
 
- bool  ROSCameraObserver::pullCameraInfo(double &fx,
-					 double &fy,
-					 double &cx, 
-					 double &cy, 
-					 double &k1,
-					 double &k2,
-					 double &k3, 
-					 double &p1,
-					 double &p2)
+bool ROSCameraObserver::pullCameraInfo(double& fx, double& fy, double& cx, double& cy, double& k1, double& k2,
+                                       double& k3, double& p1, double& p2)
 {
-  if(camera_name_.empty()){
+  if (camera_name_.empty())
+  {
     ROS_ERROR("camera name is not set, cannot pull camera info from topic");
-    return(false);
+    return (false);
   }
 
-  // Some cameras have a nested namespace (i.e. /camera/rgb/image_rect_color), so camera info lies on topic '/camera/rgb/camera_info'.
+  // Some cameras have a nested namespace (i.e. /camera/rgb/image_rect_color), so camera info lies on topic
+  // '/camera/rgb/camera_info'.
   // Remove the last item after the last '/', and substitute with "camera_info" to get the right camera_info topic
   std::string topic;
-    int pos = image_topic_.find_last_of('/');
+  int pos = image_topic_.find_last_of('/');
   topic = image_topic_.substr(0, pos);
   std::string camera_info_topic = topic + "/camera_info";
 
-  const sensor_msgs::CameraInfoConstPtr& info_msg = ros::topic::waitForMessage<sensor_msgs::CameraInfo>(camera_info_topic);
-  if(info_msg->K[0]  ==0){
+  const sensor_msgs::CameraInfoConstPtr& info_msg =
+      ros::topic::waitForMessage< sensor_msgs::CameraInfo >(camera_info_topic);
+  if (info_msg->K[0] == 0)
+  {
     ROS_ERROR("camera info msg not correct");
-    return(false);
+    return (false);
   }
   k1 = info_msg->D[0];
   k2 = info_msg->D[1];
@@ -795,27 +856,31 @@ bool ROSCameraObserver::pushCameraInfo(double &fx,
   cx = info_msg->K[2];
   fy = info_msg->K[4];
   cy = info_msg->K[5];
-  return(true);
+  return (true);
 }
 
-bool  ROSCameraObserver::pullCameraInfo(double &fx, double &fy,
-           double &cx, double &cy, double &k1, double &k2, double &k3,
-           double &p1, double &p2, int &width, int &height)
+bool ROSCameraObserver::pullCameraInfo(double& fx, double& fy, double& cx, double& cy, double& k1, double& k2,
+                                       double& k3, double& p1, double& p2, int& width, int& height)
 {
-  if(camera_name_.empty()){
+  if (camera_name_.empty())
+  {
     ROS_ERROR("camera name is not set, cannot pull camera info from topic");
-    return(false);
+    return (false);
   }
   std::string camera_info_topic = "/" + camera_name_ + "/camera_info";
-  const sensor_msgs::CameraInfoConstPtr& info_msg = ros::topic::waitForMessage<sensor_msgs::CameraInfo>(camera_info_topic, ros::Duration(10.0));
-  if(info_msg == NULL)
-    {
-      ROS_ERROR("camera info message not available for camera %s on topic %s", camera_name_.c_str(), camera_info_topic.c_str());
-      return(false);
-    }
-  if(info_msg->K[0]  ==0){
-    ROS_ERROR("camera info message not correct for camera %s on topic %s", camera_name_.c_str(), camera_info_topic.c_str());
-    return(false);
+  const sensor_msgs::CameraInfoConstPtr& info_msg =
+      ros::topic::waitForMessage< sensor_msgs::CameraInfo >(camera_info_topic, ros::Duration(10.0));
+  if (info_msg == NULL)
+  {
+    ROS_ERROR("camera info message not available for camera %s on topic %s", camera_name_.c_str(),
+              camera_info_topic.c_str());
+    return (false);
+  }
+  if (info_msg->K[0] == 0)
+  {
+    ROS_ERROR("camera info message not correct for camera %s on topic %s", camera_name_.c_str(),
+              camera_info_topic.c_str());
+    return (false);
   }
   k1 = info_msg->D[0];
   k2 = info_msg->D[1];
@@ -828,72 +893,71 @@ bool  ROSCameraObserver::pullCameraInfo(double &fx, double &fy,
   cy = info_msg->K[5];
   width = info_msg->width;
   height = info_msg->height;
-  return(true);
+  return (true);
 }
 
-void  ROSCameraObserver::dynReConfCallBack(industrial_extrinsic_cal::circle_grid_finderConfig &config, uint32_t level)
+void ROSCameraObserver::dynReConfCallBack(industrial_extrinsic_cal::circle_grid_finderConfig& config, uint32_t level)
 {
   CircleDetector::Params circle_params;
-    circle_params.thresholdStep = 10;
-    circle_params.minThreshold = config.min_threshold;
-    circle_params.maxThreshold = config.max_threshold;
-    circle_params.minRepeatability = 2;
-    circle_params.minDistBetweenCircles = config.min_distance;
-    circle_params.minRadiusDiff = 10;
+  circle_params.thresholdStep = 10;
+  circle_params.minThreshold = config.min_threshold;
+  circle_params.maxThreshold = config.max_threshold;
+  circle_params.minRepeatability = 2;
+  circle_params.minDistBetweenCircles = config.min_distance;
+  circle_params.minRadiusDiff = 10;
 
-    circle_params.filterByColor = false;
-    if(white_blobs_)circle_params.circleColor = 200;
-    if(!white_blobs_)circle_params.circleColor = 0;
-  
-    circle_params.filterByArea = config.filter_by_area;
-    circle_params.minArea = config.min_area;
-    circle_params.maxArea = config.max_area;
-  
-    circle_params.filterByCircularity = config.filter_by_circularity;
-    circle_params.minCircularity = config.min_circularity;
-    circle_params.maxCircularity = config.max_circularity;
-  
-    circle_params.filterByInertia = false;
-    circle_params.minInertiaRatio = 0.1f;
-    circle_params.maxInertiaRatio = std::numeric_limits<float>::max();
-  
-    circle_params.filterByConvexity = false;
-    circle_params.minConvexity = 0.95f;
-    circle_params.maxConvexity = std::numeric_limits<float>::max();
+  circle_params.filterByColor = false;
+  if (white_blobs_) circle_params.circleColor = 200;
+  if (!white_blobs_) circle_params.circleColor = 0;
 
-    circle_detector_ptr_ = cv::CircleDetector::create(circle_params);
+  circle_params.filterByArea = config.filter_by_area;
+  circle_params.minArea = config.min_area;
+  circle_params.maxArea = config.max_area;
 
-    cv::SimpleBlobDetector::Params blob_params;
-    blob_params.thresholdStep = 10;
-    blob_params.minThreshold = config.min_threshold;
-    blob_params.maxThreshold = config.max_threshold;
-    blob_params.minRepeatability = 2;
-    blob_params.minDistBetweenBlobs = config.min_distance;
+  circle_params.filterByCircularity = config.filter_by_circularity;
+  circle_params.minCircularity = config.min_circularity;
+  circle_params.maxCircularity = config.max_circularity;
 
-    blob_params.filterByColor = true;
-    if(white_blobs_)blob_params.blobColor = 200;
-    if(!white_blobs_)blob_params.blobColor = 0;
-  
-    blob_params.filterByArea = config.filter_by_area;
-    blob_params.minArea = config.min_area;
-    blob_params.maxArea = config.max_area;
-  
-    blob_params.filterByCircularity = config.filter_by_circularity;
-    blob_params.minCircularity = config.min_circularity;
-    blob_params.maxCircularity = config.max_circularity;
-  
-    blob_params.filterByInertia = false;
-    blob_params.minInertiaRatio = 0.1f;
-    blob_params.maxInertiaRatio = std::numeric_limits<float>::max();
-  
-    blob_params.filterByConvexity = false;
-    blob_params.minConvexity = 0.95f;
-    blob_params.maxConvexity = std::numeric_limits<float>::max();
+  circle_params.filterByInertia = false;
+  circle_params.minInertiaRatio = 0.1f;
+  circle_params.maxInertiaRatio = std::numeric_limits< float >::max();
 
-    blob_detector_ptr_ = cv::SimpleBlobDetector::create(blob_params);
+  circle_params.filterByConvexity = false;
+  circle_params.minConvexity = 0.95f;
+  circle_params.maxConvexity = std::numeric_limits< float >::max();
 
+  circle_detector_ptr_ = cv::CircleDetector::create(circle_params);
 
-    blob_detector_ptr_ = cv::SimpleBlobDetector::create(blob_params);
+  cv::SimpleBlobDetector::Params blob_params;
+  blob_params.thresholdStep = 10;
+  blob_params.minThreshold = config.min_threshold;
+  blob_params.maxThreshold = config.max_threshold;
+  blob_params.minRepeatability = 2;
+  blob_params.minDistBetweenBlobs = config.min_distance;
+
+  blob_params.filterByColor = true;
+  if (white_blobs_) blob_params.blobColor = 200;
+  if (!white_blobs_) blob_params.blobColor = 0;
+
+  blob_params.filterByArea = config.filter_by_area;
+  blob_params.minArea = config.min_area;
+  blob_params.maxArea = config.max_area;
+
+  blob_params.filterByCircularity = config.filter_by_circularity;
+  blob_params.minCircularity = config.min_circularity;
+  blob_params.maxCircularity = config.max_circularity;
+
+  blob_params.filterByInertia = false;
+  blob_params.minInertiaRatio = 0.1f;
+  blob_params.maxInertiaRatio = std::numeric_limits< float >::max();
+
+  blob_params.filterByConvexity = false;
+  blob_params.minConvexity = 0.95f;
+  blob_params.maxConvexity = std::numeric_limits< float >::max();
+
+  blob_detector_ptr_ = cv::SimpleBlobDetector::create(blob_params);
+
+  blob_detector_ptr_ = cv::SimpleBlobDetector::create(blob_params);
 }
 
-} //industrial_extrinsic_cal
+}  // industrial_extrinsic_cal

--- a/industrial_extrinsic_cal/src/ros_transform_interface.cpp
+++ b/industrial_extrinsic_cal/src/ros_transform_interface.cpp
@@ -21,582 +21,619 @@
 #include <fstream>
 namespace industrial_extrinsic_cal
 {
-  /*! @brief uses tf listener to get a Pose6d. The pose returned transform points in the to_frame into the from_frame.
-   *   @param from_frame the starting frame
-   *   @param to_frame  the ending frame
-   *   @param tf_listener  the listener object, so we don't have to keep creating it
-   */
-  Pose6d getPoseFromTF(const std::string &from_frame, const std::string &to_frame, const tf::TransformListener &tf_listener)
+/*! @brief uses tf listener to get a Pose6d. The pose returned transform points in the to_frame into the from_frame.
+ *   @param from_frame the starting frame
+ *   @param to_frame  the ending frame
+ *   @param tf_listener  the listener object, so we don't have to keep creating it
+ */
+Pose6d getPoseFromTF(const std::string& from_frame, const std::string& to_frame,
+                     const tf::TransformListener& tf_listener)
+{
+  // get all the information from tf and from the mutable joint state publisher
+  tf::StampedTransform tf_transform;
+  ros::Time now = ros::Time::now();
+  while (!tf_listener.waitForTransform(from_frame, to_frame, now, ros::Duration(1.0)))
   {
-    // get all the information from tf and from the mutable joint state publisher
-    tf::StampedTransform tf_transform; 
-    ros::Time now = ros::Time::now();
-    while(!tf_listener.waitForTransform(from_frame, to_frame, now, ros::Duration(1.0))){
-      now = ros::Time::now();
-      ROS_INFO("waiting for tranform from %s to %s",from_frame.c_str(),to_frame.c_str());
-    }
-    try{
-      tf_listener.lookupTransform(from_frame, to_frame, now, tf_transform);
-    }
-    catch (tf::TransformException &ex) {
-      ROS_ERROR("%s",ex.what());
-    }
-    Pose6d pose;
-    pose.setBasis(tf_transform.getBasis());
-    pose.setOrigin(tf_transform.getOrigin());
-    return(pose);
+    now = ros::Time::now();
+    ROS_INFO("waiting for tranform from %s to %s", from_frame.c_str(), to_frame.c_str());
   }
-
-  using std::string;
-
-  ROSListenerTransInterface::ROSListenerTransInterface(const string & transform_frame) 
+  try
   {
-    transform_frame_ = transform_frame;
-    transform_.child_frame_id_ = transform_frame_;
-    ref_frame_initialized_ = false;    // still need to initialize ref_frame_
-  }				
-
-  Pose6d  ROSListenerTransInterface::pullTransform()
-  {
-    if(!ref_frame_initialized_){
-      Pose6d pose(0,0,0,0,0,0);
-      ROS_ERROR("Trying to pull transform from interface without setting ref frame ROSListenerTransInterface");
-      return(pose);
-    }
-    else{
-      pose_ = getPoseFromTF(ref_frame_, transform_frame_, tf_listener_);
-      return(pose_);
-    }
+    tf_listener.lookupTransform(from_frame, to_frame, now, tf_transform);
   }
-
-  ROSCameraListenerTransInterface::ROSCameraListenerTransInterface(const string & transform_frame) 
+  catch (tf::TransformException& ex)
   {
-    transform_frame_ = transform_frame;
-    transform_.child_frame_id_ = transform_frame_;
-    ref_frame_initialized_ = false;    // still need to initialize ref_frame_
-  }				
+    ROS_ERROR("%s", ex.what());
+  }
+  Pose6d pose;
+  pose.setBasis(tf_transform.getBasis());
+  pose.setOrigin(tf_transform.getOrigin());
+  return (pose);
+}
 
-  Pose6d  ROSCameraListenerTransInterface::pullTransform()
+using std::string;
+
+ROSListenerTransInterface::ROSListenerTransInterface(const string& transform_frame)
+{
+  transform_frame_ = transform_frame;
+  transform_.child_frame_id_ = transform_frame_;
+  ref_frame_initialized_ = false;  // still need to initialize ref_frame_
+}
+
+Pose6d ROSListenerTransInterface::pullTransform()
+{
+  if (!ref_frame_initialized_)
   {
-    if(!ref_frame_initialized_){
-      Pose6d pose(0,0,0,0,0,0);
-      ROS_ERROR("Trying to pull transform from interface without setting reference frame ROSCameraListenerTransInterface");
-      return(pose);
-    }
-    else{
-      pose_ = getPoseFromTF(transform_frame_, ref_frame_, tf_listener_);
-      return(pose_);
-    }
+    Pose6d pose(0, 0, 0, 0, 0, 0);
+    ROS_ERROR("Trying to pull transform from interface without setting ref frame ROSListenerTransInterface");
+    return (pose);
   }
-
-  /** @brief this object is intened to be used for cameras not targets
-   *            It simply listens to a pose from camera's optical frame to reference frame, this must be set in a urdf
-   *            This is the inverse of the transform from world to camera's optical frame
-   *            push does nothing
-   *            store does nothing
-   */
-  ROSCameraHousingListenerTInterface::ROSCameraHousingListenerTInterface(const string & transform_frame, const string & housing_frame) 
+  else
   {
-    transform_frame_               = transform_frame;
-    housing_frame_                  = housing_frame; // note, this is not used, but maintained to be symetric with Broadcaster parameter list
-    ref_frame_initialized_         = false;    // still need to initialize ref_frame_
-  }				
+    pose_ = getPoseFromTF(ref_frame_, transform_frame_, tf_listener_);
+    return (pose_);
+  }
+}
 
-  Pose6d  ROSCameraHousingListenerTInterface::pullTransform()
+ROSCameraListenerTransInterface::ROSCameraListenerTransInterface(const string& transform_frame)
+{
+  transform_frame_ = transform_frame;
+  transform_.child_frame_id_ = transform_frame_;
+  ref_frame_initialized_ = false;  // still need to initialize ref_frame_
+}
+
+Pose6d ROSCameraListenerTransInterface::pullTransform()
+{
+  if (!ref_frame_initialized_)
   {
-    if(!ref_frame_initialized_){
-      Pose6d pose(0,0,0,0,0,0);
-      ROS_ERROR("Trying to pull transform from interface without setting reference frame ROSCameraHousingListenerTInterface");
-      return(pose);
-    }
-    else{
-      pose_ = getPoseFromTF(transform_frame_, ref_frame_, tf_listener_);
-      return(pose_);
-    }
+    Pose6d pose(0, 0, 0, 0, 0, 0);
+    ROS_ERROR("Trying to pull transform from interface without setting reference frame "
+              "ROSCameraListenerTransInterface");
+    return (pose);
   }
-
-  ROSBroadcastTransInterface::ROSBroadcastTransInterface(const string & transform_frame)
+  else
   {
-    transform_frame_                = transform_frame;
-    transform_.child_frame_id_ = transform_frame_;
-    ref_frame_initialized_         = false;    // still need to initialize ref_frame_
+    pose_ = getPoseFromTF(transform_frame_, ref_frame_, tf_listener_);
+    return (pose_);
   }
+}
 
-  bool   ROSBroadcastTransInterface::pushTransform(Pose6d & pose)
+/** @brief this object is intened to be used for cameras not targets
+ *            It simply listens to a pose from camera's optical frame to reference frame, this must be set in a urdf
+ *            This is the inverse of the transform from world to camera's optical frame
+ *            push does nothing
+ *            store does nothing
+ */
+ROSCameraHousingListenerTInterface::ROSCameraHousingListenerTInterface(const string& transform_frame,
+                                                                       const string& housing_frame)
+{
+  transform_frame_ = transform_frame;
+  housing_frame_ =
+      housing_frame;  // note, this is not used, but maintained to be symetric with Broadcaster parameter list
+  ref_frame_initialized_ = false;  // still need to initialize ref_frame_
+}
+
+Pose6d ROSCameraHousingListenerTInterface::pullTransform()
+{
+  if (!ref_frame_initialized_)
   {
-    pose_ = pose; 
-    if(!ref_frame_initialized_){ 
-      return(false);		// timer won't start publishing until ref_frame_ is defined
-    }
-    return(true);
+    Pose6d pose(0, 0, 0, 0, 0, 0);
+    ROS_ERROR("Trying to pull transform from interface without setting reference frame "
+              "ROSCameraHousingListenerTInterface");
+    return (pose);
   }
-
-  bool  ROSBroadcastTransInterface::store(std::string & filePath)
+  else
   {
-    std::ofstream outputFile(filePath.c_str(), std::ios::app); // open for appending
-    if (outputFile.is_open())
-      {
-	double qx,qy,qz,qw;
-	pose_.getQuaternion(qx, qy, qz, qw);
-	outputFile<<"<node pkg=\"tf\" type=\"static_transform_publisher\" name=\"";
-	outputFile<< transform_frame_ <<"_tf_broadcaster"<<"\" args=\"";
-	outputFile<< pose_.x << ' '<< pose_.y << ' '<< pose_.z << ' ';
-	outputFile<< qx << ' '<< qy << ' '<<qz << ' ' << qw ;
-	outputFile<<" "<< ref_frame_;
-	outputFile<<" "<<transform_frame_;
-	outputFile<<" 100\" />"<<std::endl;
-	outputFile.close();	
-	return(true);
-      }
-    else
-      {
-	ROS_ERROR_STREAM("Unable to open file:" <<filePath);
-	return false;
-      }//end if writing to file
+    pose_ = getPoseFromTF(transform_frame_, ref_frame_, tf_listener_);
+    return (pose_);
   }
+}
 
-  void  ROSBroadcastTransInterface::setReferenceFrame(string &ref_frame)
+ROSBroadcastTransInterface::ROSBroadcastTransInterface(const string& transform_frame)
+{
+  transform_frame_ = transform_frame;
+  transform_.child_frame_id_ = transform_frame_;
+  ref_frame_initialized_ = false;  // still need to initialize ref_frame_
+}
+
+bool ROSBroadcastTransInterface::pushTransform(Pose6d& pose)
+{
+  pose_ = pose;
+  if (!ref_frame_initialized_)
   {
-    static ros::NodeHandle nh;
-    ref_frame_              = ref_frame;
-    ref_frame_initialized_ = true;
-    timer_                     = nh.createTimer(ros::Rate(1.0),&ROSBroadcastTransInterface::timerCallback, this);
+    return (false);  // timer won't start publishing until ref_frame_ is defined
   }
+  return (true);
+}
 
-  void  ROSBroadcastTransInterface::timerCallback(const ros::TimerEvent & timer_event)
-  { // broadcast current value of pose as a transform each time called
-    transform_.setBasis(pose_.getBasis());
-    transform_.setOrigin(pose_.getOrigin());
-    transform_.child_frame_id_ = transform_frame_;
-    transform_.frame_id_ = ref_frame_;
-    tf_broadcaster_.sendTransform(tf::StampedTransform(transform_, ros::Time::now(), ref_frame_, transform_frame_));
-  }
-
-  ROSCameraBroadcastTransInterface::ROSCameraBroadcastTransInterface(const string & transform_frame)
+bool ROSBroadcastTransInterface::store(std::string& filePath)
+{
+  std::ofstream outputFile(filePath.c_str(), std::ios::app);  // open for appending
+  if (outputFile.is_open())
   {
-    transform_frame_                = transform_frame;
-    transform_.child_frame_id_ = transform_frame_;
-    ref_frame_initialized_         = false;    // still need to initialize ref_frame_
+    double qx, qy, qz, qw;
+    pose_.getQuaternion(qx, qy, qz, qw);
+    outputFile << "<node pkg=\"tf\" type=\"static_transform_publisher\" name=\"";
+    outputFile << transform_frame_ << "_tf_broadcaster"
+               << "\" args=\"";
+    outputFile << pose_.x << ' ' << pose_.y << ' ' << pose_.z << ' ';
+    outputFile << qx << ' ' << qy << ' ' << qz << ' ' << qw;
+    outputFile << " " << ref_frame_;
+    outputFile << " " << transform_frame_;
+    outputFile << " 100\" />" << std::endl;
+    outputFile.close();
+    return (true);
   }
-
-  bool   ROSCameraBroadcastTransInterface::pushTransform(Pose6d & pose)
+  else
   {
-    pose_ = pose; 
-    if(!ref_frame_initialized_){ 
-      return(false);		// timer won't start publishing until ref_frame_ is defined
-    }
-    return(true);
-  }
+    ROS_ERROR_STREAM("Unable to open file:" << filePath);
+    return false;
+  }  // end if writing to file
+}
 
-  bool  ROSCameraBroadcastTransInterface::store(std::string & filePath)
+void ROSBroadcastTransInterface::setReferenceFrame(string& ref_frame)
+{
+  static ros::NodeHandle nh;
+  ref_frame_ = ref_frame;
+  ref_frame_initialized_ = true;
+  timer_ = nh.createTimer(ros::Rate(1.0), &ROSBroadcastTransInterface::timerCallback, this);
+}
+
+void ROSBroadcastTransInterface::timerCallback(const ros::TimerEvent& timer_event)
+{  // broadcast current value of pose as a transform each time called
+  transform_.setBasis(pose_.getBasis());
+  transform_.setOrigin(pose_.getOrigin());
+  transform_.child_frame_id_ = transform_frame_;
+  transform_.frame_id_ = ref_frame_;
+  tf_broadcaster_.sendTransform(tf::StampedTransform(transform_, ros::Time::now(), ref_frame_, transform_frame_));
+}
+
+ROSCameraBroadcastTransInterface::ROSCameraBroadcastTransInterface(const string& transform_frame)
+{
+  transform_frame_ = transform_frame;
+  transform_.child_frame_id_ = transform_frame_;
+  ref_frame_initialized_ = false;  // still need to initialize ref_frame_
+}
+
+bool ROSCameraBroadcastTransInterface::pushTransform(Pose6d& pose)
+{
+  pose_ = pose;
+  if (!ref_frame_initialized_)
   {
-    std::ofstream outputFile(filePath.c_str(), std::ios::app); // open for appending
-    if (outputFile.is_open())
-      {
-	double qx,qy,qz,qw;
-	pose_.getInverse().getQuaternion(qx, qy, qz, qw);
-	outputFile<<"<node pkg=\"tf\" type=\"static_transform_publisher\" name=\"";
-	outputFile<<transform_frame_<<"_tf_broadcaster"<<"\" args=\"";
-	outputFile<< pose_.getInverse().x << ' '<< pose_.getInverse().y << ' '<< pose_.getInverse().z << ' ';
-	outputFile<< qx << ' '<< qy << ' '<<qz << ' ' << qw ;
-	outputFile<<" "<<ref_frame_;
-	outputFile<<" "<<transform_frame_;
-	outputFile<<" 100\" />"<<std::endl;
-	outputFile.close();	
-	return(true);
-      }
-    else
-      {
-	ROS_ERROR_STREAM("Unable to open file:" <<filePath);
-	return false;
-      }//end if writing to file
+    return (false);  // timer won't start publishing until ref_frame_ is defined
   }
+  return (true);
+}
 
-  void ROSCameraBroadcastTransInterface::setReferenceFrame(string &ref_frame)
+bool ROSCameraBroadcastTransInterface::store(std::string& filePath)
+{
+  std::ofstream outputFile(filePath.c_str(), std::ios::app);  // open for appending
+  if (outputFile.is_open())
   {
-    static ros::NodeHandle nh;
-    ref_frame_              = ref_frame;
-    ref_frame_initialized_ = true;
-    timer_                     = nh.createTimer(ros::Rate(1.0),&ROSCameraBroadcastTransInterface::timerCallback, this);
+    double qx, qy, qz, qw;
+    pose_.getInverse().getQuaternion(qx, qy, qz, qw);
+    outputFile << "<node pkg=\"tf\" type=\"static_transform_publisher\" name=\"";
+    outputFile << transform_frame_ << "_tf_broadcaster"
+               << "\" args=\"";
+    outputFile << pose_.getInverse().x << ' ' << pose_.getInverse().y << ' ' << pose_.getInverse().z << ' ';
+    outputFile << qx << ' ' << qy << ' ' << qz << ' ' << qw;
+    outputFile << " " << ref_frame_;
+    outputFile << " " << transform_frame_;
+    outputFile << " 100\" />" << std::endl;
+    outputFile.close();
+    return (true);
   }
-
-  void  ROSCameraBroadcastTransInterface::timerCallback(const ros::TimerEvent & timer_event)
-  { // broadcast current value of pose.inverse() as a transform each time called
-    transform_.setBasis(pose_.getInverse().getBasis());
-    transform_.setOrigin(pose_.getInverse().getOrigin());
-    transform_.child_frame_id_ = transform_frame_;
-    transform_.frame_id_ = ref_frame_;
-    //    ROS_INFO("broadcasting %s in %s",transform_frame_.c_str(),ref_frame_.c_str());
-    tf_broadcaster_.sendTransform(tf::StampedTransform(transform_, ros::Time::now(), transform_frame_, ref_frame_));
-  }
-
-  ROSCameraHousingBroadcastTInterface::ROSCameraHousingBroadcastTInterface(const string & transform_frame,
-									   const string &housing_frame,
-									   const string &mounting_frame,
-									   const Pose6d &pose)
+  else
   {
-    transform_frame_                = transform_frame;
-    housing_frame_                  = housing_frame; 
-    mounting_frame_                 = mounting_frame;
-    transform_.child_frame_id_ = transform_frame_;
-    ref_frame_initialized_         = false;    // still need to initialize ref_frame_
-  }
+    ROS_ERROR_STREAM("Unable to open file:" << filePath);
+    return false;
+  }  // end if writing to file
+}
 
-  bool   ROSCameraHousingBroadcastTInterface::pushTransform(Pose6d & pose)
+void ROSCameraBroadcastTransInterface::setReferenceFrame(string& ref_frame)
+{
+  static ros::NodeHandle nh;
+  ref_frame_ = ref_frame;
+  ref_frame_initialized_ = true;
+  timer_ = nh.createTimer(ros::Rate(1.0), &ROSCameraBroadcastTransInterface::timerCallback, this);
+}
+
+void ROSCameraBroadcastTransInterface::timerCallback(const ros::TimerEvent& timer_event)
+{  // broadcast current value of pose.inverse() as a transform each time called
+  transform_.setBasis(pose_.getInverse().getBasis());
+  transform_.setOrigin(pose_.getInverse().getOrigin());
+  transform_.child_frame_id_ = transform_frame_;
+  transform_.frame_id_ = ref_frame_;
+  //    ROS_INFO("broadcasting %s in %s",transform_frame_.c_str(),ref_frame_.c_str());
+  tf_broadcaster_.sendTransform(tf::StampedTransform(transform_, ros::Time::now(), transform_frame_, ref_frame_));
+}
+
+ROSCameraHousingBroadcastTInterface::ROSCameraHousingBroadcastTInterface(const string& transform_frame,
+                                                                         const string& housing_frame,
+                                                                         const string& mounting_frame,
+                                                                         const Pose6d& pose)
+{
+  transform_frame_ = transform_frame;
+  housing_frame_ = housing_frame;
+  mounting_frame_ = mounting_frame;
+  transform_.child_frame_id_ = transform_frame_;
+  ref_frame_initialized_ = false;  // still need to initialize ref_frame_
+}
+
+bool ROSCameraHousingBroadcastTInterface::pushTransform(Pose6d& pose)
+{
+  Pose6d mountingMVoptical = pose.getInverse();
+  Pose6d opticalMVhousing = getPoseFromTF(transform_frame_, housing_frame_, tf_listener_);
+  Pose6d mountingMVhousing = mountingMVoptical * opticalMVhousing;
+  pose_ = mountingMVhousing;
+  if (!ref_frame_initialized_)
   {
-    Pose6d mountingMVoptical = pose.getInverse();
-    Pose6d opticalMVhousing = getPoseFromTF(transform_frame_, housing_frame_, tf_listener_);
-    Pose6d mountingMVhousing = mountingMVoptical * opticalMVhousing;
-    pose_ = mountingMVhousing;
-    if(!ref_frame_initialized_){ 
-      return(false);		// timer won't start publishing until ref_frame_ is defined
-    }
-    return(true);
+    return (false);  // timer won't start publishing until ref_frame_ is defined
   }
+  return (true);
+}
 
-  bool  ROSCameraHousingBroadcastTInterface::store(std::string & filePath)
+bool ROSCameraHousingBroadcastTInterface::store(std::string& filePath)
+{
+  std::ofstream outputFile(filePath.c_str(), std::ios::app);  // open for appending
+  if (outputFile.is_open())
   {
-    std::ofstream outputFile(filePath.c_str(), std::ios::app); // open for appending
-    if (outputFile.is_open()){
-      // Camer optical frame to ref is estimated by bundle adjustment  optical2ref
-      // Camer housing to camera optical frame is specified by urdf   optical2housing
-      // Desired ref2optical = optical2ref^-1 * optical2housing
-      
-      Pose6d ref2housing = pose_;
-      
-      // append the transform to a launch file
-      double qx,qy,qz,qw;
-      ref2housing.getQuaternion(qx, qy, qz, qw);
-      outputFile<<"<node pkg=\"tf\" type=\"static_transform_publisher\" name=\"";
-      outputFile<<transform_frame_<<"_tf_broadcaster"<<"\" args=\"";
-      outputFile<< ref2housing.x << ' '<< ref2housing.y << ' '<< ref2housing.z << ' ';
-      outputFile<< qx << ' '<< qy << ' '<<qz << ' ' << qw ;
-      outputFile<<" "<<ref_frame_;
-      outputFile<<" "<<housing_frame_;
-      outputFile<<" 100\" />"<<std::endl;
-      outputFile.close();	
-      return(true);
-    }
-    else{
-      ROS_ERROR_STREAM("Unable to open file:" <<filePath);
-      return false;
-    }//end if writing to file
-  }
-
-  void  ROSCameraHousingBroadcastTInterface::setReferenceFrame(std::string &ref_frame)
-  {
-    static ros::NodeHandle nh;
-    ref_frame_              = ref_frame;
-    ref_frame_initialized_ = true;
-    timer_                     = nh.createTimer(ros::Rate(1.0),&ROSCameraHousingBroadcastTInterface::timerCallback, this);
-  }
-
-  void  ROSCameraHousingBroadcastTInterface::timerCallback(const ros::TimerEvent & timer_event)
-  { // broadcast current value of pose.inverse() as a transform each time called
+    // Camer optical frame to ref is estimated by bundle adjustment  optical2ref
+    // Camer housing to camera optical frame is specified by urdf   optical2housing
+    // Desired ref2optical = optical2ref^-1 * optical2housing
 
     Pose6d ref2housing = pose_;
-    
-    transform_.setBasis(ref2housing.getBasis());
-    transform_.setOrigin(ref2housing.getOrigin());
-    tf_broadcaster_.sendTransform(tf::StampedTransform(transform_, ros::Time::now(), ref_frame_, housing_frame_));
+
+    // append the transform to a launch file
+    double qx, qy, qz, qw;
+    ref2housing.getQuaternion(qx, qy, qz, qw);
+    outputFile << "<node pkg=\"tf\" type=\"static_transform_publisher\" name=\"";
+    outputFile << transform_frame_ << "_tf_broadcaster"
+               << "\" args=\"";
+    outputFile << ref2housing.x << ' ' << ref2housing.y << ' ' << ref2housing.z << ' ';
+    outputFile << qx << ' ' << qy << ' ' << qz << ' ' << qw;
+    outputFile << " " << ref_frame_;
+    outputFile << " " << housing_frame_;
+    outputFile << " 100\" />" << std::endl;
+    outputFile.close();
+    return (true);
+  }
+  else
+  {
+    ROS_ERROR_STREAM("Unable to open file:" << filePath);
+    return false;
+  }  // end if writing to file
+}
+
+void ROSCameraHousingBroadcastTInterface::setReferenceFrame(std::string& ref_frame)
+{
+  static ros::NodeHandle nh;
+  ref_frame_ = ref_frame;
+  ref_frame_initialized_ = true;
+  timer_ = nh.createTimer(ros::Rate(1.0), &ROSCameraHousingBroadcastTInterface::timerCallback, this);
+}
+
+void ROSCameraHousingBroadcastTInterface::timerCallback(const ros::TimerEvent& timer_event)
+{  // broadcast current value of pose.inverse() as a transform each time called
+
+  Pose6d ref2housing = pose_;
+
+  transform_.setBasis(ref2housing.getBasis());
+  transform_.setOrigin(ref2housing.getOrigin());
+  tf_broadcaster_.sendTransform(tf::StampedTransform(transform_, ros::Time::now(), ref_frame_, housing_frame_));
+}
+
+Pose6d ROSCameraHousingBroadcastTInterface::pullTransform()
+{
+  if (!ref_frame_initialized_)
+  {  // still need the reference frame in order to return the transform!!
+    Pose6d pose(0, 0, 0, 0, 0, 0);
+    ROS_ERROR("Trying to pull transform from interface without setting reference frame "
+              "ROSCameraHousingBroadcastTInterface");
+    return (pose);
   }
 
-  Pose6d ROSCameraHousingBroadcastTInterface::pullTransform()
-  {
-    if(!ref_frame_initialized_){ // still need the reference frame in order to return the transform!!
-      Pose6d pose(0,0,0,0,0,0);
-      ROS_ERROR("Trying to pull transform from interface without setting reference frame ROSCameraHousingBroadcastTInterface");
-      return(pose);
-    }
+  Pose6d opticalMVhousing = getPoseFromTF(transform_frame_, housing_frame_, tf_listener_);
+  Pose6d mountingMVhousing = pose_;
+  Pose6d housingMVmounting = mountingMVhousing.getInverse();
+  Pose6d opticalMVmounting = opticalMVhousing * housingMVmounting;
+  return (opticalMVmounting);
+}
 
-    Pose6d opticalMVhousing = getPoseFromTF(transform_frame_, housing_frame_, tf_listener_);
-    Pose6d mountingMVhousing = pose_;
-    Pose6d housingMVmounting = mountingMVhousing.getInverse();
-    Pose6d opticalMVmounting = opticalMVhousing * housingMVmounting;
-    return(opticalMVmounting);
+ROSCameraHousingCalTInterface::ROSCameraHousingCalTInterface(const string& transform_frame, const string& housing_frame,
+                                                             const string& mounting_frame)
+{
+  transform_frame_ = transform_frame;
+  housing_frame_ = housing_frame;
+  mounting_frame_ = mounting_frame;
+  ref_frame_initialized_ = false;  // still need to initialize ref_frame_
+  nh_ = new ros::NodeHandle;
+
+  get_client_ = nh_->serviceClient< industrial_extrinsic_cal::get_mutable_joint_states >("get_mutable_joint_states");
+  set_client_ = nh_->serviceClient< industrial_extrinsic_cal::set_mutable_joint_states >("set_mutable_joint_states");
+  store_client_ =
+      nh_->serviceClient< industrial_extrinsic_cal::store_mutable_joint_states >("store_mutable_joint_states");
+
+  get_request_.joint_names.push_back(housing_frame + "_x_joint");
+  get_request_.joint_names.push_back(housing_frame + "_y_joint");
+  get_request_.joint_names.push_back(housing_frame + "_z_joint");
+  get_request_.joint_names.push_back(housing_frame + "_yaw_joint");
+  get_request_.joint_names.push_back(housing_frame + "_pitch_joint");
+  get_request_.joint_names.push_back(housing_frame + "_roll_joint");
+
+  set_request_.joint_names.push_back(housing_frame + "_x_joint");
+  set_request_.joint_names.push_back(housing_frame + "_y_joint");
+  set_request_.joint_names.push_back(housing_frame + "_z_joint");
+  set_request_.joint_names.push_back(housing_frame + "_yaw_joint");
+  set_request_.joint_names.push_back(housing_frame + "_pitch_joint");
+  set_request_.joint_names.push_back(housing_frame + "_roll_joint");
+
+  while (!get_client_.call(get_request_, get_response_))
+  {
+    sleep(1);
+    ROS_INFO("Waiting for mutable joint state publisher to come up");
   }
-
-  ROSCameraHousingCalTInterface::ROSCameraHousingCalTInterface(const string &transform_frame, 
-							       const string &housing_frame, 
-							       const string &mounting_frame) 
+  for (int i = 0; i < (int)get_response_.joint_values.size(); i++)
   {
-    transform_frame_               = transform_frame;
-    housing_frame_                  = housing_frame; 
-    mounting_frame_               = mounting_frame;
-    ref_frame_initialized_         = false;    // still need to initialize ref_frame_
-    nh_ = new ros::NodeHandle;
+    joint_values_.push_back(get_response_.joint_values[i]);
+  }
+}
 
-    get_client_    = nh_->serviceClient<industrial_extrinsic_cal::get_mutable_joint_states>("get_mutable_joint_states");
-    set_client_    = nh_->serviceClient<industrial_extrinsic_cal::set_mutable_joint_states>("set_mutable_joint_states");
-    store_client_ = nh_->serviceClient<industrial_extrinsic_cal::store_mutable_joint_states>("store_mutable_joint_states");
+Pose6d ROSCameraHousingCalTInterface::pullTransform()
+{
+  // The computed transform from the optical frame to the mounting frame is composed of 2 transforms
+  // one from the optical frame to the housing, and
+  // one from the housing to the mounting frame which is composed of the 6DOF unknowns we are trying to calibrate
+  // there is also an intermediate frame from the mount point to the reference frame which we don't need here
 
-    get_request_.joint_names.push_back(housing_frame+"_x_joint");
-    get_request_.joint_names.push_back(housing_frame+"_y_joint");
-    get_request_.joint_names.push_back(housing_frame+"_z_joint");
-    get_request_.joint_names.push_back(housing_frame+"_yaw_joint");
-    get_request_.joint_names.push_back(housing_frame+"_pitch_joint");
-    get_request_.joint_names.push_back(housing_frame+"_roll_joint");
+  // get all the information from tf and from the mutable joint state publisher
+  Pose6d optical2housing = getPoseFromTF(transform_frame_, housing_frame_, tf_listener_);
 
-    set_request_.joint_names.push_back(housing_frame+"_x_joint");
-    set_request_.joint_names.push_back(housing_frame+"_y_joint");
-    set_request_.joint_names.push_back(housing_frame+"_z_joint");
-    set_request_.joint_names.push_back(housing_frame+"_yaw_joint");
-    set_request_.joint_names.push_back(housing_frame+"_pitch_joint");
-    set_request_.joint_names.push_back(housing_frame+"_roll_joint");
+  // get the transform from housing 2 mount  from the client
+  Pose6d mount2housing;
+  get_client_.call(get_request_, get_response_);
+  mount2housing.setOrigin(get_response_.joint_values[0], get_response_.joint_values[1], get_response_.joint_values[2]);
+  mount2housing.setEulerZYX(get_response_.joint_values[3], get_response_.joint_values[4],
+                            get_response_.joint_values[5]);
+  Pose6d housing2mount = mount2housing.getInverse();
+  Pose6d optical2mount = optical2housing * housing2mount;
+  pose_ = optical2mount;
 
-    while(!get_client_.call(get_request_,get_response_)){
-      sleep(1);
-      ROS_INFO("Waiting for mutable joint state publisher to come up");
-    }
-    for(int i=0;i<(int) get_response_.joint_values.size();i++){
+  return (optical2mount);
+}
+
+bool ROSCameraHousingCalTInterface::pushTransform(Pose6d& pose)
+{
+  Pose6d pose_inverse = pose.getInverse();
+  pose_inverse.show("results being pushed");
+
+  // get transform from optical frame to housing frame from tf
+  Pose6d optical2housing = getPoseFromTF(transform_frame_, housing_frame_, tf_listener_);
+
+  // compute the desired transform
+  Pose6d mount2housing = pose_inverse * optical2housing;
+
+  // convert to xyz, roll, pitch and yaw for client
+  double ez, ey, ex;
+  mount2housing.getEulerZYX(ez, ey, ex);
+
+  set_request_.joint_values.clear();
+  set_request_.joint_values.push_back(mount2housing.x);
+  set_request_.joint_values.push_back(mount2housing.y);
+  set_request_.joint_values.push_back(mount2housing.z);
+  set_request_.joint_values.push_back(ez);
+  set_request_.joint_values.push_back(ey);
+  set_request_.joint_values.push_back(ex);
+  set_client_.call(set_request_, set_response_);
+  return (true);
+}
+
+bool ROSCameraHousingCalTInterface::store(std::string& filePath)
+{
+  // NOTE, file_name is not used, but is kept here for consistency with store functions of other transform interfaces
+  store_client_.call(store_request_, store_response_);
+  return (true);
+}
+
+void ROSCameraHousingCalTInterface::setReferenceFrame(std::string& ref_frame)
+{
+  ref_frame_ = ref_frame;
+  ref_frame_initialized_ = true;
+}
+
+Pose6d ROSCameraHousingCalTInterface::getIntermediateFrame()
+{
+  Pose6d pose(0, 0, 0, 0, 0, 0);
+  if (ref_frame_initialized_)
+  {
+    pose = getPoseFromTF(ref_frame_, mounting_frame_, tf_listener_);
+  }
+  else
+  {
+    ROS_ERROR("ROSCameraHousingCalTInterface requires ref_frame_ initialized before calling getIntermediateFrame()");
+  }
+  return (pose);
+}
+
+ROSSimpleCalTInterface::ROSSimpleCalTInterface(const string& transform_frame, const string& parent_frame)
+{
+  transform_frame_ = transform_frame;
+  parent_frame_ = parent_frame;
+  ref_frame_initialized_ = false;  // still need to initialize ref_frame_
+  nh_ = new ros::NodeHandle;
+
+  get_client_ = nh_->serviceClient< industrial_extrinsic_cal::get_mutable_joint_states >("get_mutable_joint_states");
+  set_client_ = nh_->serviceClient< industrial_extrinsic_cal::set_mutable_joint_states >("set_mutable_joint_states");
+  store_client_ =
+      nh_->serviceClient< industrial_extrinsic_cal::store_mutable_joint_states >("store_mutable_joint_states");
+
+  get_request_.joint_names.push_back(transform_frame + "_x_joint");
+  get_request_.joint_names.push_back(transform_frame + "_y_joint");
+  get_request_.joint_names.push_back(transform_frame + "_z_joint");
+  get_request_.joint_names.push_back(transform_frame + "_yaw_joint");
+  get_request_.joint_names.push_back(transform_frame + "_pitch_joint");
+  get_request_.joint_names.push_back(transform_frame + "_roll_joint");
+
+  set_request_.joint_names.push_back(transform_frame + "_x_joint");
+  set_request_.joint_names.push_back(transform_frame + "_y_joint");
+  set_request_.joint_names.push_back(transform_frame + "_z_joint");
+  set_request_.joint_names.push_back(transform_frame + "_yaw_joint");
+  set_request_.joint_names.push_back(transform_frame + "_pitch_joint");
+  set_request_.joint_names.push_back(transform_frame + "_roll_joint");
+
+  if (get_client_.call(get_request_, get_response_))
+  {
+    for (int i = 0; i < (int)get_response_.joint_values.size(); i++)
+    {
       joint_values_.push_back(get_response_.joint_values[i]);
     }
-  }				
-
-  Pose6d  ROSCameraHousingCalTInterface::pullTransform()
+  }
+  else
   {
-    // The computed transform from the optical frame to the mounting frame is composed of 2 transforms
-    // one from the optical frame to the housing, and
-    // one from the housing to the mounting frame which is composed of the 6DOF unknowns we are trying to calibrate
-    // there is also an intermediate frame from the mount point to the reference frame which we don't need here
+    ROS_ERROR("get_client_ returned false");
+  }
+}
 
-    // get all the information from tf and from the mutable joint state publisher
-    Pose6d optical2housing = getPoseFromTF( transform_frame_, housing_frame_, tf_listener_);
+Pose6d ROSSimpleCalTInterface::pullTransform()
+{
+  // The computed transform from the reference frame to the optical frame is composed of 3 transforms
+  // one from reference frame to mounting frame
+  // one composed of the 6DOF unknowns we are trying to calibrate
+  // from the mounting frame to the housing. It's values are maintained by the mutable joint state publisher
+  // the third is from housing to optical frame
 
-    // get the transform from housing 2 mount  from the client
-    Pose6d mount2housing;
-    get_client_.call(get_request_,get_response_);
-    mount2housing.setOrigin(get_response_.joint_values[0],get_response_.joint_values[1],get_response_.joint_values[2]);
-    mount2housing.setEulerZYX(get_response_.joint_values[3],get_response_.joint_values[4],get_response_.joint_values[5]);
-    Pose6d housing2mount = mount2housing.getInverse();
-    Pose6d optical2mount = optical2housing * housing2mount;
-    pose_ = optical2mount;
-
-    return(optical2mount);
+  if (!ref_frame_initialized_)
+  {  // still need the reference frame in order to return the transform!!
+    Pose6d pose(0, 0, 0, 0, 0, 0);
+    ROS_ERROR("Trying to pull transform from interface without setting reference frame ROSSimpleCalTInterface");
+    return (pose);
   }
 
-  bool  ROSCameraHousingCalTInterface::pushTransform(Pose6d &pose)
+  get_client_.call(get_request_, get_response_);
+  pose_.setOrigin(get_response_.joint_values[0], get_response_.joint_values[1], get_response_.joint_values[2]);
+  pose_.setEulerZYX(get_response_.joint_values[3], get_response_.joint_values[4], get_response_.joint_values[5]);
+  return (pose_);
+}
+
+bool ROSSimpleCalTInterface::pushTransform(Pose6d& pose)
+{
+  double ez, ey, ex;
+  pose.getEulerZYX(ez, ey, ex);
+
+  set_request_.joint_values.clear();
+  set_request_.joint_values.push_back(pose.x);
+  set_request_.joint_values.push_back(pose.y);
+  set_request_.joint_values.push_back(pose.z);
+  set_request_.joint_values.push_back(ez);
+  set_request_.joint_values.push_back(ey);
+  set_request_.joint_values.push_back(ex);
+  set_client_.call(set_request_, set_response_);
+
+  return (true);
+}
+
+bool ROSSimpleCalTInterface::store(std::string& filePath)
+{
+  // NOTE, file_name is not used, but is kept here for consistency with store functions of other transform interfaces
+  store_client_.call(store_request_, store_response_);
+  return (true);
+}
+
+void ROSSimpleCalTInterface::setReferenceFrame(std::string& ref_frame)
+{
+  ref_frame_ = ref_frame;
+  ref_frame_initialized_ = true;
+}
+
+ROSSimpleCameraCalTInterface::ROSSimpleCameraCalTInterface(const string& transform_frame, const string& parent_frame)
+{
+  transform_frame_ = transform_frame;
+  parent_frame_ = parent_frame;
+  ref_frame_initialized_ = false;  // still need to initialize ref_frame_
+  nh_ = new ros::NodeHandle;
+
+  get_client_ = nh_->serviceClient< industrial_extrinsic_cal::get_mutable_joint_states >("get_mutable_joint_states");
+  set_client_ = nh_->serviceClient< industrial_extrinsic_cal::set_mutable_joint_states >("set_mutable_joint_states");
+  store_client_ =
+      nh_->serviceClient< industrial_extrinsic_cal::store_mutable_joint_states >("store_mutable_joint_states");
+
+  get_request_.joint_names.push_back(transform_frame + "_x_joint");
+  get_request_.joint_names.push_back(transform_frame + "_y_joint");
+  get_request_.joint_names.push_back(transform_frame + "_z_joint");
+  get_request_.joint_names.push_back(transform_frame + "_yaw_joint");
+  get_request_.joint_names.push_back(transform_frame + "_pitch_joint");
+  get_request_.joint_names.push_back(transform_frame + "_roll_joint");
+
+  set_request_.joint_names.push_back(transform_frame + "_x_joint");
+  set_request_.joint_names.push_back(transform_frame + "_y_joint");
+  set_request_.joint_names.push_back(transform_frame + "_z_joint");
+  set_request_.joint_names.push_back(transform_frame + "_yaw_joint");
+  set_request_.joint_names.push_back(transform_frame + "_pitch_joint");
+  set_request_.joint_names.push_back(transform_frame + "_roll_joint");
+
+  if (get_client_.call(get_request_, get_response_))
   {
-    Pose6d pose_inverse = pose.getInverse();
-    pose_inverse.show("results being pushed");
-
-    // get transform from optical frame to housing frame from tf
-    Pose6d optical2housing = getPoseFromTF(transform_frame_, housing_frame_, tf_listener_);
-    
-    // compute the desired transform
-    Pose6d mount2housing =  pose_inverse * optical2housing;
-
-    // convert to xyz, roll, pitch and yaw for client
-    double ez,ey,ex;
-    mount2housing.getEulerZYX(ez,ey,ex);
-
-    set_request_.joint_values.clear();
-    set_request_.joint_values.push_back(mount2housing.x);
-    set_request_.joint_values.push_back(mount2housing.y);
-    set_request_.joint_values.push_back(mount2housing.z);
-    set_request_.joint_values.push_back(ez);
-    set_request_.joint_values.push_back(ey);
-    set_request_.joint_values.push_back(ex);
-    set_client_.call(set_request_,set_response_);
-    return(true);
-  }
-
-  bool ROSCameraHousingCalTInterface::store(std::string &filePath)
-  {
-    // NOTE, file_name is not used, but is kept here for consistency with store functions of other transform interfaces
-    store_client_.call(store_request_, store_response_);
-    return(true);
-  }
-
-  void ROSCameraHousingCalTInterface::setReferenceFrame(std::string &ref_frame)
-  {
-    ref_frame_ = ref_frame;
-    ref_frame_initialized_ = true;
-  }
-
-  Pose6d ROSCameraHousingCalTInterface::getIntermediateFrame()
-  {
-    Pose6d pose(0,0,0,0,0,0);
-    if(ref_frame_initialized_){
-      pose =  getPoseFromTF(ref_frame_, mounting_frame_, tf_listener_);
+    for (int i = 0; i < (int)get_response_.joint_values.size(); i++)
+    {
+      joint_values_.push_back(get_response_.joint_values[i]);
     }
-    else{
-      ROS_ERROR("ROSCameraHousingCalTInterface requires ref_frame_ initialized before calling getIntermediateFrame()");
-    }
-    return(pose);
+  }
+  else
+  {
+    ROS_ERROR("get_client_ returned false");
+  }
+}
+
+Pose6d ROSSimpleCameraCalTInterface::pullTransform()
+{
+  // The computed transform from the reference frame to the optical frame is composed of 3 transforms
+  // one from reference frame to mounting frame
+  // one composed of the 6DOF unknowns we are trying to calibrate
+  // from the mounting frame to the housing. It's values are maintained by the mutable joint state publisher
+  // the third is from housing to optical frame
+
+  if (!ref_frame_initialized_)
+  {  // still need the reference frame in order to return the transform!!
+    Pose6d pose(0, 0, 0, 0, 0, 0);
+    ROS_ERROR("Trying to pull transform from interface without setting reference frame ROSSimpleCameraCalTInterface");
+    return (pose);
   }
 
-  ROSSimpleCalTInterface::ROSSimpleCalTInterface(const string &transform_frame,  const string &parent_frame)
-  {
-    transform_frame_               = transform_frame;
-    parent_frame_                     = parent_frame; 
-    ref_frame_initialized_         = false;    // still need to initialize ref_frame_
-    nh_ = new ros::NodeHandle;
+  get_client_.call(get_request_, get_response_);
+  pose_.setOrigin(get_response_.joint_values[0], get_response_.joint_values[1], get_response_.joint_values[2]);
+  pose_.setEulerZYX(get_response_.joint_values[3], get_response_.joint_values[4], get_response_.joint_values[5]);
+  return (pose_.getInverse());
+}
 
-    get_client_    = nh_->serviceClient<industrial_extrinsic_cal::get_mutable_joint_states>("get_mutable_joint_states");
-    set_client_    = nh_->serviceClient<industrial_extrinsic_cal::set_mutable_joint_states>("set_mutable_joint_states");
-    store_client_ = nh_->serviceClient<industrial_extrinsic_cal::store_mutable_joint_states>("store_mutable_joint_states");
+bool ROSSimpleCameraCalTInterface::pushTransform(Pose6d& pose)
+{
+  double ez, ey, ex;
+  Pose6d ipose = pose.getInverse();
+  ipose.getEulerZYX(ez, ey, ex);
 
-    get_request_.joint_names.push_back(transform_frame+"_x_joint");
-    get_request_.joint_names.push_back(transform_frame+"_y_joint");
-    get_request_.joint_names.push_back(transform_frame+"_z_joint");
-    get_request_.joint_names.push_back(transform_frame+"_yaw_joint");
-    get_request_.joint_names.push_back(transform_frame+"_pitch_joint");
-    get_request_.joint_names.push_back(transform_frame+"_roll_joint");
+  set_request_.joint_values.clear();
+  set_request_.joint_values.push_back(ipose.x);
+  set_request_.joint_values.push_back(ipose.y);
+  set_request_.joint_values.push_back(ipose.z);
+  set_request_.joint_values.push_back(ez);
+  set_request_.joint_values.push_back(ey);
+  set_request_.joint_values.push_back(ex);
+  set_client_.call(set_request_, set_response_);
 
-    set_request_.joint_names.push_back(transform_frame+"_x_joint");
-    set_request_.joint_names.push_back(transform_frame+"_y_joint");
-    set_request_.joint_names.push_back(transform_frame+"_z_joint");
-    set_request_.joint_names.push_back(transform_frame+"_yaw_joint");
-    set_request_.joint_names.push_back(transform_frame+"_pitch_joint");
-    set_request_.joint_names.push_back(transform_frame+"_roll_joint");
+  return (true);
+}
 
-    if(get_client_.call(get_request_,get_response_)){
-      for(int i=0;i<(int) get_response_.joint_values.size();i++){
-	joint_values_.push_back(get_response_.joint_values[i]);
-      }
-    }
-    else{
-      ROS_ERROR("get_client_ returned false");
-    }
+bool ROSSimpleCameraCalTInterface::store(std::string& filePath)
+{
+  // NOTE, file_name is not used, but is kept here for consistency with store functions of other transform interfaces
+  store_client_.call(store_request_, store_response_);
+  return (true);
+}
 
-  }				
+void ROSSimpleCameraCalTInterface::setReferenceFrame(std::string& ref_frame)
+{
+  ref_frame_ = ref_frame;
+  ref_frame_initialized_ = true;
+}
 
-  Pose6d  ROSSimpleCalTInterface::pullTransform()
-  {
-    // The computed transform from the reference frame to the optical frame is composed of 3 transforms
-    // one from reference frame to mounting frame
-    // one composed of the 6DOF unknowns we are trying to calibrate
-    // from the mounting frame to the housing. It's values are maintained by the mutable joint state publisher
-    // the third is from housing to optical frame
-
-    if(!ref_frame_initialized_){ // still need the reference frame in order to return the transform!!
-      Pose6d pose(0,0,0,0,0,0);
-      ROS_ERROR("Trying to pull transform from interface without setting reference frame ROSSimpleCalTInterface");
-      return(pose);
-    }
-
-    get_client_.call(get_request_,get_response_);
-    pose_.setOrigin(get_response_.joint_values[0],get_response_.joint_values[1],get_response_.joint_values[2]);
-    pose_.setEulerZYX(get_response_.joint_values[3],get_response_.joint_values[4],get_response_.joint_values[5]);
-    return(pose_);
-  }
-
-  bool  ROSSimpleCalTInterface::pushTransform(Pose6d &pose)
-  {
-    double ez,ey,ex;
-    pose.getEulerZYX(ez,ey,ex);
-    
-    set_request_.joint_values.clear();
-    set_request_.joint_values.push_back(pose.x);
-    set_request_.joint_values.push_back(pose.y);
-    set_request_.joint_values.push_back(pose.z);
-    set_request_.joint_values.push_back(ez);
-    set_request_.joint_values.push_back(ey);
-    set_request_.joint_values.push_back(ex);
-    set_client_.call(set_request_,set_response_);
-
-    return(true);
-  }
-
-  bool ROSSimpleCalTInterface::store(std::string &filePath)
-  {
-    // NOTE, file_name is not used, but is kept here for consistency with store functions of other transform interfaces
-    store_client_.call(store_request_, store_response_);
-    return(true);
-  }
-
-  void ROSSimpleCalTInterface::setReferenceFrame(std::string &ref_frame)
-  {
-    ref_frame_ = ref_frame;
-    ref_frame_initialized_ = true;
-  }
-
-  ROSSimpleCameraCalTInterface::ROSSimpleCameraCalTInterface(const string &transform_frame,  const string &parent_frame)
-  {
-    transform_frame_               = transform_frame;
-    parent_frame_                     = parent_frame; 
-    ref_frame_initialized_         = false;    // still need to initialize ref_frame_
-    nh_ = new ros::NodeHandle;
-
-    get_client_    = nh_->serviceClient<industrial_extrinsic_cal::get_mutable_joint_states>("get_mutable_joint_states");
-    set_client_    = nh_->serviceClient<industrial_extrinsic_cal::set_mutable_joint_states>("set_mutable_joint_states");
-    store_client_ = nh_->serviceClient<industrial_extrinsic_cal::store_mutable_joint_states>("store_mutable_joint_states");
-
-    get_request_.joint_names.push_back(transform_frame+"_x_joint");
-    get_request_.joint_names.push_back(transform_frame+"_y_joint");
-    get_request_.joint_names.push_back(transform_frame+"_z_joint");
-    get_request_.joint_names.push_back(transform_frame+"_yaw_joint");
-    get_request_.joint_names.push_back(transform_frame+"_pitch_joint");
-    get_request_.joint_names.push_back(transform_frame+"_roll_joint");
-
-    set_request_.joint_names.push_back(transform_frame+"_x_joint");
-    set_request_.joint_names.push_back(transform_frame+"_y_joint");
-    set_request_.joint_names.push_back(transform_frame+"_z_joint");
-    set_request_.joint_names.push_back(transform_frame+"_yaw_joint");
-    set_request_.joint_names.push_back(transform_frame+"_pitch_joint");
-    set_request_.joint_names.push_back(transform_frame+"_roll_joint");
-
-    if(get_client_.call(get_request_,get_response_)){
-      for(int i=0;i<(int) get_response_.joint_values.size();i++){
-	joint_values_.push_back(get_response_.joint_values[i]);
-      }
-    }
-    else{
-      ROS_ERROR("get_client_ returned false");
-    }
-
-  }				
-
-  Pose6d  ROSSimpleCameraCalTInterface::pullTransform()
-  {
-    // The computed transform from the reference frame to the optical frame is composed of 3 transforms
-    // one from reference frame to mounting frame
-    // one composed of the 6DOF unknowns we are trying to calibrate
-    // from the mounting frame to the housing. It's values are maintained by the mutable joint state publisher
-    // the third is from housing to optical frame
-
-    if(!ref_frame_initialized_){ // still need the reference frame in order to return the transform!!
-      Pose6d pose(0,0,0,0,0,0);
-      ROS_ERROR("Trying to pull transform from interface without setting reference frame ROSSimpleCameraCalTInterface");
-      return(pose);
-    }
-
-    get_client_.call(get_request_,get_response_);
-    pose_.setOrigin(get_response_.joint_values[0],get_response_.joint_values[1],get_response_.joint_values[2]);
-    pose_.setEulerZYX(get_response_.joint_values[3],get_response_.joint_values[4],get_response_.joint_values[5]);
-    return(pose_.getInverse());
-  }
-
-  bool  ROSSimpleCameraCalTInterface::pushTransform(Pose6d &pose)
-  {
-    double ez,ey,ex;
-    Pose6d ipose = pose.getInverse();
-    ipose.getEulerZYX(ez,ey,ex);
-    
-    set_request_.joint_values.clear();
-    set_request_.joint_values.push_back(ipose.x);
-    set_request_.joint_values.push_back(ipose.y);
-    set_request_.joint_values.push_back(ipose.z);
-    set_request_.joint_values.push_back(ez);
-    set_request_.joint_values.push_back(ey);
-    set_request_.joint_values.push_back(ex);
-    set_client_.call(set_request_,set_response_);
-
-    return(true);
-  }
-
-  bool ROSSimpleCameraCalTInterface::store(std::string &filePath)
-  {
-    // NOTE, file_name is not used, but is kept here for consistency with store functions of other transform interfaces
-    store_client_.call(store_request_, store_response_);
-    return(true);
-  }
-
-  void ROSSimpleCameraCalTInterface::setReferenceFrame(std::string &ref_frame)
-  {
-    ref_frame_ = ref_frame;
-    ref_frame_initialized_ = true;
-  }
-
-} // end namespace industrial_extrinsic_cal
+}  // end namespace industrial_extrinsic_cal

--- a/industrial_extrinsic_cal/src/target.cpp
+++ b/industrial_extrinsic_cal/src/target.cpp
@@ -19,25 +19,24 @@
 
 namespace industrial_extrinsic_cal
 {
-
-  void Target::pushTransform()
-  {
-    transform_interface_->pushTransform(pose_);
-  }
-  void Target::pullTransform()
-  {
-    pose_ = transform_interface_->pullTransform();
-  }
-  void Target::setTransformInterface(boost::shared_ptr<TransformInterface> transform_interface)
-  {
-    transform_interface_ = transform_interface;
-  }
-  boost::shared_ptr<TransformInterface> Target::getTransformInterface()
-  {
-    return(transform_interface_);
-  }
-  void Target::setTIReferenceFrame(std::string ref_frame)
-  {
-    transform_interface_->setReferenceFrame(ref_frame);
-  }
-}// end of namespace
+void Target::pushTransform()
+{
+  transform_interface_->pushTransform(pose_);
+}
+void Target::pullTransform()
+{
+  pose_ = transform_interface_->pullTransform();
+}
+void Target::setTransformInterface(boost::shared_ptr< TransformInterface > transform_interface)
+{
+  transform_interface_ = transform_interface;
+}
+boost::shared_ptr< TransformInterface > Target::getTransformInterface()
+{
+  return (transform_interface_);
+}
+void Target::setTIReferenceFrame(std::string ref_frame)
+{
+  transform_interface_->setReferenceFrame(ref_frame);
+}
+}  // end of namespace

--- a/industrial_extrinsic_cal/src/targets_yaml_parser.cpp
+++ b/industrial_extrinsic_cal/src/targets_yaml_parser.cpp
@@ -8,8 +8,8 @@
 #include <yaml-cpp/yaml.h>
 #include <industrial_extrinsic_cal/ros_transform_interface.h>
 #include <industrial_extrinsic_cal/targets_yaml_parser.h>
-#include <industrial_extrinsic_cal/camera_yaml_parser.h> // for parse_pose() and parse_transform_interface()
-#include <industrial_extrinsic_cal/ros_camera_observer.h> // for pattern options
+#include <industrial_extrinsic_cal/camera_yaml_parser.h>   // for parse_pose() and parse_transform_interface()
+#include <industrial_extrinsic_cal/ros_camera_observer.h>  // for pattern options
 
 using std::ifstream;
 using std::string;
@@ -18,168 +18,180 @@ using boost::shared_ptr;
 using boost::make_shared;
 using YAML::Node;
 
-namespace industrial_extrinsic_cal {
+namespace industrial_extrinsic_cal
+{
+// prototypes
+int parseTargetPoints(const Node& node, std::vector< Point3d >& points);
 
-  // prototypes
-  int parseTargetPoints(const Node &node, std::vector<Point3d> &points);
-
-
-  bool parseTargets(std::string &target_file,vector< boost::shared_ptr<Target> > & targets)
+bool parseTargets(std::string& target_file, vector< boost::shared_ptr< Target > >& targets)
+{
+  bool rtn = true;
+  Node target_doc;
+  try
   {
-    bool rtn = true;
-    Node target_doc;
-    try{
-      YAML::Node target_doc;
-      if(!yamlNodeFromFileName(target_file, target_doc)){
-	ROS_ERROR("Can't parse yaml file %s", target_file.c_str());
-      }
-      // read in all static cameras
-      targets.clear();
-      int n_static =0;
-      const YAML::Node& target_parameters = parseNode(target_doc, "static_targets");
-      if(target_parameters)
+    YAML::Node target_doc;
+    if (!yamlNodeFromFileName(target_file, target_doc))
+    {
+      ROS_ERROR("Can't parse yaml file %s", target_file.c_str());
+    }
+    // read in all static cameras
+    targets.clear();
+    int n_static = 0;
+    const YAML::Node& target_parameters = parseNode(target_doc, "static_targets");
+    if (target_parameters)
+    {
+      for (unsigned int i = 0; i < target_parameters.size(); i++)
       {
-        for (unsigned int i = 0; i < target_parameters.size(); i++){
-        shared_ptr<Target> temp_target = parseSingleTarget(target_parameters[i]);
+        shared_ptr< Target > temp_target = parseSingleTarget(target_parameters[i]);
         temp_target->is_moving_ = false;
         targets.push_back(temp_target);
         n_static++;
-        }
       }
-
-
-
-      // read in all moving targets
-      int n_moving=0;
-      const YAML::Node& target_parameters2 = parseNode(target_doc, "moving_targets");
-      if(target_parameters2)
-      {
-        for (unsigned int i = 0; i < target_parameters2.size(); i++){
-          shared_ptr<Target> temp_target = parseSingleTarget(target_parameters2[i]);
-          temp_target->is_moving_ = true;
-          targets.push_back(temp_target);
-          n_moving++;
-        }
-      }
-
-      if(targets.size() == 0)
-      {
-        ROS_ERROR_STREAM("No valid targets found in file " << target_file.c_str());
-        return false;
-      }
-      ROS_INFO_STREAM((int) targets.size() << " targets " << n_static << " static " << n_moving << " moving");
     }
-    catch (YAML::ParserException& e){
-      ROS_ERROR_STREAM("Failed to parse targets with exception "<< e.what());
-      rtn = false;
+
+    // read in all moving targets
+    int n_moving = 0;
+    const YAML::Node& target_parameters2 = parseNode(target_doc, "moving_targets");
+    if (target_parameters2)
+    {
+      for (unsigned int i = 0; i < target_parameters2.size(); i++)
+      {
+        shared_ptr< Target > temp_target = parseSingleTarget(target_parameters2[i]);
+        temp_target->is_moving_ = true;
+        targets.push_back(temp_target);
+        n_moving++;
+      }
     }
-    return(rtn);
+
+    if (targets.size() == 0)
+    {
+      ROS_ERROR_STREAM("No valid targets found in file " << target_file.c_str());
+      return false;
+    }
+    ROS_INFO_STREAM((int)targets.size() << " targets " << n_static << " static " << n_moving << " moving");
   }
-
-  shared_ptr<Target> parseSingleTarget(const Node &node)
+  catch (YAML::ParserException& e)
   {
-    shared_ptr<Target> temp_target = make_shared<Target>();
-    shared_ptr<TransformInterface> temp_ti;
-    try{
-      bool success=true;
-      success &= parseString(node, "target_name", temp_target->target_name_);
-      success &= parseString(node, "target_frame", temp_target->target_frame_);
-      success &= parseUInt(node, "target_type", temp_target->target_type_);
-      if(!success){
-	ROS_ERROR("must set target name, frame and type %s %s %u",
-		  temp_target->target_name_.c_str(),
-		  temp_target->target_frame_.c_str(),
-		  temp_target->target_type_);
-      }      
-      Pose6d pose;
-      bool transform_available = parsePose(node, pose);
-      if(transform_available){
-	temp_target->pose_ = pose;
-      }
+    ROS_ERROR_STREAM("Failed to parse targets with exception " << e.what());
+    rtn = false;
+  }
+  return (rtn);
+}
 
-      switch (temp_target->target_type_){
+shared_ptr< Target > parseSingleTarget(const Node& node)
+{
+  shared_ptr< Target > temp_target = make_shared< Target >();
+  shared_ptr< TransformInterface > temp_ti;
+  try
+  {
+    bool success = true;
+    success &= parseString(node, "target_name", temp_target->target_name_);
+    success &= parseString(node, "target_frame", temp_target->target_frame_);
+    success &= parseUInt(node, "target_type", temp_target->target_type_);
+    if (!success)
+    {
+      ROS_ERROR("must set target name, frame and type %s %s %u", temp_target->target_name_.c_str(),
+                temp_target->target_frame_.c_str(), temp_target->target_type_);
+    }
+    Pose6d pose;
+    bool transform_available = parsePose(node, pose);
+    if (transform_available)
+    {
+      temp_target->pose_ = pose;
+    }
+
+    switch (temp_target->target_type_)
+    {
       case pattern_options::Chessboard:
-	success &=parseInt(node, "target_rows", temp_target->checker_board_parameters_.pattern_rows);
-	success &=parseInt(node, "target_cols", temp_target->checker_board_parameters_.pattern_cols);
-	ROS_DEBUG_STREAM("TargetRows: "<<temp_target->checker_board_parameters_.pattern_rows);
-	if(!success) ROS_ERROR("must set rows and cols");
-	break;
+        success &= parseInt(node, "target_rows", temp_target->checker_board_parameters_.pattern_rows);
+        success &= parseInt(node, "target_cols", temp_target->checker_board_parameters_.pattern_cols);
+        ROS_DEBUG_STREAM("TargetRows: " << temp_target->checker_board_parameters_.pattern_rows);
+        if (!success) ROS_ERROR("must set rows and cols");
+        break;
       case pattern_options::CircleGrid:
-	parseInt(node, "target_rows", temp_target->circle_grid_parameters_.pattern_rows);
-	parseInt(node, "target_cols", temp_target->circle_grid_parameters_.pattern_cols);
-	parseDouble(node, "circle_dia", temp_target->circle_grid_parameters_.circle_diameter);
-	temp_target->circle_grid_parameters_.is_symmetric=true;
-	ROS_DEBUG_STREAM("TargetRows: "<<temp_target->circle_grid_parameters_.pattern_rows);
-	break;
+        parseInt(node, "target_rows", temp_target->circle_grid_parameters_.pattern_rows);
+        parseInt(node, "target_cols", temp_target->circle_grid_parameters_.pattern_cols);
+        parseDouble(node, "circle_dia", temp_target->circle_grid_parameters_.circle_diameter);
+        temp_target->circle_grid_parameters_.is_symmetric = true;
+        ROS_DEBUG_STREAM("TargetRows: " << temp_target->circle_grid_parameters_.pattern_rows);
+        break;
       case pattern_options::ModifiedCircleGrid:
-	parseInt(node, "target_rows", temp_target->circle_grid_parameters_.pattern_rows);
-	parseInt(node, "target_cols", temp_target->circle_grid_parameters_.pattern_cols);
-	parseDouble(node, "circle_dia", temp_target->circle_grid_parameters_.circle_diameter);
-	temp_target->circle_grid_parameters_.is_symmetric=true;
-	ROS_DEBUG_STREAM("TargetRows: "<<temp_target->circle_grid_parameters_.pattern_rows);
-	break;
+        parseInt(node, "target_rows", temp_target->circle_grid_parameters_.pattern_rows);
+        parseInt(node, "target_cols", temp_target->circle_grid_parameters_.pattern_cols);
+        parseDouble(node, "circle_dia", temp_target->circle_grid_parameters_.circle_diameter);
+        temp_target->circle_grid_parameters_.is_symmetric = true;
+        ROS_DEBUG_STREAM("TargetRows: " << temp_target->circle_grid_parameters_.pattern_rows);
+        break;
       case pattern_options::ARtag:
-	// no parameters yet
-	break;
+        // no parameters yet
+        break;
       case pattern_options::Balls:
-	// no parameters yet
-	break;
+        // no parameters yet
+        break;
       default:
-	ROS_ERROR("unknown pattern option %d (Chessboard, CircleGrid, or ModifiedCircleGrid, Balls)", 
-			 (int) temp_target->target_type_);
-	break;
-      } // end of target type
-      std::string transform_interface;
-      if(!parseString(node, "transform_interface", transform_interface)){
-	ROS_ERROR("must set transform interface for target");
+        ROS_ERROR("unknown pattern option %d (Chessboard, CircleGrid, or ModifiedCircleGrid, Balls)",
+                  (int)temp_target->target_type_);
+        break;
+    }  // end of target type
+    std::string transform_interface;
+    if (!parseString(node, "transform_interface", transform_interface))
+    {
+      ROS_ERROR("must set transform interface for target");
+    }
+    else
+    {
+      shared_ptr< TransformInterface > temp_ti =
+          parseTransformInterface(node, transform_interface, temp_target->target_frame_, pose);
+      temp_target->setTransformInterface(temp_ti);  // install the transform interface
+      if (transform_available)
+      {
+        temp_target->pushTransform();
       }
-      else{
-	shared_ptr<TransformInterface>  temp_ti = parseTransformInterface(node, transform_interface, temp_target->target_frame_, pose);
-	temp_target->setTransformInterface(temp_ti);// install the transform interface 
-	if(transform_available){
-	  temp_target->pushTransform();
-	}
-      }
+    }
 
-      if(!parseUInt(node, "num_points", temp_target->num_points_)){
-	ROS_ERROR("must set target num_points");
-      }
-      const YAML::Node& points_node = parseNode(node, "points");
-      int num_points = parseTargetPoints(points_node, temp_target->pts_);
-      if(num_points  != temp_target->num_points_  || num_points != (int)temp_target->pts_.size()){
-	ROS_ERROR("Expecting %d points found %d",temp_target->num_points_, num_points);
-      }
-    }// end try
-    catch (YAML::ParserException& e){
-      ROS_ERROR_STREAM("Failed to parse single target with exception "<< e.what());
-      ROS_INFO_STREAM("Failed to read target from yaml file ");
-      ROS_INFO_STREAM("target name    = " << temp_target->target_name_.c_str());
-      ROS_INFO_STREAM("target type    = " << temp_target->target_type_);
-      ROS_INFO_STREAM("target frame    = " << temp_target->target_frame_.c_str());
-      ROS_INFO_STREAM("num_points    = " << temp_target->num_points_);
-      ROS_INFO_STREAM("angle_axis_ax  = " << temp_target->pose_.ax);
-      ROS_INFO_STREAM("angle_axis_ay = " << temp_target->pose_.ay);
-      ROS_INFO_STREAM("angle_axis_az  = " << temp_target->pose_.az);
-      ROS_INFO_STREAM("position_x     = " << temp_target->pose_.x);
-      ROS_INFO_STREAM("position_y     = " << temp_target->pose_.y);
-      ROS_INFO_STREAM("position_z     = " << temp_target->pose_.z);
+    if (!parseUInt(node, "num_points", temp_target->num_points_))
+    {
+      ROS_ERROR("must set target num_points");
     }
-    return(temp_target);
-  }// end parse_single_target
-  
-  int parseTargetPoints(const Node &node, std::vector<Point3d> &points)
+    const YAML::Node& points_node = parseNode(node, "points");
+    int num_points = parseTargetPoints(points_node, temp_target->pts_);
+    if (num_points != temp_target->num_points_ || num_points != (int)temp_target->pts_.size())
+    {
+      ROS_ERROR("Expecting %d points found %d", temp_target->num_points_, num_points);
+    }
+  }  // end try
+  catch (YAML::ParserException& e)
   {
-    points.clear();
-    for (int i = 0; i <(int) node.size(); i++){
-      std::vector<double> temp_pnt;
-      parseVectorD(node[i], "pnt", temp_pnt);
-      Point3d temp_pnt3d;
-      temp_pnt3d.x = temp_pnt[0];
-      temp_pnt3d.y = temp_pnt[1];
-      temp_pnt3d.z = temp_pnt[2];
-      points.push_back(temp_pnt3d);
-    }
-    return(node.size());
+    ROS_ERROR_STREAM("Failed to parse single target with exception " << e.what());
+    ROS_INFO_STREAM("Failed to read target from yaml file ");
+    ROS_INFO_STREAM("target name    = " << temp_target->target_name_.c_str());
+    ROS_INFO_STREAM("target type    = " << temp_target->target_type_);
+    ROS_INFO_STREAM("target frame    = " << temp_target->target_frame_.c_str());
+    ROS_INFO_STREAM("num_points    = " << temp_target->num_points_);
+    ROS_INFO_STREAM("angle_axis_ax  = " << temp_target->pose_.ax);
+    ROS_INFO_STREAM("angle_axis_ay = " << temp_target->pose_.ay);
+    ROS_INFO_STREAM("angle_axis_az  = " << temp_target->pose_.az);
+    ROS_INFO_STREAM("position_x     = " << temp_target->pose_.x);
+    ROS_INFO_STREAM("position_y     = " << temp_target->pose_.y);
+    ROS_INFO_STREAM("position_z     = " << temp_target->pose_.z);
   }
-  
-}// end of industrial_extrinsic_cal namespace
+  return (temp_target);
+}  // end parse_single_target
+
+int parseTargetPoints(const Node& node, std::vector< Point3d >& points)
+{
+  points.clear();
+  for (int i = 0; i < (int)node.size(); i++)
+  {
+    std::vector< double > temp_pnt;
+    parseVectorD(node[i], "pnt", temp_pnt);
+    Point3d temp_pnt3d;
+    temp_pnt3d.x = temp_pnt[0];
+    temp_pnt3d.y = temp_pnt[1];
+    temp_pnt3d.z = temp_pnt[2];
+    points.push_back(temp_pnt3d);
+  }
+  return (node.size());
+}
+
+}  // end of industrial_extrinsic_cal namespace

--- a/industrial_extrinsic_cal/src/targets_yaml_parser_indigo.cpp
+++ b/industrial_extrinsic_cal/src/targets_yaml_parser_indigo.cpp
@@ -8,8 +8,8 @@
 #include <yaml-cpp/yaml.h>
 #include <industrial_extrinsic_cal/ros_transform_interface.h>
 #include <industrial_extrinsic_cal/targets_yaml_parser.h>
-#include <industrial_extrinsic_cal/camera_yaml_parser.h> // for parse_pose() and parse_transform_interface()
-#include <industrial_extrinsic_cal/ros_camera_observer.h> // for pattern options
+#include <industrial_extrinsic_cal/camera_yaml_parser.h>   // for parse_pose() and parse_transform_interface()
+#include <industrial_extrinsic_cal/ros_camera_observer.h>  // for pattern options
 
 using std::ifstream;
 using std::string;
@@ -18,122 +18,129 @@ using boost::shared_ptr;
 using boost::make_shared;
 using YAML::Node;
 
-namespace industrial_extrinsic_cal {
+namespace industrial_extrinsic_cal
+{
+// prototypes
+int parse_target_points(const Node& node, std::vector< Point3d > points);
 
-  // prototypes
-  int parse_target_points(const Node &node, std::vector<Point3d> points);
-
-
-  void parse_targets(ifstream &targets_input_file,vector< boost::shared_ptr<Target> > & targets)
+void parse_targets(ifstream& targets_input_file, vector< boost::shared_ptr< Target > >& targets)
+{
+  try
   {
-    
-    try{
-      YAML::Node targets_node = YAML::LoadFile(targets_input_file.c_str());
-      
-      // read in all static cameras
-      targets.clear();
-      const Node target_parameters = target_node.("static_targets");
-      ROS_INFO_STREAM("Found "<<target_parameters.size()<<" static targets ");
-      for (unsigned int i = 0; i < target_parameters.size(); i++){
-	shared_ptr<Target> temp_target = parse_single_target(target_parameters[i]);
-	targets.push_back(temp_target);
-      }
-      
-      // read in all moving targets
-      target_parameters = target_doc.("moving_targets");
-      ROS_INFO_STREAM("Found "<<target_parameters.size()<<" moving targets ");
-      for (unsigned int i = 0; i < target_parameters.size(); i++){
-	shared_ptr<Target> temp_target = parse_single_target(target_parameters[i]);
-	temp_target->is_moving_ = true;
-	targets.push_back(temp_target);
-      }
-      
-    }
-    catch (YAML::ParserException& e){
-      ROS_INFO_STREAM("Failed to read points file ");
-    }
-    ROS_INFO_STREAM("Successfully read in " << (int) targets.size() << " targets");
-  }// end of parse_targets
+    YAML::Node targets_node = YAML::LoadFile(targets_input_file.c_str());
 
-  shared_ptr<Target> parse_single_target(const Node &node)
-  {
-    shared_ptr<Target> temp_target = make_shared<Target>();
-    shared_ptr<TransformInterface> temp_ti;
-    try{
-      temp_target->target_name_ = node["target_name"].at<std::string>();
-      temp_target->target_frame_ = node["target_frame"].at<std::string>();
-      temp_target->target_type_ = node["target_type"].at<std::string>();
-      switch (temp_target->target_type_){
-      case pattern_options::Chessboard:
-	temp_target->checker_board_parameters_.pattern_rows = node["target_rows"].at<int>();
-	temp_target->checker_board_parameters_.pattern_cols = node["target_cols"].at<int>();
-	ROS_DEBUG_STREAM("TargetRows: "<<temp_target->checker_board_parameters_.pattern_rows);
-	break;
-      case pattern_options::CircleGrid:
-	temp_target->circle_grid_parameters_.pattern_rows = node["target_rows"].at<int>();
-	temp_target->circle_grid_parameters_.pattern_cols = node["target_cols"].at<int>();
-	temp_target->circle_grid_parameters_.circle_diameter =["circle_dia"] .at<double>();
-	temp_target->circle_grid_parameters_.is_symmetric=true;
-	ROS_DEBUG_STREAM("TargetRows: "<<temp_target->circle_grid_parameters_.pattern_rows);
-	break;
-      case pattern_options::ModifiedCircleGrid:
-	temp_target->circle_grid_parameters_.pattern_rows = node["target_rows"].at<int>();
-	temp_target->circle_grid_parameters_.pattern_cols = node["target_cols"].at<int>();
-	temp_target->circle_grid_parameters_.circle_diameter =["circle_dia"] .at<double>();
-	temp_target->circle_grid_parameters_.is_symmetric=true;
-	ROS_DEBUG_STREAM("TargetRows: "<<temp_target->circle_grid_parameters_.pattern_rows);
-	break;
-      case pattern_options::Balls:
-	// no parameters yet
-	break;
-      default:
-	ROS_ERROR_STREAM("unknown pattern option (Chessboard, CircleGrid, or ModifiedCircleGrid, Balls)");
-	break;
-      } // end of target type
-      temp_target->pose_ = parsePose(node);
-      std::string transform_interface;
-      transform_interface = node["transform_interface"].at<std::string>();
-      shared_ptr<TransformInterface>  temp_ti = parseTransformInterface(node, transform_interface, temp_target->target_frame_);
-      temp_target->setTransformInterface(temp_ti);// install the transform interface 
+    // read in all static cameras
+    targets.clear();
+    const Node target_parameters = target_node.("static_targets");
+    ROS_INFO_STREAM("Found " << target_parameters.size() << " static targets ");
+    for (unsigned int i = 0; i < target_parameters.size(); i++)
+    {
+      shared_ptr< Target > temp_target = parse_single_target(target_parameters[i]);
+      targets.push_back(temp_target);
+    }
 
-      temp_target->num_points_ =      node["num_points"].at<int>();
-      const Node points_node = node("points");
-      int num_points = parse_target_points(points_node, temp_target->pts_);
-      if(num_points  != temp_target->num_points_ ){
-	ROS_ERROR("Expecting %d points found %d",temp_target->num_points_, num_points);
-      }
-    }// end try
-    catch (YAML::ParserException& e){
-      ROS_INFO_STREAM("Failed to read target from yaml file ");
-      ROS_INFO_STREAM("target name    = " << temp_target->target_name_.c_str());
-      ROS_INFO_STREAM("target type    = " << temp_target->target_type_);
-      ROS_INFO_STREAM("target frame    = " << temp_target->target_frame_.c_str());
-      ROS_INFO_STREAM("num_points    = " << temp_target->num_points_);
-      ROS_INFO_STREAM("angle_axis_ax  = " << temp_target->pose_.ax);
-      ROS_INFO_STREAM("angle_axis_ay = " << temp_target->pose_.ay);
-      ROS_INFO_STREAM("angle_axis_az  = " << temp_target->pose_.az);
-      ROS_INFO_STREAM("position_x     = " << temp_target->pose_.x);
-      ROS_INFO_STREAM("position_y     = " << temp_target->pose_.y);
-      ROS_INFO_STREAM("position_z     = " << temp_target->pose_.z);
+    // read in all moving targets
+    target_parameters = target_doc.("moving_targets");
+    ROS_INFO_STREAM("Found " << target_parameters.size() << " moving targets ");
+    for (unsigned int i = 0; i < target_parameters.size(); i++)
+    {
+      shared_ptr< Target > temp_target = parse_single_target(target_parameters[i]);
+      temp_target->is_moving_ = true;
+      targets.push_back(temp_target);
     }
-    return(temp_target);
-  }// end parse_single_target
-  
-  int parse_target_points(const Node &node, std::vector<Point3d> points)
-  {
-    ROS_DEBUG_STREAM("FoundPoints: "<<node.size());
-    points.clear();
-    for (int i = 0; i <(int) node.size(); i++){
-      const YAML::Node pnt_node = node[i]("pnt");
-      std::vector<float> temp_pnt;
-      temp_pnt = pnt_node.at< std::vector<double> >();
-      Point3d temp_pnt3d;
-      temp_pnt3d.x = temp_pnt[0];
-      temp_pnt3d.y = temp_pnt[1];
-      temp_pnt3d.z = temp_pnt[2];
-      points.push_back(temp_pnt3d);
-    }
-    return(node.size());
   }
-  
-}// end of industrial_extrinsic_cal namespace
+  catch (YAML::ParserException& e)
+  {
+    ROS_INFO_STREAM("Failed to read points file ");
+  }
+  ROS_INFO_STREAM("Successfully read in " << (int)targets.size() << " targets");
+}  // end of parse_targets
+
+shared_ptr< Target > parse_single_target(const Node& node)
+{
+  shared_ptr< Target > temp_target = make_shared< Target >();
+  shared_ptr< TransformInterface > temp_ti;
+  try
+  {
+    temp_target->target_name_ = node["target_name"].at< std::string >();
+    temp_target->target_frame_ = node["target_frame"].at< std::string >();
+    temp_target->target_type_ = node["target_type"].at< std::string >();
+    switch (temp_target->target_type_)
+    {
+      case pattern_options::Chessboard:
+        temp_target->checker_board_parameters_.pattern_rows = node["target_rows"].at< int >();
+        temp_target->checker_board_parameters_.pattern_cols = node["target_cols"].at< int >();
+        ROS_DEBUG_STREAM("TargetRows: " << temp_target->checker_board_parameters_.pattern_rows);
+        break;
+      case pattern_options::CircleGrid:
+        temp_target->circle_grid_parameters_.pattern_rows = node["target_rows"].at< int >();
+        temp_target->circle_grid_parameters_.pattern_cols = node["target_cols"].at< int >();
+        temp_target->circle_grid_parameters_.circle_diameter = ["circle_dia"].at< double >();
+        temp_target->circle_grid_parameters_.is_symmetric = true;
+        ROS_DEBUG_STREAM("TargetRows: " << temp_target->circle_grid_parameters_.pattern_rows);
+        break;
+      case pattern_options::ModifiedCircleGrid:
+        temp_target->circle_grid_parameters_.pattern_rows = node["target_rows"].at< int >();
+        temp_target->circle_grid_parameters_.pattern_cols = node["target_cols"].at< int >();
+        temp_target->circle_grid_parameters_.circle_diameter = ["circle_dia"].at< double >();
+        temp_target->circle_grid_parameters_.is_symmetric = true;
+        ROS_DEBUG_STREAM("TargetRows: " << temp_target->circle_grid_parameters_.pattern_rows);
+        break;
+      case pattern_options::Balls:
+        // no parameters yet
+        break;
+      default:
+        ROS_ERROR_STREAM("unknown pattern option (Chessboard, CircleGrid, or ModifiedCircleGrid, Balls)");
+        break;
+    }  // end of target type
+    temp_target->pose_ = parsePose(node);
+    std::string transform_interface;
+    transform_interface = node["transform_interface"].at< std::string >();
+    shared_ptr< TransformInterface > temp_ti =
+        parseTransformInterface(node, transform_interface, temp_target->target_frame_);
+    temp_target->setTransformInterface(temp_ti);  // install the transform interface
+
+    temp_target->num_points_ = node["num_points"].at< int >();
+    const Node points_node = node("points");
+    int num_points = parse_target_points(points_node, temp_target->pts_);
+    if (num_points != temp_target->num_points_)
+    {
+      ROS_ERROR("Expecting %d points found %d", temp_target->num_points_, num_points);
+    }
+  }  // end try
+  catch (YAML::ParserException& e)
+  {
+    ROS_INFO_STREAM("Failed to read target from yaml file ");
+    ROS_INFO_STREAM("target name    = " << temp_target->target_name_.c_str());
+    ROS_INFO_STREAM("target type    = " << temp_target->target_type_);
+    ROS_INFO_STREAM("target frame    = " << temp_target->target_frame_.c_str());
+    ROS_INFO_STREAM("num_points    = " << temp_target->num_points_);
+    ROS_INFO_STREAM("angle_axis_ax  = " << temp_target->pose_.ax);
+    ROS_INFO_STREAM("angle_axis_ay = " << temp_target->pose_.ay);
+    ROS_INFO_STREAM("angle_axis_az  = " << temp_target->pose_.az);
+    ROS_INFO_STREAM("position_x     = " << temp_target->pose_.x);
+    ROS_INFO_STREAM("position_y     = " << temp_target->pose_.y);
+    ROS_INFO_STREAM("position_z     = " << temp_target->pose_.z);
+  }
+  return (temp_target);
+}  // end parse_single_target
+
+int parse_target_points(const Node& node, std::vector< Point3d > points)
+{
+  ROS_DEBUG_STREAM("FoundPoints: " << node.size());
+  points.clear();
+  for (int i = 0; i < (int)node.size(); i++)
+  {
+    const YAML::Node pnt_node = node[i]("pnt");
+    std::vector< float > temp_pnt;
+    temp_pnt = pnt_node.at< std::vector< double > >();
+    Point3d temp_pnt3d;
+    temp_pnt3d.x = temp_pnt[0];
+    temp_pnt3d.y = temp_pnt[1];
+    temp_pnt3d.z = temp_pnt[2];
+    points.push_back(temp_pnt3d);
+  }
+  return (node.size());
+}
+
+}  // end of industrial_extrinsic_cal namespace

--- a/industrial_extrinsic_cal/test/ceres_utest.cpp
+++ b/industrial_extrinsic_cal/test/ceres_utest.cpp
@@ -16,8 +16,6 @@
  * limitations under the License.
  */
 
-
-
 #include <gtest/gtest.h>
 #include <yaml-cpp/yaml.h>
 #include <fstream>
@@ -29,9 +27,7 @@
 
 using namespace industrial_extrinsic_cal;
 
-
-Point3d xformPoint(Point3d &original_point, double &ax, double &ay, double &az, double &x, double&y, double &z);
-
+Point3d xformPoint(Point3d& original_point, double& ax, double& ay, double& az, double& x, double& y, double& z);
 
 class Observation
 {
@@ -75,16 +71,10 @@ Observation projectPoint(CameraParameters C, Point3d P)
   double yp2 = yp * yp;
 
   /* apply the distortion coefficients to refine pixel location */
-  double xpp = xp + C.distortion_k1 * r2 * xp 
-    + C.distortion_k2 * r4 * xp  
-    + C.distortion_k3 * r6 * xp  
-    + C.distortion_p2 * (r2 + 2 * xp2) 
-    + C.distortion_p1 * xp * yp * 2.0;
-  double ypp = yp + C.distortion_k1 * r2 * yp 
-    + C.distortion_k2 * r4 * yp 
-    + C.distortion_k3 * r6 * yp 
-    + C.distortion_p1 * (r2 + 2 * yp2) 
-    + C.distortion_p2 * xp * yp * 2.0;
+  double xpp = xp + C.distortion_k1 * r2 * xp + C.distortion_k2 * r4 * xp + C.distortion_k3 * r6 * xp +
+               C.distortion_p2 * (r2 + 2 * xp2) + C.distortion_p1 * xp * yp * 2.0;
+  double ypp = yp + C.distortion_k1 * r2 * yp + C.distortion_k2 * r4 * yp + C.distortion_k3 * r6 * yp +
+               C.distortion_p1 * (r2 + 2 * yp2) + C.distortion_p2 * xp * yp * 2.0;
 
   /* perform projection using focal length and camera center into image plane */
   Observation O;
@@ -96,11 +86,11 @@ Observation projectPoint(CameraParameters C, Point3d P)
 }
 
 // GLOBAL VARIABLES FOR TESTING
-std::vector<Point3d> created_points;
-double aa[3]; // angle axis known/set
-double p[3]; // point rotated known/set
-std::vector<Point3d> transformed_points;
-std::vector<Observation> observations;
+std::vector< Point3d > created_points;
+double aa[3];  // angle axis known/set
+double p[3];   // point rotated known/set
+std::vector< Point3d > transformed_points;
+std::vector< Observation > observations;
 CameraParameters C;
 
 TEST(IndustrialExtrinsicCalCeresSuite, rotationProduct)
@@ -116,38 +106,42 @@ TEST(IndustrialExtrinsicCalCeresSuite, rotationProduct)
   Pose6d P1, P2;
   P1.setAngleAxis(.1, .2, 3.0);
   P2 = P1.getInverse();
-  ceres::AngleAxisToRotationMatrix(P1.pb_aa,R1);
-  ceres::AngleAxisToRotationMatrix(P2.pb_aa,R2);
-  rotationProduct(R1,  R2,  R3);
+  ceres::AngleAxisToRotationMatrix(P1.pb_aa, R1);
+  ceres::AngleAxisToRotationMatrix(P2.pb_aa, R2);
+  rotationProduct(R1, R2, R3);
   // NOTE, this should work regardless of row/column major snaffos
-  for(int i=0; i<3; i++){
-    for(int j=0; j<3; j++){
-      if(i==j){
-	ASSERT_NEAR( 1.0, R3[i+3*j], .001);
+  for (int i = 0; i < 3; i++)
+  {
+    for (int j = 0; j < 3; j++)
+    {
+      if (i == j)
+      {
+        ASSERT_NEAR(1.0, R3[i + 3 * j], .001);
       }
-      else{
-	ASSERT_NEAR( 0.0, R3[i+3*j], .001);
+      else
+      {
+        ASSERT_NEAR(0.0, R3[i + 3 * j], .001);
       }
     }
   }
 }
 TEST(IndustrialExtrinsicCalCeresSuite, extractCameraIntrinsics)
 {
-  C.angle_axis[0]=0.0;
-  C.angle_axis[1]=0.0;
-  C.angle_axis[2]=0.0;
-  C.position[0]=0.0;
-  C.position[1]=0.0;
-  C.position[2]=0.0;
-  C.focal_length_x=525;
-  C.focal_length_y=525;
-  C.center_x=320;
-  C.center_y=240;
-  C.distortion_k1=0.01;
-  C.distortion_k2=0.02;
-  C.distortion_k3=0.03;
-  C.distortion_p1=0.01;
-  C.distortion_p2=0.01;
+  C.angle_axis[0] = 0.0;
+  C.angle_axis[1] = 0.0;
+  C.angle_axis[2] = 0.0;
+  C.position[0] = 0.0;
+  C.position[1] = 0.0;
+  C.position[2] = 0.0;
+  C.focal_length_x = 525;
+  C.focal_length_y = 525;
+  C.center_x = 320;
+  C.center_y = 240;
+  C.distortion_k1 = 0.01;
+  C.distortion_k2 = 0.02;
+  C.distortion_k3 = 0.03;
+  C.distortion_p1 = 0.01;
+  C.distortion_p2 = 0.01;
 
   double intrinsics[9];
   intrinsics[0] = C.focal_length_x;
@@ -182,11 +176,13 @@ TEST(IndustrialExtrinsicCalCeresSuite, rotationInverse)
   angle_axis[2] = .5;
   ceres::AngleAxisToRotationMatrix(angle_axis, R1);
   rotationInverse(R1, R2);
-  for(int i=0; i<3; i++){
-    for(int j=0; j<3; j++){
-      int index1 = i*3+j;
-      int index2 = i+j*3;
-      ASSERT_NEAR(R1[index1],R2[index2], .00001);
+  for (int i = 0; i < 3; i++)
+  {
+    for (int j = 0; j < 3; j++)
+    {
+      int index1 = i * 3 + j;
+      int index2 = i + j * 3;
+      ASSERT_NEAR(R1[index1], R2[index2], .00001);
     }
   }
 }
@@ -196,7 +192,7 @@ TEST(IndustrialExtrinsicCalCeresSuite, transformPoint)
   tx[0] = 15.0;
   tx[1] = 30.0;
   tx[2] = 23;
-  point[0] = 10.0; 
+  point[0] = 10.0;
   point[1] = -35;
   point[2] = -100;
   double angle_axis[3];
@@ -208,7 +204,7 @@ TEST(IndustrialExtrinsicCalCeresSuite, transformPoint)
 
   Pose6d pose;
   pose.setAngleAxis(angle_axis[0], angle_axis[1], angle_axis[2]);
-  pose.setOrigin(tx[0],tx[1],tx[2]);
+  pose.setOrigin(tx[0], tx[1], tx[2]);
 
   // invert transformation and apply
   Pose6d posei = pose.getInverse();
@@ -230,13 +226,13 @@ TEST(IndustrialExtrinsicCalCeresSuite, poseTransformPoint)
   Pose6d pose;
   Pose6d posei;
   double point[3];
-  point[0] = 10.0; 
+  point[0] = 10.0;
   point[1] = -35;
   point[2] = -100;
   pose.setAngleAxis(1.2, 2.2, 3.3);
   pose.setOrigin(1.2, 2.2, 3.3);
-  posei  = pose.getInverse();
-  
+  posei = pose.getInverse();
+
   double t_point[3];
   double tt_point[3];
   poseTransformPoint(pose, point, t_point);
@@ -244,17 +240,16 @@ TEST(IndustrialExtrinsicCalCeresSuite, poseTransformPoint)
   ASSERT_NEAR(tt_point[0], point[0], .00001);
   ASSERT_NEAR(tt_point[1], point[1], .00001);
   ASSERT_NEAR(tt_point[2], point[2], .00001);
-  
 }
 
 TEST(IndustrialExtrinsicCalCeresSuite, transformPoint3d)
 {
-  double  tx[3];
+  double tx[3];
   tx[0] = 15.0;
   tx[1] = 30.0;
   tx[2] = 23;
   Point3d point;
-  point.x = 10.0; 
+  point.x = 10.0;
   point.y = -35;
   point.z = -100;
   double angle_axis[3];
@@ -270,7 +265,7 @@ TEST(IndustrialExtrinsicCalCeresSuite, transformPoint3d)
 
   Pose6d pose;
   pose.setAngleAxis(angle_axis[0], angle_axis[1], angle_axis[2]);
-  pose.setOrigin(tx[0],tx[1],tx[2]);
+  pose.setOrigin(tx[0], tx[1], tx[2]);
 
   // invert transformation and apply
   Pose6d posei = pose.getInverse();
@@ -286,12 +281,11 @@ TEST(IndustrialExtrinsicCalCeresSuite, transformPoint3d)
   ASSERT_NEAR(tt_point[0], point.x, .00001);
   ASSERT_NEAR(tt_point[1], point.y, .00001);
   ASSERT_NEAR(tt_point[2], point.z, .00001);
-  
 }
 TEST(IndustrialExtrinsicCalCeresSuite, poseRotationMatrix)
 {
   Pose6d pose;
-  double ax = .5; // must use small values to avoid alternate solutions
+  double ax = .5;  // must use small values to avoid alternate solutions
   double ay = .23;
   double az = .45;
   pose.setAngleAxis(ax, ay, az);
@@ -315,7 +309,7 @@ TEST(IndustrialExtrinsicCalCeresSuite, cameraCircResidualDist)
 TEST(IndustrialExtrinsicCalCeresSuite, cameraCircResidual)
 {
 }
-// used for intrinsic cal 
+// used for intrinsic cal
 // Camera may move to several locations (multiple extrinsics)
 // target has no transform, origin is origin of target, single static target
 // points are known, no calibraition of the target itself
@@ -329,126 +323,165 @@ TEST(IndustrialExtrinsicCalCeresSuite, LinkCameraCircleTargetReprjError)
 {
 }
 
-
 TEST(IndustrialExtrinsicCalCeresSuite, create_points)
 {
   Point3d x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18, x19, x20;
-  x1.pb[0]=1.0;x1.pb[1]=1.0;x1.pb[2]=1;
+  x1.pb[0] = 1.0;
+  x1.pb[1] = 1.0;
+  x1.pb[2] = 1;
   created_points.push_back(x1);
-  x2.pb[0]=0;x2.pb[1]=0;x2.pb[2]=0.01;
+  x2.pb[0] = 0;
+  x2.pb[1] = 0;
+  x2.pb[2] = 0.01;
   created_points.push_back(x2);
-  x3.pb[0]=0.65;x3.pb[1]=0.94;x3.pb[2]=0.01;
+  x3.pb[0] = 0.65;
+  x3.pb[1] = 0.94;
+  x3.pb[2] = 0.01;
   created_points.push_back(x3);
-  x4.pb[0]=0.2;x4.pb[1]=0.3;x4.pb[2]=0.01;
+  x4.pb[0] = 0.2;
+  x4.pb[1] = 0.3;
+  x4.pb[2] = 0.01;
   created_points.push_back(x4);
-  x5.pb[0]=0.372;x5.pb[1]=0.4;x5.pb[2]=0.4;
+  x5.pb[0] = 0.372;
+  x5.pb[1] = 0.4;
+  x5.pb[2] = 0.4;
   created_points.push_back(x5);
-  x6.pb[0]=0.3762;x6.pb[1]=0.8;x6.pb[2]=0.3;
+  x6.pb[0] = 0.3762;
+  x6.pb[1] = 0.8;
+  x6.pb[2] = 0.3;
   created_points.push_back(x6);
-  x7.pb[0]=0.4;x7.pb[1]=0.389;x7.pb[2]=0.4;
+  x7.pb[0] = 0.4;
+  x7.pb[1] = 0.389;
+  x7.pb[2] = 0.4;
   created_points.push_back(x7);
-  x8.pb[0]=0.431;x8.pb[1]=0.7;x8.pb[2]=0.7;
+  x8.pb[0] = 0.431;
+  x8.pb[1] = 0.7;
+  x8.pb[2] = 0.7;
   created_points.push_back(x8);
-  x9.pb[0]=0.535;x9.pb[1]=0.9;x9.pb[2]=0.01;
+  x9.pb[0] = 0.535;
+  x9.pb[1] = 0.9;
+  x9.pb[2] = 0.01;
   created_points.push_back(x9);
-  x10.pb[0]=0.596;x10.pb[1]=1;x10.pb[2]=1.0;
+  x10.pb[0] = 0.596;
+  x10.pb[1] = 1;
+  x10.pb[2] = 1.0;
   created_points.push_back(x10);
-  x11.pb[0]=0.24;x11.pb[1]=1.0;x11.pb[2]=0.01;
+  x11.pb[0] = 0.24;
+  x11.pb[1] = 1.0;
+  x11.pb[2] = 0.01;
   created_points.push_back(x11);
-  x12.pb[0]=0.673;x12.pb[1]=1.7;x12.pb[2]=0.8;
+  x12.pb[0] = 0.673;
+  x12.pb[1] = 1.7;
+  x12.pb[2] = 0.8;
   created_points.push_back(x12);
-  x13.pb[0]=0.552;x13.pb[1]=1.15;x13.pb[2]=0.01;
+  x13.pb[0] = 0.552;
+  x13.pb[1] = 1.15;
+  x13.pb[2] = 0.01;
   created_points.push_back(x13);
-  x14.pb[0]=0.56;x14.pb[1]=0.81;x14.pb[2]=0.01;
+  x14.pb[0] = 0.56;
+  x14.pb[1] = 0.81;
+  x14.pb[2] = 0.01;
   created_points.push_back(x14);
-  x15.pb[0]=.70;x15.pb[1]=1.10;x15.pb[2]=0.01;
+  x15.pb[0] = .70;
+  x15.pb[1] = 1.10;
+  x15.pb[2] = 0.01;
   created_points.push_back(x15);
-  x16.pb[0]=0.3762;x16.pb[1]=0.02435;x16.pb[2]=0.3;
+  x16.pb[0] = 0.3762;
+  x16.pb[1] = 0.02435;
+  x16.pb[2] = 0.3;
   created_points.push_back(x16);
-  x17.pb[0]=0.0234;x17.pb[1]=0.389;x17.pb[2]=0.132;
+  x17.pb[0] = 0.0234;
+  x17.pb[1] = 0.389;
+  x17.pb[2] = 0.132;
   created_points.push_back(x17);
-  x18.pb[0]=0.431;x18.pb[1]=0.245;x18.pb[2]=0.0235;
+  x18.pb[0] = 0.431;
+  x18.pb[1] = 0.245;
+  x18.pb[2] = 0.0235;
   created_points.push_back(x18);
-  x19.pb[0]=0.535;x19.pb[1]=0.673;x19.pb[2]=0.01;
+  x19.pb[0] = 0.535;
+  x19.pb[1] = 0.673;
+  x19.pb[2] = 0.01;
   created_points.push_back(x19);
-  x20.pb[0]=0.76;x20.pb[1]=0.453;x20.pb[2]=1.0;
+  x20.pb[0] = 0.76;
+  x20.pb[1] = 0.453;
+  x20.pb[2] = 1.0;
   created_points.push_back(x20);
-  std::cout<<"Original Point 1: "<<x1.pb[0]<<" "<<x1.pb[1]<<" "<<x1.pb[2]<<std::endl;
+  std::cout << "Original Point 1: " << x1.pb[0] << " " << x1.pb[1] << " " << x1.pb[2] << std::endl;
 
-  //create known transform
+  // create known transform
   aa[0] = 2.7;
   aa[1] = 0.3;
   aa[2] = 0.1;
-  p[0]=0.2;
-  p[1]=0.4;
-  p[2]=0.5;
+  p[0] = 0.2;
+  p[1] = 0.4;
+  p[2] = 0.5;
 
   // initialize the camera parameters
-  C.angle_axis[0]=0.0;
-  C.angle_axis[1]=0.0;
-  C.angle_axis[2]=0.0;
-  C.position[0]=0.0;
-  C.position[1]=0.0;
-  C.position[2]=0.0;
-  C.focal_length_x=525;
-  C.focal_length_y=525;
-  C.center_x=320;
-  C.center_y=240;
-  C.distortion_k1=0.01;
-  C.distortion_k2=0.02;
-  C.distortion_k3=0.03;
-  C.distortion_p1=0.01;
-  C.distortion_p2=0.01;
+  C.angle_axis[0] = 0.0;
+  C.angle_axis[1] = 0.0;
+  C.angle_axis[2] = 0.0;
+  C.position[0] = 0.0;
+  C.position[1] = 0.0;
+  C.position[2] = 0.0;
+  C.focal_length_x = 525;
+  C.focal_length_y = 525;
+  C.center_x = 320;
+  C.center_y = 240;
+  C.distortion_k1 = 0.01;
+  C.distortion_k2 = 0.02;
+  C.distortion_k3 = 0.03;
+  C.distortion_p1 = 0.01;
+  C.distortion_p2 = 0.01;
 
   // transform points, and then project into image plane
   Point3d t_point;
   Observation o_point;
-  for (int i=0; i<created_points.size();i++)
-    {
-      t_point = xformPoint(created_points.at(i), aa[0], aa[1], aa[2], p[0], p[1], p[2]);
-      o_point = projectPoint(C,t_point);
-      transformed_points.push_back(t_point);
-      observations.push_back(o_point);
-    }
+  for (int i = 0; i < created_points.size(); i++)
+  {
+    t_point = xformPoint(created_points.at(i), aa[0], aa[1], aa[2], p[0], p[1], p[2]);
+    o_point = projectPoint(C, t_point);
+    transformed_points.push_back(t_point);
+    observations.push_back(o_point);
+  }
 }
 
 TEST(IndustrialExtrinsicCalCeresSuite, points_costfunction)
 {
-  //create known transform to move created points to transformed points
+  // create known transform to move created points to transformed points
   aa[0] = 2.7;
   aa[1] = 0.3;
   aa[2] = 0.1;
-  p[0]=0.2;
-  p[1]=0.4;
-  p[2]=0.5;
+  p[0] = 0.2;
+  p[1] = 0.4;
+  p[2] = 0.5;
 
   // initialize the camera parameters
-  C.angle_axis[0]=0.0;
-  C.angle_axis[1]=0.0;
-  C.angle_axis[2]=0.0;
-  C.position[0]=0.0;
-  C.position[1]=0.0;
-  C.position[2]=0.0;
-  C.focal_length_x=525;
-  C.focal_length_y=525;
-  C.center_x=320;
-  C.center_y=240;
-  C.distortion_k1=0.01;
-  C.distortion_k2=0.02;
-  C.distortion_k3=0.03;
-  C.distortion_p1=0.01;
-  C.distortion_p2=0.01;
+  C.angle_axis[0] = 0.0;
+  C.angle_axis[1] = 0.0;
+  C.angle_axis[2] = 0.0;
+  C.position[0] = 0.0;
+  C.position[1] = 0.0;
+  C.position[2] = 0.0;
+  C.focal_length_x = 525;
+  C.focal_length_y = 525;
+  C.center_x = 320;
+  C.center_y = 240;
+  C.distortion_k1 = 0.01;
+  C.distortion_k2 = 0.02;
+  C.distortion_k3 = 0.03;
+  C.distortion_p1 = 0.01;
+  C.distortion_p2 = 0.01;
 
   // transform points, and then project into image plane
   Point3d t_point;
   Observation o_point;
-  for (int i=0; i<created_points.size();i++)
-    {
-      t_point = xformPoint(created_points.at(i), aa[0], aa[1], aa[2], p[0], p[1], p[2]);
-      o_point = projectPoint(C,t_point);
-      transformed_points.push_back(t_point);
-      observations.push_back(o_point);
-    }
+  for (int i = 0; i < created_points.size(); i++)
+  {
+    t_point = xformPoint(created_points.at(i), aa[0], aa[1], aa[2], p[0], p[1], p[2]);
+    o_point = projectPoint(C, t_point);
+    transformed_points.push_back(t_point);
+    observations.push_back(o_point);
+  }
 
   double extrinsics[6];
   extrinsics[0] = C.angle_axis[0];
@@ -457,7 +490,7 @@ TEST(IndustrialExtrinsicCalCeresSuite, points_costfunction)
   extrinsics[3] = C.position[0];
   extrinsics[4] = C.position[1];
   extrinsics[5] = C.position[2];
-  
+
   double intrinsics[9];
   intrinsics[0] = C.focal_length_x;
   intrinsics[1] = C.focal_length_y;
@@ -471,28 +504,28 @@ TEST(IndustrialExtrinsicCalCeresSuite, points_costfunction)
   ceres::Problem problem;
   // when points, extrinsics, and intrinsics are not perturbed, there should be very little re-projection error
   for (int j = 0; j < transformed_points.size(); ++j)
-    {
-      double ox = observations[j].image_loc_x;
-      double oy = observations[j].image_loc_y;
-      ceres::CostFunction* cost_function = CameraReprjErrorWithDistortion::Create(ox, oy);
-      problem.AddResidualBlock(cost_function, NULL, extrinsics, intrinsics, transformed_points[j].pb);
-      double residual[2];
-      CameraReprjErrorWithDistortion CFC(ox, oy);
-      CFC(extrinsics, intrinsics, transformed_points[j].pb, residual);
-      // no reprojection error should be observed
-      ASSERT_NEAR(0.0, residual[0], .1);
-      ASSERT_NEAR(0.0, residual[1], .1);
-    }
+  {
+    double ox = observations[j].image_loc_x;
+    double oy = observations[j].image_loc_y;
+    ceres::CostFunction* cost_function = CameraReprjErrorWithDistortion::Create(ox, oy);
+    problem.AddResidualBlock(cost_function, NULL, extrinsics, intrinsics, transformed_points[j].pb);
+    double residual[2];
+    CameraReprjErrorWithDistortion CFC(ox, oy);
+    CFC(extrinsics, intrinsics, transformed_points[j].pb, residual);
+    // no reprojection error should be observed
+    ASSERT_NEAR(0.0, residual[0], .1);
+    ASSERT_NEAR(0.0, residual[1], .1);
+  }
 
   // optimization should therefore not do anything either
   ceres::Solver::Options options;
   options.linear_solver_type = ceres::DENSE_SCHUR;
   options.minimizer_progress_to_stdout = false;
   options.max_num_iterations = 1000;
-  
+
   ceres::Solver::Summary summary;
   ceres::Solve(options, &problem, &summary);
-  
+
   // no changes due to optimization
   ASSERT_NEAR(C.angle_axis[0], extrinsics[0], .1);
   ASSERT_NEAR(C.angle_axis[1], extrinsics[1], .1);
@@ -510,47 +543,45 @@ TEST(IndustrialExtrinsicCalCeresSuite, points_costfunction)
   ASSERT_NEAR(C.distortion_k3, intrinsics[6], .1);
   ASSERT_NEAR(C.distortion_p1, intrinsics[7], .1);
   ASSERT_NEAR(C.distortion_p2, intrinsics[8], .1);
-
 }
-
 
 TEST(IndustrialExtrinsicCalCeresSuite, circle_cost)
 {
-  //create known transform to move created points to transformed points
+  // create known transform to move created points to transformed points
   aa[0] = 2.7;
   aa[1] = 0.3;
   aa[2] = 0.1;
-  p[0]=0.2;
-  p[1]=0.4;
-  p[2]=0.5;
+  p[0] = 0.2;
+  p[1] = 0.4;
+  p[2] = 0.5;
 
   // initialize the camera parameters
-  C.angle_axis[0]=0.0;
-  C.angle_axis[1]=0.0;
-  C.angle_axis[2]=0.0;
-  C.position[0]=0.0;
-  C.position[1]=0.0;
-  C.position[2]=0.0;
-  C.focal_length_x=525;
-  C.focal_length_y=525;
-  C.center_x=320;
-  C.center_y=240;
-  C.distortion_k1=0.01;
-  C.distortion_k2=0.02;
-  C.distortion_k3=0.03;
-  C.distortion_p1=0.01;
-  C.distortion_p2=0.01;
+  C.angle_axis[0] = 0.0;
+  C.angle_axis[1] = 0.0;
+  C.angle_axis[2] = 0.0;
+  C.position[0] = 0.0;
+  C.position[1] = 0.0;
+  C.position[2] = 0.0;
+  C.focal_length_x = 525;
+  C.focal_length_y = 525;
+  C.center_x = 320;
+  C.center_y = 240;
+  C.distortion_k1 = 0.01;
+  C.distortion_k2 = 0.02;
+  C.distortion_k3 = 0.03;
+  C.distortion_p1 = 0.01;
+  C.distortion_p2 = 0.01;
 
   // transform points, and then project into image plane
   Point3d t_point;
   Observation o_point;
-  for (int i=0; i<created_points.size();i++)
-    {
-      t_point = xformPoint(created_points.at(i), aa[0], aa[1], aa[2], p[0], p[1], p[2]);
-      o_point = projectPoint(C,t_point);
-      transformed_points.push_back(t_point);
-      observations.push_back(o_point);
-    }
+  for (int i = 0; i < created_points.size(); i++)
+  {
+    t_point = xformPoint(created_points.at(i), aa[0], aa[1], aa[2], p[0], p[1], p[2]);
+    o_point = projectPoint(C, t_point);
+    transformed_points.push_back(t_point);
+    observations.push_back(o_point);
+  }
 
   double extrinsics[6];
   extrinsics[0] = C.angle_axis[0];
@@ -559,7 +590,7 @@ TEST(IndustrialExtrinsicCalCeresSuite, circle_cost)
   extrinsics[3] = C.position[0];
   extrinsics[4] = C.position[1];
   extrinsics[5] = C.position[2];
-  
+
   double intrinsics[9];
   intrinsics[0] = C.focal_length_x;
   intrinsics[1] = C.focal_length_y;
@@ -573,28 +604,28 @@ TEST(IndustrialExtrinsicCalCeresSuite, circle_cost)
   ceres::Problem problem;
   // when points, extrinsics, and intrinsics are not perturbed, there should be very little re-projection error
   for (int j = 0; j < transformed_points.size(); ++j)
-    {
-      double ox = observations[j].image_loc_x;
-      double oy = observations[j].image_loc_y;
-      ceres::CostFunction* cost_function = CameraReprjErrorWithDistortion::Create(ox, oy);
-      problem.AddResidualBlock(cost_function, NULL, extrinsics, intrinsics, transformed_points[j].pb);
-      double residual[2];
-      CameraReprjErrorWithDistortion CFC(ox, oy);
-      CFC(extrinsics, intrinsics, transformed_points[j].pb, residual);
-      // no reprojection error should be observed
-      ASSERT_NEAR(0.0, residual[0], .1);
-      ASSERT_NEAR(0.0, residual[1], .1);
-    }
+  {
+    double ox = observations[j].image_loc_x;
+    double oy = observations[j].image_loc_y;
+    ceres::CostFunction* cost_function = CameraReprjErrorWithDistortion::Create(ox, oy);
+    problem.AddResidualBlock(cost_function, NULL, extrinsics, intrinsics, transformed_points[j].pb);
+    double residual[2];
+    CameraReprjErrorWithDistortion CFC(ox, oy);
+    CFC(extrinsics, intrinsics, transformed_points[j].pb, residual);
+    // no reprojection error should be observed
+    ASSERT_NEAR(0.0, residual[0], .1);
+    ASSERT_NEAR(0.0, residual[1], .1);
+  }
 
   // optimization should therefore not do anything either
   ceres::Solver::Options options;
   options.linear_solver_type = ceres::DENSE_SCHUR;
   options.minimizer_progress_to_stdout = false;
   options.max_num_iterations = 1000;
-  
+
   ceres::Solver::Summary summary;
   ceres::Solve(options, &problem, &summary);
-  
+
   // no changes due to optimization
   ASSERT_NEAR(C.angle_axis[0], extrinsics[0], .1);
   ASSERT_NEAR(C.angle_axis[1], extrinsics[1], .1);
@@ -612,51 +643,49 @@ TEST(IndustrialExtrinsicCalCeresSuite, circle_cost)
   ASSERT_NEAR(C.distortion_k3, intrinsics[6], .1);
   ASSERT_NEAR(C.distortion_p1, intrinsics[7], .1);
   ASSERT_NEAR(C.distortion_p2, intrinsics[8], .1);
-
 }
 
-
-
-Point3d xformPoint(Point3d &original_point, double &ax, double &ay, double &az, double &x, double&y, double &z)
+Point3d xformPoint(Point3d& original_point, double& ax, double& ay, double& az, double& x, double& y, double& z)
 {
-  //std::cout<<"ange axis inputs ax, ay, az: "<<ax<<", "<<ay<<", "<<az<<std::endl;
+  // std::cout<<"ange axis inputs ax, ay, az: "<<ax<<", "<<ay<<", "<<az<<std::endl;
   Eigen::Matrix3f m_ceres;
   Eigen::Matrix3f m_eigen;
-  m_eigen = Eigen::AngleAxisf(ax, Eigen::Vector3f::UnitX())
-    * Eigen::AngleAxisf(ay, Eigen::Vector3f::UnitY())
-    * Eigen::AngleAxisf(az, Eigen::Vector3f::UnitZ());
-  //std::cout<<"m_eigen : "<<std::endl<< m_eigen <<std::endl;
-  double aa[3]; // angle axis
-  double p[3]; // point rotated
+  m_eigen = Eigen::AngleAxisf(ax, Eigen::Vector3f::UnitX()) * Eigen::AngleAxisf(ay, Eigen::Vector3f::UnitY()) *
+            Eigen::AngleAxisf(az, Eigen::Vector3f::UnitZ());
+  // std::cout<<"m_eigen : "<<std::endl<< m_eigen <<std::endl;
+  double aa[3];  // angle axis
+  double p[3];   // point rotated
   aa[0] = ax;
   aa[1] = ay;
   aa[2] = az;
   Eigen::Vector3f orig_point(original_point.pb[0], original_point.pb[1], original_point.pb[2]);
-  //std::cout<<"within transformPoint, original point Vector3f x, y, z: "<<orig_point.x()<<", "<<orig_point.y()<<", "<<orig_point.z()<<std::endl;
+  // std::cout<<"within transformPoint, original point Vector3f x, y, z: "<<orig_point.x()<<", "<<orig_point.y()<<",
+  // "<<orig_point.z()<<std::endl;
 
   double R[9];
   ceres::AngleAxisToRotationMatrix(aa, R);
-  m_ceres << R[0], R[1],R[2],
-    R[3], R[4], R[5],
-    R[6], R[7], R[8];
-  //std::cout<<"m_ceres : "<<std::endl<< m_ceres <<std::endl;
-  Eigen::Vector3f rot_point=m_ceres*orig_point;
-  //std::cout<<"within transformPoint, rotated point Vector3f x, y, z: "<<rot_point.x()<<", "<<rot_point.y()<<", "<<rot_point.z()<<std::endl;
-  double xp1 = rot_point.x() + x; // point rotated and translated
+  m_ceres << R[0], R[1], R[2], R[3], R[4], R[5], R[6], R[7], R[8];
+  // std::cout<<"m_ceres : "<<std::endl<< m_ceres <<std::endl;
+  Eigen::Vector3f rot_point = m_ceres * orig_point;
+  // std::cout<<"within transformPoint, rotated point Vector3f x, y, z: "<<rot_point.x()<<", "<<rot_point.y()<<",
+  // "<<rot_point.z()<<std::endl;
+  double xp1 = rot_point.x() + x;  // point rotated and translated
   double yp1 = rot_point.y() + y;
   double zp1 = rot_point.z() + z;
-  //std::cout<<"within transformPoint, original point double x, y, z: "<<xp1<<", "<<yp1<<", "<<zp1<<std::endl;
+  // std::cout<<"within transformPoint, original point double x, y, z: "<<xp1<<", "<<yp1<<", "<<zp1<<std::endl;
   Point3d t_point;
-  t_point.pb[0]=xp1;t_point.pb[1]=yp1;t_point.pb[2]=zp1;
-  //std::cout<<"within transformPoint, t_point x, y, z: "<<t_point.pb[0]<<", "<<t_point.pb[1]<<", "<<t_point.pb[2]<<std::endl;
+  t_point.pb[0] = xp1;
+  t_point.pb[1] = yp1;
+  t_point.pb[2] = zp1;
+  // std::cout<<"within transformPoint, t_point x, y, z: "<<t_point.pb[0]<<", "<<t_point.pb[1]<<",
+  // "<<t_point.pb[2]<<std::endl;
   return t_point;
 }
 
 // Run all the tests that were declared with TEST()
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
-  //ros::init(argc, argv, "test");
+  // ros::init(argc, argv, "test");
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
-
 }

--- a/industrial_extrinsic_cal/test/utest.cpp
+++ b/industrial_extrinsic_cal/test/utest.cpp
@@ -27,7 +27,6 @@
 
 TEST(IndustrialExtrinsicCalSuite, loadCamera)
 {
-  
   ros::NodeHandle nh("~");
   std::string yaml_path;
   // set test/yaml_file_path to the test/yaml directory
@@ -36,20 +35,21 @@ TEST(IndustrialExtrinsicCalSuite, loadCamera)
   std::string camera_file("/test_cameras.yaml");
   std::string target_file("/test_targets.yaml");
   std::string caljob_file("/test_caljob.yaml");
-  industrial_extrinsic_cal::CalibrationJob cal_job(yaml_path+camera_file, yaml_path+target_file, yaml_path+caljob_file);
-  EXPECT_TRUE(cal_job.load()); // read in cameras, targets, and scenes
-  industrial_extrinsic_cal::CeresBlocks * cblocks = cal_job.getBlocks();
-  std::vector<industrial_extrinsic_cal::ObservationScene> * scenes = cal_job.getScenes();
+  industrial_extrinsic_cal::CalibrationJob cal_job(yaml_path + camera_file, yaml_path + target_file,
+                                                   yaml_path + caljob_file);
+  EXPECT_TRUE(cal_job.load());  // read in cameras, targets, and scenes
+  industrial_extrinsic_cal::CeresBlocks* cblocks = cal_job.getBlocks();
+  std::vector< industrial_extrinsic_cal::ObservationScene >* scenes = cal_job.getScenes();
   // now, compare the data in these to that expected
-  EXPECT_EQ((int) scenes->size(), 2);
+  EXPECT_EQ((int)scenes->size(), 2);
   EXPECT_EQ((*scenes)[0].get_id(), 0);
   EXPECT_EQ((*scenes)[1].get_id(), 1);
 
   // cursury check to see if the targets were loaded by names
-  boost::shared_ptr<industrial_extrinsic_cal::Target> T1 = boost::make_shared<industrial_extrinsic_cal::Target>();
-  boost::shared_ptr<industrial_extrinsic_cal::Target> T2 = boost::make_shared<industrial_extrinsic_cal::Target>();
-  boost::shared_ptr<industrial_extrinsic_cal::Target> T3 = boost::make_shared<industrial_extrinsic_cal::Target>();
-  boost::shared_ptr<industrial_extrinsic_cal::Target> T4 = boost::make_shared<industrial_extrinsic_cal::Target>();
+  boost::shared_ptr< industrial_extrinsic_cal::Target > T1 = boost::make_shared< industrial_extrinsic_cal::Target >();
+  boost::shared_ptr< industrial_extrinsic_cal::Target > T2 = boost::make_shared< industrial_extrinsic_cal::Target >();
+  boost::shared_ptr< industrial_extrinsic_cal::Target > T3 = boost::make_shared< industrial_extrinsic_cal::Target >();
+  boost::shared_ptr< industrial_extrinsic_cal::Target > T4 = boost::make_shared< industrial_extrinsic_cal::Target >();
   T1 = cblocks->getTargetByName("Chessboard");
   EXPECT_EQ(T1->target_name_, "Chessboard");
   T2 = cblocks->getTargetByName("CircleGrid");
@@ -60,10 +60,10 @@ TEST(IndustrialExtrinsicCalSuite, loadCamera)
   EXPECT_EQ(T4->target_name_, "Balls");
 
   // cursury check to see if the cameras were loaded by names
-  boost::shared_ptr<industrial_extrinsic_cal::Camera> C1 = boost::make_shared<industrial_extrinsic_cal::Camera>();
-  boost::shared_ptr<industrial_extrinsic_cal::Camera> C2 = boost::make_shared<industrial_extrinsic_cal::Camera>();
-  boost::shared_ptr<industrial_extrinsic_cal::Camera> C3 = boost::make_shared<industrial_extrinsic_cal::Camera>();
-  boost::shared_ptr<industrial_extrinsic_cal::Camera> C4 = boost::make_shared<industrial_extrinsic_cal::Camera>();
+  boost::shared_ptr< industrial_extrinsic_cal::Camera > C1 = boost::make_shared< industrial_extrinsic_cal::Camera >();
+  boost::shared_ptr< industrial_extrinsic_cal::Camera > C2 = boost::make_shared< industrial_extrinsic_cal::Camera >();
+  boost::shared_ptr< industrial_extrinsic_cal::Camera > C3 = boost::make_shared< industrial_extrinsic_cal::Camera >();
+  boost::shared_ptr< industrial_extrinsic_cal::Camera > C4 = boost::make_shared< industrial_extrinsic_cal::Camera >();
   C1 = cblocks->getCameraByName("asus1");
   EXPECT_EQ(C1->camera_name_, "asus1");
   C2 = cblocks->getCameraByName("asus2");
@@ -72,12 +72,10 @@ TEST(IndustrialExtrinsicCalSuite, loadCamera)
   EXPECT_EQ(C3->camera_name_, "asus6");
   C4 = cblocks->getCameraByName("asus7");
   EXPECT_EQ(C4->camera_name_, "asus7");
-
-  
 }
 
 // Run all the tests that were declared with TEST()
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
   ros::init(argc, argv, "test");
   testing::InitGoogleTest(&argc, argv);
@@ -85,5 +83,5 @@ int main(int argc, char **argv)
   spinner.start();
   bool rtn = RUN_ALL_TESTS();
   ros::waitForShutdown();
-  return(rtn);
+  return (rtn);
 }

--- a/intrinsic_cal/src/create_ical_scenes.cpp
+++ b/intrinsic_cal/src/create_ical_scenes.cpp
@@ -12,7 +12,7 @@ int main(int argc, char** argv)
   std::string image_topic;
   std::string target_name;
   std::string cost_type("CameraReprjErrorWithDistortionPK");
-  int target_type=2;
+  int target_type = 2;
   int sample_rows;
   int sample_cols;
   int sample_layers;
@@ -20,119 +20,138 @@ int main(int argc, char** argv)
   double max_image_percent;
   std::string ref_frame("world_frame");
   int image_width, image_height;
-  FILE *fp;
-  
+  FILE* fp;
+
   // essential parameters
-  if(!nh.getParam("caljob_filename", caljob_filename)){
+  if (!nh.getParam("caljob_filename", caljob_filename))
+  {
     ROS_ERROR("Need to define ros parameter: caljob_filename");
     exit(1);
   }
-  if(!nh.getParam("target_name", target_name)){
+  if (!nh.getParam("target_name", target_name))
+  {
     ROS_ERROR("Need to define ros parameter: target_name");
     exit(1);
   }
-  if(!nh.getParam("camera_name", camera_name)){
+  if (!nh.getParam("camera_name", camera_name))
+  {
     ROS_ERROR("Need to define ros parameter: camera_name");
     exit(1);
   }
-  if(!nh.getParam("image_width", image_width)){
+  if (!nh.getParam("image_width", image_width))
+  {
     ROS_ERROR("Need to define ros parameter: image_width");
     exit(1);
   }
-  if(!nh.getParam("image_topic", image_topic)){
+  if (!nh.getParam("image_topic", image_topic))
+  {
     ROS_ERROR("Need to define ros parameter: image_topic");
     exit(1);
   }
-  if(!nh.getParam("image_height", image_height)){
+  if (!nh.getParam("image_height", image_height))
+  {
     ROS_ERROR("Need to define ros parameter: image_height");
     exit(1);
   }
-  if(!nh.getParam("sample_rows", sample_rows)){
+  if (!nh.getParam("sample_rows", sample_rows))
+  {
     ROS_ERROR("Need to define ros parameter: sample_rows");
     exit(1);
   }
-  if(!nh.getParam("sample_cols", sample_cols)){
+  if (!nh.getParam("sample_cols", sample_cols))
+  {
     ROS_ERROR("Need to define ros parameter: sample_cols");
     exit(1);
   }
-  if(!nh.getParam("sample_layers", sample_layers)){
+  if (!nh.getParam("sample_layers", sample_layers))
+  {
     ROS_ERROR("Need to define ros parameter: sample_layers");
     exit(1);
   }
-  if(!nh.getParam("min_image_percent", min_image_percent)){
+  if (!nh.getParam("min_image_percent", min_image_percent))
+  {
     ROS_ERROR("Need to define ros parameter: min_image_percent");
     exit(1);
   }
-  if(!nh.getParam("max_image_percent", max_image_percent)){
+  if (!nh.getParam("max_image_percent", max_image_percent))
+  {
     ROS_ERROR("Need to define ros parameter: max_image_percent");
     exit(1);
   }
-  
+
   // non-essential parameters
   nh.getParam("reference_frame", ref_frame);
   nh.getParam("target_type", target_type);
   nh.getParam("cost_type", cost_type);
-    
+
   // check for valid parameters
-  if(min_image_percent <1.0 || min_image_percent > 99.0){
+  if (min_image_percent < 1.0 || min_image_percent > 99.0)
+  {
     ROS_ERROR("min_image_percent not valid %f", min_image_percent);
   }
-  if(max_image_percent <2.0 || max_image_percent > 100.0 || max_image_percent < min_image_percent){
+  if (max_image_percent < 2.0 || max_image_percent > 100.0 || max_image_percent < min_image_percent)
+  {
     ROS_ERROR("max_image_percent not valid %f", max_image_percent);
   }
-  if(sample_layers<=1){
+  if (sample_layers <= 1)
+  {
     ROS_ERROR("sample_layers not valid");
     exit(1);
   }
-  if(!(fp= fopen(caljob_filename.c_str(), "w"))){
+  if (!(fp = fopen(caljob_filename.c_str(), "w")))
+  {
     ROS_ERROR("could not open %s for writing", caljob_filename.c_str());
     exit(1);
   }
-  if(target_type<0 || target_type>3){
+  if (target_type < 0 || target_type > 3)
+  {
     ROS_ERROR("target_type not valid %d", target_type);
   }
-  
+
   // write the header
-  fprintf(fp,"---\n");
-  fprintf(fp,"reference_frame: %s\n", ref_frame.c_str());
-  fprintf(fp,"scenes:\n");
+  fprintf(fp, "---\n");
+  fprintf(fp, "reference_frame: %s\n", ref_frame.c_str());
+  fprintf(fp, "scenes:\n");
   int scene_id = 0;
   int roi_width;
   int roi_height;
-  
-  double percent_change = (max_image_percent - min_image_percent)/100/(sample_layers -1.0);
+
+  double percent_change = (max_image_percent - min_image_percent) / 100 / (sample_layers - 1.0);
   double portion;
-  for(portion = min_image_percent/100.0; portion <= max_image_percent/100.0; portion += percent_change){
-    roi_width = image_width*portion;
-    roi_height = image_height*portion;
-    for(int i=0; i<sample_rows; i++){
-      for(int j=0; j<sample_cols; j++){
-	int x = i*(image_width- roi_width)/(sample_rows-1.0);
-	int y = j*(image_height-roi_height)/(sample_cols-1.0);
-	fprintf(fp,"-\n");
-	fprintf(fp,"    trigger: ROS_CAMERA_OBSERVER_TRIGGER\n");
-	fprintf(fp,"    trigger_parameters:\n");
-	fprintf(fp,"    -\n");
-	fprintf(fp,"         service_name: ObserverTrigger\n");
-	fprintf(fp,"         instructions: Center target within region of interest\n");
-	fprintf(fp,"         image_topic: %s\n", image_topic.c_str());
-	fprintf(fp,"         target_type: %d\n",target_type);
-	fprintf(fp,"         roi_min_x: %d\n", x);
-	fprintf(fp,"         roi_max_x: %d\n", x+roi_width);
-	fprintf(fp,"         roi_min_y: %d\n", y);
-	fprintf(fp,"         roi_max_y: %d\n", y+roi_height);
-	fprintf(fp,"    observations:\n");
-	fprintf(fp,"    -\n");
-	fprintf(fp,"        camera: %s\n", camera_name.c_str());
-	fprintf(fp,"        target: %s\n", target_name.c_str());
-	fprintf(fp,"        roi_x_min: %d\n", x);
-	fprintf(fp,"        roi_x_max: %d\n", x+roi_width);
-	fprintf(fp,"        roi_y_min: %d\n", y);
-	fprintf(fp,"        roi_y_max: %d\n", y+roi_height);
-	fprintf(fp,"        cost_type: %s\n", cost_type.c_str());
-      }//end each column
-    }// end each row
-  }// end each layer
-  fprintf(fp,"optimization_parameters: xx\n");
+  for (portion = min_image_percent / 100.0; portion <= max_image_percent / 100.0; portion += percent_change)
+  {
+    roi_width = image_width * portion;
+    roi_height = image_height * portion;
+    for (int i = 0; i < sample_rows; i++)
+    {
+      for (int j = 0; j < sample_cols; j++)
+      {
+        int x = i * (image_width - roi_width) / (sample_rows - 1.0);
+        int y = j * (image_height - roi_height) / (sample_cols - 1.0);
+        fprintf(fp, "-\n");
+        fprintf(fp, "    trigger: ROS_CAMERA_OBSERVER_TRIGGER\n");
+        fprintf(fp, "    trigger_parameters:\n");
+        fprintf(fp, "    -\n");
+        fprintf(fp, "         service_name: ObserverTrigger\n");
+        fprintf(fp, "         instructions: Center target within region of interest\n");
+        fprintf(fp, "         image_topic: %s\n", image_topic.c_str());
+        fprintf(fp, "         target_type: %d\n", target_type);
+        fprintf(fp, "         roi_min_x: %d\n", x);
+        fprintf(fp, "         roi_max_x: %d\n", x + roi_width);
+        fprintf(fp, "         roi_min_y: %d\n", y);
+        fprintf(fp, "         roi_max_y: %d\n", y + roi_height);
+        fprintf(fp, "    observations:\n");
+        fprintf(fp, "    -\n");
+        fprintf(fp, "        camera: %s\n", camera_name.c_str());
+        fprintf(fp, "        target: %s\n", target_name.c_str());
+        fprintf(fp, "        roi_x_min: %d\n", x);
+        fprintf(fp, "        roi_x_max: %d\n", x + roi_width);
+        fprintf(fp, "        roi_y_min: %d\n", y);
+        fprintf(fp, "        roi_y_max: %d\n", y + roi_height);
+        fprintf(fp, "        cost_type: %s\n", cost_type.c_str());
+      }  // end each column
+    }    // end each row
+  }      // end each layer
+  fprintf(fp, "optimization_parameters: xx\n");
   fclose(fp);
 }

--- a/intrinsic_cal/src/rail_cal.cpp
+++ b/intrinsic_cal/src/rail_cal.cpp
@@ -27,8 +27,8 @@
 #include <industrial_extrinsic_cal/ros_camera_observer.h>
 #include <industrial_extrinsic_cal/basic_types.h>
 #include <industrial_extrinsic_cal/camera_definition.h>
-#include <industrial_extrinsic_cal/ceres_costs_utils.h> 
-#include <industrial_extrinsic_cal/ceres_costs_utils.hpp> 
+#include <industrial_extrinsic_cal/ceres_costs_utils.h>
+#include <industrial_extrinsic_cal/ceres_costs_utils.hpp>
 #include <intrinsic_cal/rail_ical_run.h>
 #include "ceres/ceres.h"
 #include "ceres/rotation.h"
@@ -50,13 +50,13 @@ using industrial_extrinsic_cal::Camera;
 using industrial_extrinsic_cal::CameraParameters;
 using industrial_extrinsic_cal::NoWaitTrigger;
 
-class RailCalService 
+class RailCalService
 {
 public:
   RailCalService(ros::NodeHandle nh);
-  ~RailCalService()  {  } ;
-  bool executeCallBack( intrinsic_cal::rail_ical_run::Request &req, intrinsic_cal::rail_ical_run::Response &res);
-  void  initMCircleTarget(int rows, int cols, double circle_dia, double spacing);
+  ~RailCalService(){};
+  bool executeCallBack(intrinsic_cal::rail_ical_run::Request& req, intrinsic_cal::rail_ical_run::Response& res);
+  void initMCircleTarget(int rows, int cols, double circle_dia, double spacing);
   void cameraCallback(const sensor_msgs::Image& image);
 
 private:
@@ -64,8 +64,8 @@ private:
   ros::ServiceServer rail_cal_server_;
   ros::Subscriber rgb_sub_;
   ros::Publisher rgb_pub_;
-  shared_ptr<Target> target_;
-  shared_ptr<Camera> camera_;
+  shared_ptr< Target > target_;
+  shared_ptr< Camera > camera_;
   double focal_length_x_;
   double focal_length_y_;
   double center_x_;
@@ -88,56 +88,66 @@ private:
 
 RailCalService::RailCalService(ros::NodeHandle nh)
 {
-  
   nh_ = nh;
   ros::NodeHandle pnh("~");
 
-  if(!pnh.getParam( "image_topic", image_topic_)){
+  if (!pnh.getParam("image_topic", image_topic_))
+  {
     ROS_ERROR("Must set param:  image_topic");
   }
 
-  if(!pnh.getParam( "camera_name", camera_name_)){
+  if (!pnh.getParam("camera_name", camera_name_))
+  {
     ROS_ERROR("Must set param:  camera_name");
   }
 
   target_type_ == pattern_options::ModifiedCircleGrid;
 
-  if(!pnh.getParam( "target_rows", target_rows_)){
+  if (!pnh.getParam("target_rows", target_rows_))
+  {
     ROS_ERROR("Must set param:  target_rows");
   }
-  if(!pnh.getParam( "target_cols", target_cols_)){
+  if (!pnh.getParam("target_cols", target_cols_))
+  {
     ROS_ERROR("Must set param:  target_cols");
   }
-  if(!pnh.getParam( "target_circle_dia", circle_diameter_)){
+  if (!pnh.getParam("target_circle_dia", circle_diameter_))
+  {
     ROS_ERROR("Must set param:  target_circle_dia");
   }
-  if(!pnh.getParam( "target_spacing", circle_spacing_)){
+  if (!pnh.getParam("target_spacing", circle_spacing_))
+  {
     ROS_ERROR("Must set param:  target_spacing");
   }
-  if(!pnh.getParam( "num_camera_locations", num_camera_locations_)){
+  if (!pnh.getParam("num_camera_locations", num_camera_locations_))
+  {
     ROS_ERROR("Must set param:  num_camera_locations");
   }
-  if(!pnh.getParam( "camera_spacing", camera_spacing_)){
+  if (!pnh.getParam("camera_spacing", camera_spacing_))
+  {
     ROS_ERROR("Must set param:  camera_spacing");
   }
-  if(!pnh.getParam( "image_height", image_height_)){
+  if (!pnh.getParam("image_height", image_height_))
+  {
     ROS_ERROR("Must set param:  image_height_");
   }
-  if(!pnh.getParam( "image_width", image_width_)){
+  if (!pnh.getParam("image_width", image_width_))
+  {
     ROS_ERROR("Must set param:  image_width_");
   }
-  if(!pnh.getParam( "target_to_rail_distance", D0_)){
+  if (!pnh.getParam("target_to_rail_distance", D0_))
+  {
     ROS_ERROR("Must set param:  target_to_rail_distance");
   }
 
   bool use_quaternion = false;
-  if(pnh.getParam( "qx", qx_))
+  if (pnh.getParam("qx", qx_))
   {
-    if(pnh.getParam( "qy", qy_))
+    if (pnh.getParam("qy", qy_))
     {
-      if(pnh.getParam( "qz", qz_))
+      if (pnh.getParam("qz", qz_))
       {
-        if(pnh.getParam( "qw", qw_))
+        if (pnh.getParam("qw", qw_))
         {
           use_quaternion = true;
         }
@@ -147,70 +157,64 @@ RailCalService::RailCalService(ros::NodeHandle nh)
 
   u_int32_t queue_size = 5;
   rgb_sub_ = nh_.subscribe("color_image", queue_size, &RailCalService::cameraCallback, this);
-  rgb_pub_ = nh_.advertise<sensor_msgs::Image>("color_image_center", 1);
+  rgb_pub_ = nh_.advertise< sensor_msgs::Image >("color_image_center", 1);
 
-  if(!use_quaternion)
+  if (!use_quaternion)
   {
     qx_ = 1.0;
     qy_ = qz_ = qw_ = 0.0;
-    ROS_WARN("parameters qx, qy, qz, and qw not provided, using default values of (%.2f, %.2f, %.2f, %.2f)", qx_, qy_, qz_, qw_);
+    ROS_WARN("parameters qx, qy, qz, and qw not provided, using default values of (%.2f, %.2f, %.2f, %.2f)", qx_, qy_,
+             qz_, qw_);
   }
 
   bool is_moving = true;
-  camera_ =  boost::make_shared<industrial_extrinsic_cal::Camera>("my_camera", camera_parameters_, is_moving);
-  camera_->trigger_ = boost::make_shared<NoWaitTrigger>();
-  camera_->camera_observer_ = boost::make_shared<ROSCameraObserver>(image_topic_, camera_name_);
-  if(!camera_->camera_observer_->pullCameraInfo(camera_->camera_parameters_.focal_length_x,
-                                           camera_->camera_parameters_.focal_length_y,
-                                           camera_->camera_parameters_.center_x,
-                                           camera_->camera_parameters_.center_y,
-                                           camera_->camera_parameters_.distortion_k1,
-                                           camera_->camera_parameters_.distortion_k2,
-                                           camera_->camera_parameters_.distortion_k3,
-                                           camera_->camera_parameters_.distortion_p1,
-                                           camera_->camera_parameters_.distortion_p2,
-                                           image_width_, image_height_))
+  camera_ = boost::make_shared< industrial_extrinsic_cal::Camera >("my_camera", camera_parameters_, is_moving);
+  camera_->trigger_ = boost::make_shared< NoWaitTrigger >();
+  camera_->camera_observer_ = boost::make_shared< ROSCameraObserver >(image_topic_, camera_name_);
+  if (!camera_->camera_observer_->pullCameraInfo(
+          camera_->camera_parameters_.focal_length_x, camera_->camera_parameters_.focal_length_y,
+          camera_->camera_parameters_.center_x, camera_->camera_parameters_.center_y,
+          camera_->camera_parameters_.distortion_k1, camera_->camera_parameters_.distortion_k2,
+          camera_->camera_parameters_.distortion_k3, camera_->camera_parameters_.distortion_p1,
+          camera_->camera_parameters_.distortion_p2, image_width_, image_height_))
   {
-    ROS_FATAL("Could not get camera information for %s from topic %s. Shutting down node.", camera_name_.c_str(), image_topic_.c_str());
+    ROS_FATAL("Could not get camera information for %s from topic %s. Shutting down node.", camera_name_.c_str(),
+              image_topic_.c_str());
     ros::shutdown();
   }
 
   ROS_INFO("initial camera info focal:%f %f center:%f %f  radial:%f %f %f tang: %f %f",
-            camera_->camera_parameters_.focal_length_x,
-            camera_->camera_parameters_.focal_length_y,
-            camera_->camera_parameters_.center_x,
-            camera_->camera_parameters_.center_y,
-            camera_->camera_parameters_.distortion_k1,
-            camera_->camera_parameters_.distortion_k2,
-            camera_->camera_parameters_.distortion_k3,
-            camera_->camera_parameters_.distortion_p1,
-            camera_->camera_parameters_.distortion_p2);
-            
+           camera_->camera_parameters_.focal_length_x, camera_->camera_parameters_.focal_length_y,
+           camera_->camera_parameters_.center_x, camera_->camera_parameters_.center_y,
+           camera_->camera_parameters_.distortion_k1, camera_->camera_parameters_.distortion_k2,
+           camera_->camera_parameters_.distortion_k3, camera_->camera_parameters_.distortion_p1,
+           camera_->camera_parameters_.distortion_p2);
+
   initMCircleTarget(target_rows_, target_cols_, circle_diameter_, circle_spacing_);
-  rail_cal_server_ = nh_.advertiseService( "RailCalService", &RailCalService::executeCallBack, this);
+  rail_cal_server_ = nh_.advertiseService("RailCalService", &RailCalService::executeCallBack, this);
 }
 
-void RailCalService::cameraCallback(const sensor_msgs::Image &image)
+void RailCalService::cameraCallback(const sensor_msgs::Image& image)
 {
   cv_bridge::CvImagePtr bridge = cv_bridge::toCvCopy(image, image.encoding);
 
   cv::Mat mod_img = bridge->image;
-  cv::circle(mod_img, cv::Point2d(image.width / 2.0, image.height / 2.0), 4, cv::Scalar(255,0,0), 2);
+  cv::circle(mod_img, cv::Point2d(image.width / 2.0, image.height / 2.0), 4, cv::Scalar(255, 0, 0), 2);
   bridge->image = mod_img;
 
   sensor_msgs::Image out_img;
   bridge->toImageMsg(out_img);
   rgb_pub_.publish(out_img);
-
 }
 
-bool RailCalService::executeCallBack( intrinsic_cal::rail_ical_run::Request &req, intrinsic_cal::rail_ical_run::Response &res)
+bool RailCalService::executeCallBack(intrinsic_cal::rail_ical_run::Request& req,
+                                     intrinsic_cal::rail_ical_run::Response& res)
 {
   ros::NodeHandle nh;
   CameraObservations camera_observations;
-  int num_observations ;
-  int total_observations=0;
-  double rxry[2]; // pitch and yaw of camera relative to rail
+  int num_observations;
+  int total_observations = 0;
+  double rxry[2];  // pitch and yaw of camera relative to rail
   rxry[0] = 0.0;
   rxry[1] = 0.0;
 
@@ -224,26 +228,33 @@ bool RailCalService::executeCallBack( intrinsic_cal::rail_ical_run::Request &req
   roi.x_max = image_width_;
   roi.y_max = image_height_;
 
-  industrial_extrinsic_cal::Cost_function cost_type = industrial_extrinsic_cal::cost_functions::CameraReprjErrorWithDistortion;
-  Problem problem; // note, a new problem gets created each time execute is called, so old observation data is not re-used.
+  industrial_extrinsic_cal::Cost_function cost_type =
+      industrial_extrinsic_cal::cost_functions::CameraReprjErrorWithDistortion;
+  Problem problem;  // note, a new problem gets created each time execute is called, so old observation data is not
+                    // re-used.
 
   // set initial conditions,
-  // Need to use setQuaternion because setBasis does not work for some rotations (results in flipped yaw values and negative focal lengths)
+  // Need to use setQuaternion because setBasis does not work for some rotations (results in flipped yaw values and
+  // negative focal lengths)
   target_->pose_.setQuaternion(qx_, qy_, qz_, qw_);
   target_->pose_.setOrigin(0.011, 0.05, D0_);
   target_->pose_.show("initial target pose");
   ros::NodeHandle pnh("~");
   bool camera_ready = false;
   pnh.setParam("camera_ready", camera_ready);
-  for(int i=0; i<num_camera_locations_; i++){
-    double rail_position = i*camera_spacing_;
-    ROS_WARN("Move Camera to location %d which should be %lf meters from start. Then set camera_ready", i, i*camera_spacing_);
+  for (int i = 0; i < num_camera_locations_; i++)
+  {
+    double rail_position = i * camera_spacing_;
+    ROS_WARN("Move Camera to location %d which should be %lf meters from start. Then set camera_ready", i,
+             i * camera_spacing_);
 
     // wait for camera to be moved
     camera_ready = false;
     pnh.setParam("camera_ready", camera_ready);
-    while(camera_ready == false){
-      if(!pnh.getParam("camera_ready", camera_ready)){
+    while (camera_ready == false)
+    {
+      if (!pnh.getParam("camera_ready", camera_ready))
+      {
         ROS_ERROR_THROTTLE(1, "parameter camera_ready does not exists");
         ros::Duration(0.25).sleep();
       }
@@ -253,29 +264,32 @@ bool RailCalService::executeCallBack( intrinsic_cal::rail_ical_run::Request &req
     camera_->camera_observer_->clearObservations();
     camera_->camera_observer_->addTarget(target_, roi, cost_type);
     camera_->camera_observer_->triggerCamera();
-    while (!camera_->camera_observer_->observationsDone()) ;
+    while (!camera_->camera_observer_->observationsDone())
+      ;
     camera_->camera_observer_->getObservations(camera_observations);
-    ROS_INFO("Found %d observations",(int) camera_observations.size());
-    num_observations = (int) camera_observations.size();
-    if(num_observations != target_rows_* target_cols_){
+    ROS_INFO("Found %d observations", (int)camera_observations.size());
+    num_observations = (int)camera_observations.size();
+    if (num_observations != target_rows_ * target_cols_)
+    {
       ROS_ERROR("Target Locator could not find target %d", num_observations);
     }
-    
+
     // add a new cost to the problem for each observation
-    CostFunction* cost_function[num_observations]; // not sure I need a new cost function each time, but this just uses memory
+    CostFunction* cost_function[num_observations];  // not sure I need a new cost function each time, but this just uses
+                                                    // memory
     total_observations += num_observations;
-    for(int i=0; i<num_observations; i++){
+    for (int i = 0; i < num_observations; i++)
+    {
       double image_x = camera_observations[i].image_loc_x;
       double image_y = camera_observations[i].image_loc_y;
-      Point3d point = target_->pts_[i]; // assume correct ordering from camera observer
+      Point3d point = target_->pts_[i];  // assume correct ordering from camera observer
       cost_function[i] = industrial_extrinsic_cal::RailICal::Create(image_x, image_y, rail_position, point);
-      problem.AddResidualBlock(cost_function[i], NULL ,
-             camera_->camera_parameters_.pb_intrinsics,
-             target_->pose_.pb_pose);
+      problem.AddResidualBlock(cost_function[i], NULL, camera_->camera_parameters_.pb_intrinsics,
+                               target_->pose_.pb_pose);
       double residual[2];
       industrial_extrinsic_cal::RailICal RC(image_x, image_y, rail_position, point);
-    } // for each observation at this camera_location
-  }// for each camera_location
+    }  // for each observation at this camera_location
+  }    // for each camera_location
 
   // set up and solve the problem
   Solver::Options options;
@@ -284,75 +298,68 @@ bool RailCalService::executeCallBack( intrinsic_cal::rail_ical_run::Request &req
   options.minimizer_progress_to_stdout = true;
   options.max_num_iterations = 2000;
   ceres::Solve(options, &problem, &summary);
-  if(summary.termination_type != ceres::NO_CONVERGENCE){
-    double initial_cost = summary.initial_cost/total_observations;
-    double final_cost = summary.final_cost/total_observations;
+  if (summary.termination_type != ceres::NO_CONVERGENCE)
+  {
+    double initial_cost = summary.initial_cost / total_observations;
+    double final_cost = summary.final_cost / total_observations;
     ROS_INFO("Problem solved, initial cost = %lf, final cost = %lf", initial_cost, final_cost);
     target_->pose_.show("target_pose");
-    ROS_INFO("camera_matrix data: [ %lf, 0.0, %lf, 0.0, %lf, %lf, 0.0, 0.0, 1.0]", 
-	      camera_->camera_parameters_.focal_length_x,
-	      camera_->camera_parameters_.center_x,
-	      camera_->camera_parameters_.focal_length_y,
-	      camera_->camera_parameters_.center_y);
-    ROS_INFO("distortion data: [ %lf,  %lf,  %lf,  %lf,  %lf]",
-   	      camera_->camera_parameters_.distortion_k1,
-   	      camera_->camera_parameters_.distortion_k2,
-   	      camera_->camera_parameters_.distortion_p1,
-   	      camera_->camera_parameters_.distortion_p2,
-   	      camera_->camera_parameters_.distortion_k3);
-    ROS_INFO("projection_matrix data: [ %lf, 0.0, %lf, 0.0, 0.0, %lf, %lf, 0.0, 0.0, 0.0, 1.0, 0.0]", 
-	      camera_->camera_parameters_.focal_length_x,
-	      camera_->camera_parameters_.center_x,
-	      camera_->camera_parameters_.focal_length_y,
-	      camera_->camera_parameters_.center_y);
-    if(final_cost <= req.allowable_cost_per_observation){
+    ROS_INFO("camera_matrix data: [ %lf, 0.0, %lf, 0.0, %lf, %lf, 0.0, 0.0, 1.0]",
+             camera_->camera_parameters_.focal_length_x, camera_->camera_parameters_.center_x,
+             camera_->camera_parameters_.focal_length_y, camera_->camera_parameters_.center_y);
+    ROS_INFO("distortion data: [ %lf,  %lf,  %lf,  %lf,  %lf]", camera_->camera_parameters_.distortion_k1,
+             camera_->camera_parameters_.distortion_k2, camera_->camera_parameters_.distortion_p1,
+             camera_->camera_parameters_.distortion_p2, camera_->camera_parameters_.distortion_k3);
+    ROS_INFO("projection_matrix data: [ %lf, 0.0, %lf, 0.0, 0.0, %lf, %lf, 0.0, 0.0, 0.0, 1.0, 0.0]",
+             camera_->camera_parameters_.focal_length_x, camera_->camera_parameters_.center_x,
+             camera_->camera_parameters_.focal_length_y, camera_->camera_parameters_.center_y);
+    if (final_cost <= req.allowable_cost_per_observation)
+    {
       res.final_pose.position.x = target_->pose_.x;
       res.final_pose.position.y = target_->pose_.y;
       res.final_pose.position.z = target_->pose_.z;
-      res.final_cost_per_observation  = final_cost;
-      target_->pose_.getQuaternion(res.final_pose.orientation.x,
-				   res.final_pose.orientation.y, 
-				   res.final_pose.orientation.z,
-				   res.final_pose.orientation.w);
-      camera_->camera_observer_->pushCameraInfo(camera_->camera_parameters_.focal_length_x,
-                                                camera_->camera_parameters_.focal_length_y,
-                                                camera_->camera_parameters_.center_x,
-                                                camera_->camera_parameters_.center_y,
-                                                camera_->camera_parameters_.distortion_k1,
-                                                camera_->camera_parameters_.distortion_k2,
-                                                camera_->camera_parameters_.distortion_k3,
-                                                camera_->camera_parameters_.distortion_p1,
-                                                camera_->camera_parameters_.distortion_p2);
+      res.final_cost_per_observation = final_cost;
+      target_->pose_.getQuaternion(res.final_pose.orientation.x, res.final_pose.orientation.y,
+                                   res.final_pose.orientation.z, res.final_pose.orientation.w);
+      camera_->camera_observer_->pushCameraInfo(
+          camera_->camera_parameters_.focal_length_x, camera_->camera_parameters_.focal_length_y,
+          camera_->camera_parameters_.center_x, camera_->camera_parameters_.center_y,
+          camera_->camera_parameters_.distortion_k1, camera_->camera_parameters_.distortion_k2,
+          camera_->camera_parameters_.distortion_k3, camera_->camera_parameters_.distortion_p1,
+          camera_->camera_parameters_.distortion_p2);
 
       return true;
     }
-    else{
-      res.final_cost_per_observation  = final_cost;
+    else
+    {
+      res.final_cost_per_observation = final_cost;
       ROS_ERROR("allowable cost exceeded %f > %f", final_cost, req.allowable_cost_per_observation);
-      return(false);
+      return (false);
     }
   }
 }
 
 void RailCalService::initMCircleTarget(int rows, int cols, double circle_dia, double spacing)
 {
-  target_ =  boost::make_shared<industrial_extrinsic_cal::Target>();
+  target_ = boost::make_shared< industrial_extrinsic_cal::Target >();
   target_->is_moving_ = true;
   target_->target_name_ = "modified_circle_target";
   target_->target_frame_ = "target_frame";
-  target_->target_type_ =  2;
-  target_->circle_grid_parameters_.pattern_rows =rows;
+  target_->target_type_ = 2;
+  target_->circle_grid_parameters_.pattern_rows = rows;
   target_->circle_grid_parameters_.pattern_cols = cols;
   target_->circle_grid_parameters_.circle_diameter = circle_dia;
-  target_->circle_grid_parameters_.is_symmetric = true; 
+  target_->circle_grid_parameters_.is_symmetric = true;
   // create a grid of points
   target_->pts_.clear();
-  target_->num_points_ = rows*cols;
-  for(int i=rows-1; i>=0; i--){
-    for(int j=0; j<cols; j++){
+  target_->num_points_ = rows * cols;
+  for (int i = rows - 1; i >= 0; i--)
+  {
+    for (int j = 0; j < cols; j++)
+    {
       Point3d point;
-      point.x = j*spacing;
-      point.y = i*spacing;
+      point.x = j * spacing;
+      point.y = i * spacing;
       point.z = 0.0;
       target_->pts_.push_back(point);
     }

--- a/rgbd_depth_correction/include/depth_calibration/depth_calibration.h
+++ b/rgbd_depth_correction/include/depth_calibration/depth_calibration.h
@@ -38,27 +38,26 @@
 
 #include "ceres/ceres.h"
 
-template<typename T> void calculateResidualError(T& a, T& b, T& c, T& d, T& dk,
-                                                 T pt[3], T dp[2], T& error);
-template<typename T> inline void calculateResidualError(T& a, T& b, T& c, T& d, T& dk,
-                                                        T pt[3], T dp[2], T& residual)
+template < typename T >
+void calculateResidualError(T& a, T& b, T& c, T& d, T& dk, T pt[3], T dp[2], T& error);
+template < typename T >
+inline void calculateResidualError(T& a, T& b, T& c, T& d, T& dk, T pt[3], T dp[2], T& residual)
 {
   // depth correction amount
   T dc = dk * exp(dp[0] + dp[1] * pt[2]);
 
-
   T z = T(0.0);
-  if(pt[2] == 0.0)
+  if (pt[2] == 0.0)
   {
     residual = T(0.0);
   }
   else
   {
     // calculated depth using plane equation (ax + by + cz + d = 0)
-    z = (-d - a*pt[0] - b*pt[1]) / c;
+    z = (-d - a * pt[0] - b * pt[1]) / c;
 
     // residual = ( (calculated depth) - (measured depth + depth correction) )^2
-    residual = abs( z - (pt[2] + dc) );
+    residual = abs(z - (pt[2] + dc));
   }
 
   return;
@@ -67,13 +66,12 @@ template<typename T> inline void calculateResidualError(T& a, T& b, T& c, T& d, 
 class DepthError
 {
 public:
-
-  DepthError(double a, double b, double c, double d, double dk, pcl::PointXYZ pt) :
-    a_(a), b_(b), c_(c), d_(d), dk_(dk), pt_(pt)
+  DepthError(double a, double b, double c, double d, double dk, pcl::PointXYZ pt)
+    : a_(a), b_(b), c_(c), d_(d), dk_(dk), pt_(pt)
   {
   }
 
-  template<typename T>
+  template < typename T >
 
   bool operator()(const T* const d_params, /** depth coefficients */
                   T* residual) const
@@ -93,7 +91,6 @@ public:
     depth_params[0] = d_params[0];
     depth_params[1] = d_params[1];
 
-
     calculateResidualError(a, b, c, d, dk, pt, depth_params, *residual);
 
     return true;
@@ -101,42 +98,40 @@ public:
 
   /** Factory to hide the construction of the CostFunction object from */
   /** the client code. */
-  static ceres::CostFunction* Create(const double a, const double b,
-             const double c, const double d, const double dk, const pcl::PointXYZ pt)
+  static ceres::CostFunction* Create(const double a, const double b, const double c, const double d, const double dk,
+                                     const pcl::PointXYZ pt)
   {
-    return ( new ceres::AutoDiffCostFunction<DepthError, 1, 2>(new DepthError(a, b, c, d, dk, pt)) );
+    return (new ceres::AutoDiffCostFunction< DepthError, 1, 2 >(new DepthError(a, b, c, d, dk, pt)));
   }
 
-  double a_;  /** plane equation parameter a */
-  double b_;  /** plane equation parameter b */
-  double c_;  /** plane equation parameter c */
-  double d_;  /** plane equation parameter d */
-  double dk_; /** depth correction value */
+  double a_;         /** plane equation parameter a */
+  double b_;         /** plane equation parameter b */
+  double c_;         /** plane equation parameter c */
+  double d_;         /** plane equation parameter d */
+  double dk_;        /** depth correction value */
   pcl::PointXYZ pt_; /** point cloud (x,y,z) location */
-
 };
-
 
 class DepthCalibrator
 {
-
 public:
-
   DepthCalibrator(ros::NodeHandle& nh);
 
   /**
-     * @brief If pixel depth calibration has been performed, and points clouds have been stored, performs depth correction calculations
+     * @brief If pixel depth calibration has been performed, and points clouds have been stored, performs depth
+   * correction calculations
      *
      * Calculates the depth correction coefficients d1 and d2 using the point clouds previously stored.
      * Depth correction for each pixel is of the form D*e^(d1 + d2 * z), where D is the pixel depth error found from the
-     * calibrateCameraPixelDepth callback, z is the depth of the given pixel, and d1 and d2 are the depth coefficients to be solved for.
+     * calibrateCameraPixelDepth callback, z is the depth of the given pixel, and d1 and d2 are the depth coefficients
+   * to be solved for.
      *
      *
      * @param[in] request Empty
      * @param[out] response Empty
      * @return True if the call succeeded
      */
-  bool calibrateCameraDepth(std_srvs::Empty::Request &request, std_srvs::Empty::Response &response);
+  bool calibrateCameraDepth(std_srvs::Empty::Request& request, std_srvs::Empty::Response& response);
 
   /**
      * @brief Finds the depth error for each pixel in the point cloud
@@ -149,19 +144,21 @@ public:
      * @param[out] response Empty
      * @return True if the call succeeded
      */
-  bool calibrateCameraPixelDepth(std_srvs::Empty::Request &request, std_srvs::Empty::Response &response);
+  bool calibrateCameraPixelDepth(std_srvs::Empty::Request& request, std_srvs::Empty::Response& response);
 
   /**
-     * @brief Sets the flag to store the next point cloud retrieved for later use when performing depth correction calculations
+     * @brief Sets the flag to store the next point cloud retrieved for later use when performing depth correction
+   * calculations
      *
      * @param[in] request Empty
      * @param[out] response Empty
      * @return True if the call succeeded
      */
-  bool setStoreCloud(std_srvs::Empty::Request &request, std_srvs::Empty::Response &response);
+  bool setStoreCloud(std_srvs::Empty::Request& request, std_srvs::Empty::Response& response);
 
   /**
-     * @brief Updates the last_cloud_ data, and if the store_point_cloud_ boolean is set, stores the latest cloud, image, and target pose
+     * @brief Updates the last_cloud_ data, and if the store_point_cloud_ boolean is set, stores the latest cloud,
+   * image, and target pose
      *
      * @param[in] cloud The latest point cloud received
      * @param[in] image The latest RGB image received
@@ -170,42 +167,49 @@ public:
   void updateInputData(const sensor_msgs::PointCloud2ConstPtr& cloud, const sensor_msgs::ImageConstPtr& image);
 
 private:
-  const static unsigned int VERSION_NUMBER_;  /**< @brief Version number for the calibration package  */
+  const static unsigned int VERSION_NUMBER_; /**< @brief Version number for the calibration package  */
 
-  ros::NodeHandle nh_;  /**< @brief ROS node handle */
-  bool save_data_;      /**< @brief Flag to determine whether to save calibration results or not */
+  ros::NodeHandle nh_; /**< @brief ROS node handle */
+  bool save_data_;     /**< @brief Flag to determine whether to save calibration results or not */
 
-  typedef message_filters::sync_policies::ApproximateTime<sensor_msgs::PointCloud2, sensor_msgs::Image> PolicyType;
-  typedef message_filters::Subscriber<sensor_msgs::PointCloud2> PointCloudSubscriberType;
-  typedef message_filters::Subscriber<sensor_msgs::Image> ImageSubscriberType;
-  typedef message_filters::Synchronizer<PolicyType> SynchronizerType;
-  boost::shared_ptr<PointCloudSubscriberType> point_cloud_sub_;  /**< @brief Point cloud subscriber */
-  boost::shared_ptr<ImageSubscriberType> image_sub_;  /**< @brief RGB image subscriber */
-  boost::shared_ptr<SynchronizerType> synchronizer_;  /**< @brief Syncronizer for point cloud and image data */
+  typedef message_filters::sync_policies::ApproximateTime< sensor_msgs::PointCloud2, sensor_msgs::Image > PolicyType;
+  typedef message_filters::Subscriber< sensor_msgs::PointCloud2 > PointCloudSubscriberType;
+  typedef message_filters::Subscriber< sensor_msgs::Image > ImageSubscriberType;
+  typedef message_filters::Synchronizer< PolicyType > SynchronizerType;
+  boost::shared_ptr< PointCloudSubscriberType > point_cloud_sub_; /**< @brief Point cloud subscriber */
+  boost::shared_ptr< ImageSubscriberType > image_sub_;            /**< @brief RGB image subscriber */
+  boost::shared_ptr< SynchronizerType > synchronizer_; /**< @brief Syncronizer for point cloud and image data */
 
-  ros::ServiceClient get_target_pose_; /**< @brief Service to call target locator to get target pose */
-  ros::ServiceServer calibrate_depth_; /**< @brief Service to compute depth coefficients d1 and d2 */
+  ros::ServiceClient get_target_pose_;       /**< @brief Service to call target locator to get target pose */
+  ros::ServiceServer calibrate_depth_;       /**< @brief Service to compute depth coefficients d1 and d2 */
   ros::ServiceServer calibrate_pixel_depth_; /**< @brief Service to calculate pixel depth error */
-  ros::ServiceServer set_store_cloud_; /**< @brief Service to set and store next point cloud available */
+  ros::ServiceServer set_store_cloud_;       /**< @brief Service to set and store next point cloud available */
 
-  int num_views_;  /**< @brief Number of times to find the calibration target to get average pose */
-  int num_attempts_;  /**< @brief Number of attempts allowed for finding calibration target before failing */
-  int num_point_clouds_;  /**< @brief Number of point clouds to save and check when performing pixel depth error calculations */
-  std::string filename_;  /**< @brief Name of the calibration files to save */
-  std::string filepath_;  /**< @brief Pathway to the location to save calibration files */
-  geometry_msgs::Pose target_initial_pose_;  /**< @brief The initial pose guess of the calibration target for the target finder service */
+  int num_views_;        /**< @brief Number of times to find the calibration target to get average pose */
+  int num_attempts_;     /**< @brief Number of attempts allowed for finding calibration target before failing */
+  int num_point_clouds_; /**< @brief Number of point clouds to save and check when performing pixel depth error
+                            calculations */
+  std::string filename_; /**< @brief Name of the calibration files to save */
+  std::string filepath_; /**< @brief Pathway to the location to save calibration files */
+  geometry_msgs::Pose
+      target_initial_pose_; /**< @brief The initial pose guess of the calibration target for the target finder service
+                               */
 
-  double std_dev_error_;  /**< @brief The standard deviation error allowed for finding the target pose */
-  double depth_error_threshold_; /**< @brief The depth error allowed for calculating the pixel depth error map */
-  boost::mutex data_lock_; /**< @brief Lock for data subscription */
-  sensor_msgs::Image last_image_;  /**< @brief The last color image received */
-  pcl::PointCloud<pcl::PointXYZ> last_cloud_;  /**< @brief The last point cloud received */
-  pcl::PointCloud<pcl::PointXYZ> correction_cloud_;  /**< @brief The point cloud containing the depth correction values */
-  std::vector< pcl::PointCloud<pcl::PointXYZ>, Eigen::aligned_allocator<pcl::PointCloud<pcl::PointXYZ> > > saved_clouds_;
+  double std_dev_error_;          /**< @brief The standard deviation error allowed for finding the target pose */
+  double depth_error_threshold_;  /**< @brief The depth error allowed for calculating the pixel depth error map */
+  boost::mutex data_lock_;        /**< @brief Lock for data subscription */
+  sensor_msgs::Image last_image_; /**< @brief The last color image received */
+  pcl::PointCloud< pcl::PointXYZ > last_cloud_; /**< @brief The last point cloud received */
+  pcl::PointCloud< pcl::PointXYZ >
+      correction_cloud_; /**< @brief The point cloud containing the depth correction values */
+  std::vector< pcl::PointCloud< pcl::PointXYZ >, Eigen::aligned_allocator< pcl::PointCloud< pcl::PointXYZ > > >
+      saved_clouds_;
   /**< @brief The vector of stored point clouds used to compute the distance coefficients */
-  std::vector<std::vector<double> > plane_equations_;  /**< @brief A vector of plane equations for each point cloud in saved_clouds_ */
-  std::vector<cv::Mat> saved_images_;  /**< @brief A vector of rgb images for each point cloud in saved_clouds_ */
-  std::vector<geometry_msgs::Pose> saved_target_poses_;  /**< @brief A vector of target poses for each point cloud in saved_clouds_ */
+  std::vector< std::vector< double > >
+      plane_equations_;                 /**< @brief A vector of plane equations for each point cloud in saved_clouds_ */
+  std::vector< cv::Mat > saved_images_; /**< @brief A vector of rgb images for each point cloud in saved_clouds_ */
+  std::vector< geometry_msgs::Pose > saved_target_poses_; /**< @brief A vector of target poses for each point cloud in
+                                                             saved_clouds_ */
 
   /**
      * @brief Stores the calibration results in a YAML formated file
@@ -213,7 +217,7 @@ private:
      * @param[in] yaml_file The name and pathway of the file to be saved
      * @param[in] dp The depth correction coefficients to be saved
      */
-  void storeCalibration(const std::string & yaml_file, const double dp[2]);
+  void storeCalibration(const std::string& yaml_file, const double dp[2]);
 
   /**
      * @brief Populates and calls the target finder service
@@ -225,15 +229,17 @@ private:
   bool findTarget(const double& final_cost, geometry_msgs::Pose& target_pose);
 
   /**
-     * @brief Calls the findTarget function multiple times (num_views) and returns the average plane equation and the last target pose found
+     * @brief Calls the findTarget function multiple times (num_views) and returns the average plane equation and the
+   * last target pose found
      *
-     * @param[out] plane_eq The average plane equation results found from averaging the results from all of the target poses found
+     * @param[out] plane_eq The average plane equation results found from averaging the results from all of the target
+   * poses found
      * @param[out] target_pose The pose of the target found from the last service call
      * @return True if the target was successfully found before the number of failures (num_attempts) was reached
      */
-  bool findAveragePlane(std::vector<double> &plane_eq, geometry_msgs::Pose& target_pose);
+  bool findAveragePlane(std::vector< double >& plane_eq, geometry_msgs::Pose& target_pose);
 
-  bool findAveragePointCloud(pcl::PointCloud<pcl::PointXYZ>& final_cloud);
+  bool findAveragePointCloud(pcl::PointCloud< pcl::PointXYZ >& final_cloud);
 };
 
-#endif // DEPTH_CALIBRATION_H
+#endif  // DEPTH_CALIBRATION_H

--- a/rgbd_depth_correction/src/depth_calibration.cpp
+++ b/rgbd_depth_correction/src/depth_calibration.cpp
@@ -31,8 +31,6 @@
 #include <opencv2/calib3d/calib3d.hpp>
 #include <opencv2/highgui/highgui.hpp>
 
-
-
 const unsigned int DepthCalibrator::VERSION_NUMBER_ = 1;
 
 DepthCalibrator::DepthCalibrator(ros::NodeHandle& nh)
@@ -41,14 +39,15 @@ DepthCalibrator::DepthCalibrator(ros::NodeHandle& nh)
   ros::NodeHandle pnh("~");
 
   // get parameters for services, topics, and filename
-  if(!pnh.getParam("filename", filename_))
+  if (!pnh.getParam("filename", filename_))
   {
     ROS_WARN("Depth calibration file name not given for saving calibration results.  Defaulting to 'camera'.");
     filename_ = "camera";
   }
-  if(!pnh.getParam("filepath", filepath_))
+  if (!pnh.getParam("filepath", filepath_))
   {
-    ROS_WARN("Depth calibration file path not given for saving calibration results.  Results will not be saved.  Please provide path and re-execute to save results");
+    ROS_WARN("Depth calibration file path not given for saving calibration results.  Results will not be saved.  "
+             "Please provide path and re-execute to save results");
     save_data_ = false;
   }
   else
@@ -59,47 +58,49 @@ DepthCalibrator::DepthCalibrator(ros::NodeHandle& nh)
   std_dev_error_ = 0.1;
   depth_error_threshold_ = 0.2;
 
-  double x,y,z,w;
+  double x, y, z, w;
 
-  pnh.param<double>("target_pos_x", x, 0.0);
-  pnh.param<double>("target_pos_y", y, 0.0);
-  pnh.param<double>("target_pos_z", z, 0.0);
+  pnh.param< double >("target_pos_x", x, 0.0);
+  pnh.param< double >("target_pos_y", y, 0.0);
+  pnh.param< double >("target_pos_z", z, 0.0);
 
   target_initial_pose_.position.x = x;
   target_initial_pose_.position.y = y;
   target_initial_pose_.position.z = z;
 
-  pnh.param<double>("target_orn_x", x, 0.0);
-  pnh.param<double>("target_orn_y", y, 0.0);
-  pnh.param<double>("target_orn_z", z, 0.0);
-  pnh.param<double>("target_orn_w", w, 1.0);
+  pnh.param< double >("target_orn_x", x, 0.0);
+  pnh.param< double >("target_orn_y", y, 0.0);
+  pnh.param< double >("target_orn_z", z, 0.0);
+  pnh.param< double >("target_orn_w", w, 1.0);
 
   target_initial_pose_.orientation.x = x;
   target_initial_pose_.orientation.y = y;
   target_initial_pose_.orientation.z = z;
   target_initial_pose_.orientation.w = w;
-  ROS_WARN("found target at xyz: (%.2f, %.2f, %.2f) wxyz: (%.2f, %.2f, %.2f, %.2f)", target_initial_pose_.position.x, target_initial_pose_.position.y, target_initial_pose_.position.z,
-           target_initial_pose_.orientation.w, target_initial_pose_.orientation.x, target_initial_pose_.orientation.y, target_initial_pose_.orientation.z);
+  ROS_WARN("found target at xyz: (%.2f, %.2f, %.2f) wxyz: (%.2f, %.2f, %.2f, %.2f)", target_initial_pose_.position.x,
+           target_initial_pose_.position.y, target_initial_pose_.position.z, target_initial_pose_.orientation.w,
+           target_initial_pose_.orientation.x, target_initial_pose_.orientation.y, target_initial_pose_.orientation.z);
 
-  pnh.param<int>("num_views", num_views_, 30);
-  pnh.param<int>("num_attempts", num_attempts_, 10);
-  pnh.param<int>("point_cloud_history", num_point_clouds_, 30);
+  pnh.param< int >("num_views", num_views_, 30);
+  pnh.param< int >("num_attempts", num_attempts_, 10);
+  pnh.param< int >("point_cloud_history", num_point_clouds_, 30);
 
-
-  //Create Subscribers and Services
+  // Create Subscribers and Services
   calibrate_depth_ = nh_.advertiseService("depth_calibration", &DepthCalibrator::calibrateCameraDepth, this);
-  calibrate_pixel_depth_ = nh_.advertiseService("pixel_depth_calibration", &DepthCalibrator::calibrateCameraPixelDepth, this);
+  calibrate_pixel_depth_ =
+      nh_.advertiseService("pixel_depth_calibration", &DepthCalibrator::calibrateCameraPixelDepth, this);
   set_store_cloud_ = nh_.advertiseService("store_cloud", &DepthCalibrator::setStoreCloud, this);
-  get_target_pose_ = nh.serviceClient<target_finder::target_locater>("TargetLocateService");
+  get_target_pose_ = nh.serviceClient< target_finder::target_locater >("TargetLocateService");
 
-  this->point_cloud_sub_ = boost::shared_ptr<PointCloudSubscriberType>(new PointCloudSubscriberType(nh, "depth_points", 1));
-  this->image_sub_ = boost::shared_ptr<ImageSubscriberType>(new ImageSubscriberType(nh, "image", 1));
-  synchronizer_ = boost::shared_ptr<SynchronizerType>(new SynchronizerType(PolicyType(10),
-    *this->point_cloud_sub_, *this->image_sub_));
+  this->point_cloud_sub_ =
+      boost::shared_ptr< PointCloudSubscriberType >(new PointCloudSubscriberType(nh, "depth_points", 1));
+  this->image_sub_ = boost::shared_ptr< ImageSubscriberType >(new ImageSubscriberType(nh, "image", 1));
+  synchronizer_ = boost::shared_ptr< SynchronizerType >(
+      new SynchronizerType(PolicyType(10), *this->point_cloud_sub_, *this->image_sub_));
   synchronizer_->registerCallback(boost::bind(&DepthCalibrator::updateInputData, this, _1, _2));
 }
 
-void DepthCalibrator::storeCalibration(const std::string &yaml_file, const double dp[2])
+void DepthCalibrator::storeCalibration(const std::string& yaml_file, const double dp[2])
 {
   ROS_INFO_STREAM("writing calibration data to file " << yaml_file);
   std::ofstream fout(yaml_file.c_str());
@@ -116,17 +117,16 @@ void DepthCalibrator::storeCalibration(const std::string &yaml_file, const doubl
   fout.close();
 }
 
-
-
-bool DepthCalibrator::calibrateCameraDepth(std_srvs::Empty::Request &request, std_srvs::Empty::Response &response)
+bool DepthCalibrator::calibrateCameraDepth(std_srvs::Empty::Request& request, std_srvs::Empty::Response& response)
 {
-  boost::lock_guard<boost::mutex> lock(data_lock_);
+  boost::lock_guard< boost::mutex > lock(data_lock_);
 
-  if(saved_clouds_.size() > 0)
+  if (saved_clouds_.size() > 0)
   {
-    if( !(saved_clouds_[0].points.size() == correction_cloud_.points.size()) )
+    if (!(saved_clouds_[0].points.size() == correction_cloud_.points.size()))
     {
-      ROS_ERROR("Point cloud pixel depth correction cloud size (%lu) not the same size as saved cloud size (%lu). Aborting depth calibration.",
+      ROS_ERROR("Point cloud pixel depth correction cloud size (%lu) not the same size as saved cloud size (%lu). "
+                "Aborting depth calibration.",
                 correction_cloud_.points.size(), saved_clouds_[0].points.size());
       return false;
     }
@@ -143,23 +143,23 @@ bool DepthCalibrator::calibrateCameraDepth(std_srvs::Empty::Request &request, st
   dp[0] = dp[1] = 0;
 
   // Add each point in all point clouds as a new cost
-  for(int i = 0; i < saved_clouds_[0].points.size(); ++i)
+  for (int i = 0; i < saved_clouds_[0].points.size(); ++i)
   {
-    for(int j = 0; j < saved_clouds_.size(); ++j)
+    for (int j = 0; j < saved_clouds_.size(); ++j)
     {
-      if(std::isnan(saved_clouds_[j].points.at(i).x) || saved_clouds_[j].points.at(i).z == 0)
+      if (std::isnan(saved_clouds_[j].points.at(i).x) || saved_clouds_[j].points.at(i).z == 0)
       {
         continue;
       }
-      std::vector<double> eq;
+      std::vector< double > eq;
       eq = plane_equations_[j];
-      ceres::CostFunction* cost_function = DepthError::Create(eq[0], eq[1], eq[2], eq[3],
-                                                              correction_cloud_.points.at(i).z, saved_clouds_[j].points.at(i)) ;
+      ceres::CostFunction* cost_function = DepthError::Create(
+          eq[0], eq[1], eq[2], eq[3], correction_cloud_.points.at(i).z, saved_clouds_[j].points.at(i));
       problem.AddResidualBlock(cost_function, NULL, dp);
     }
   }
 
-  //Create Ceres problem to optimize depth correction coefficients
+  // Create Ceres problem to optimize depth correction coefficients
   ceres::Solver::Options options;
   ceres::Solver::Summary summary;
   options.linear_solver_type = ceres::DENSE_SCHUR;
@@ -167,50 +167,51 @@ bool DepthCalibrator::calibrateCameraDepth(std_srvs::Empty::Request &request, st
   options.max_num_iterations = 1000;
   ceres::Solve(options, &problem, &summary);
 
-  ROS_INFO("depth calibration resulting parameters: d1: %.3f, d2: %.3f ",dp[0],dp[1]);
+  ROS_INFO("depth calibration resulting parameters: d1: %.3f, d2: %.3f ", dp[0], dp[1]);
   ROS_INFO("Finished calculating in %.2f seconds with a residual error of: %.3f (and num residuals: %d)",
            summary.total_time_in_seconds, summary.final_cost, summary.num_residuals);
 
-  //Store distortion coefficients in YAML file
-  if(save_data_)
+  // Store distortion coefficients in YAML file
+  if (save_data_)
   {
-    storeCalibration((filepath_ + "/" +filename_ + ".yaml"), dp);
+    storeCalibration((filepath_ + "/" + filename_ + ".yaml"), dp);
   }
   saved_clouds_.clear();
   plane_equations_.clear();
   saved_images_.clear();
 }
 
-bool DepthCalibrator::findAveragePointCloud(pcl::PointCloud<pcl::PointXYZ>& final_cloud)
+bool DepthCalibrator::findAveragePointCloud(pcl::PointCloud< pcl::PointXYZ >& final_cloud)
 {
-  // Store point clouds until the number of point clouds desired is reached, break if no new data is received after 1 second
+  // Store point clouds until the number of point clouds desired is reached, break if no new data is received after 1
+  // second
   int rate = 100;
-  std::vector< pcl::PointCloud<pcl::PointXYZ>, Eigen::aligned_allocator<pcl::PointCloud<pcl::PointXYZ> > > temp_clouds;
+  std::vector< pcl::PointCloud< pcl::PointXYZ >, Eigen::aligned_allocator< pcl::PointCloud< pcl::PointXYZ > > >
+      temp_clouds;
   ros::Rate sleep_rate(rate);
-  while(temp_clouds.size() < num_point_clouds_)
+  while (temp_clouds.size() < num_point_clouds_)
   {
     ros::Time new_time = ros::Time::now();
     int count = 0;
-    while(count < rate )
+    while (count < rate)
     {
       {
-        boost::lock_guard<boost::mutex> lock(data_lock_);
+        boost::lock_guard< boost::mutex > lock(data_lock_);
         std_msgs::Header ros_cloud_header;
         pcl_conversions::fromPCL(last_cloud_.header, ros_cloud_header);
         final_cloud = last_cloud_;
-        if(ros_cloud_header.stamp > new_time)
+        if (ros_cloud_header.stamp > new_time)
         {
-          ROS_INFO("Got point cloud %lu of %d", (temp_clouds.size() + 1), num_point_clouds_ );
+          ROS_INFO("Got point cloud %lu of %d", (temp_clouds.size() + 1), num_point_clouds_);
           temp_clouds.push_back(last_cloud_);
           break;
         }
-
       }
       sleep_rate.sleep();
       ++count;
     }
 
-    if(count == rate)
+    if (count == rate)
     {
       ROS_ERROR("No new point cloud data after 1 second");
       return false;
@@ -220,16 +221,16 @@ bool DepthCalibrator::findAveragePointCloud(pcl::PointCloud<pcl::PointXYZ>& fina
   final_cloud.points.clear();
 
   // Calculate average depth error for all pixels
-  for(int i = 0; i < temp_clouds[0].points.size(); ++i)
+  for (int i = 0; i < temp_clouds[0].points.size(); ++i)
   {
     // Find the average depth value for the current pixel point
     int count = 0;
     double x, y, z;
     pcl::PointXYZ pt;
     x = y = z = 0.0;
-    for(int j = 0; j < temp_clouds.size(); ++j)
+    for (int j = 0; j < temp_clouds.size(); ++j)
     {
-      if(std::isnan(temp_clouds[j].points.at(i).x) || temp_clouds[j].points.at(i).z == 0)
+      if (std::isnan(temp_clouds[j].points.at(i).x) || temp_clouds[j].points.at(i).z == 0)
       {
         continue;
       }
@@ -240,7 +241,7 @@ bool DepthCalibrator::findAveragePointCloud(pcl::PointCloud<pcl::PointXYZ>& fina
       z += temp_clouds[j].points.at(i).z;
     }
 
-    if(count > 0)
+    if (count > 0)
     {
       x = x / double(count);
       y = y / double(count);
@@ -264,13 +265,13 @@ bool DepthCalibrator::findAveragePointCloud(pcl::PointCloud<pcl::PointXYZ>& fina
   return true;
 }
 
-bool DepthCalibrator::calibrateCameraPixelDepth(std_srvs::Empty::Request &request, std_srvs::Empty::Response &response)
+bool DepthCalibrator::calibrateCameraPixelDepth(std_srvs::Empty::Request& request, std_srvs::Empty::Response& response)
 {
   // Find the target location
-  std::vector<double> plane_eq;
+  std::vector< double > plane_eq;
   geometry_msgs::Pose target_pose;
   ROS_INFO("Attempting to find target average pose");
-  if(!findAveragePlane(plane_eq, target_pose))
+  if (!findAveragePlane(plane_eq, target_pose))
   {
     ROS_ERROR("Failed to get target pose.  Aborting depth calibration");
     return false;
@@ -278,8 +279,8 @@ bool DepthCalibrator::calibrateCameraPixelDepth(std_srvs::Empty::Request &reques
   ROS_INFO("Target average pose found");
 
   // Get average point cloud
-  pcl::PointCloud<pcl::PointXYZ> avg_cloud;
-  if(!findAveragePointCloud(avg_cloud))
+  pcl::PointCloud< pcl::PointXYZ > avg_cloud;
+  if (!findAveragePointCloud(avg_cloud))
   {
     ROS_ERROR("Failed to get average point cloud.  Aborting depth calibration");
     return false;
@@ -291,10 +292,9 @@ bool DepthCalibrator::calibrateCameraPixelDepth(std_srvs::Empty::Request &reques
   correction_cloud_.header = avg_cloud.header;
   correction_cloud_.width = avg_cloud.width;
   correction_cloud_.height = avg_cloud.height;
-  for(int j = 0; j < avg_cloud.points.size(); ++j)
+  for (int j = 0; j < avg_cloud.points.size(); ++j)
   {
-
-    if(std::isnan(avg_cloud.points.at(j).x) || avg_cloud.points.at(j).z == 0)
+    if (std::isnan(avg_cloud.points.at(j).x) || avg_cloud.points.at(j).z == 0)
     {
       pcl::PointXYZ pt;
       pt.x = NAN;
@@ -304,12 +304,13 @@ bool DepthCalibrator::calibrateCameraPixelDepth(std_srvs::Empty::Request &reques
       continue;
     }
     // calculated (ideal) depth using plane equation (ax + by + cz + d = 0)
-    double ideal_depth = (-plane_eq[3] - plane_eq[0]*avg_cloud.points.at(j).x - plane_eq[1]*avg_cloud.points.at(j).y) / plane_eq[2];
+    double ideal_depth =
+        (-plane_eq[3] - plane_eq[0] * avg_cloud.points.at(j).x - plane_eq[1] * avg_cloud.points.at(j).y) / plane_eq[2];
 
     // depth correction value is error between calculated depth and average depth for the given pixel
     double error = (ideal_depth - avg_cloud.points.at(j).z);
 
-    if(fabs(error) > depth_error_threshold_)
+    if (fabs(error) > depth_error_threshold_)
     {
       ROS_WARN("depth error for pixel %d is too great (%.3f), setting to NAN", j, error);
       pcl::PointXYZ pt;
@@ -331,60 +332,59 @@ bool DepthCalibrator::calibrateCameraPixelDepth(std_srvs::Empty::Request &reques
   // Iterate through depth correction cloud and replace all NaNs with average value of neighbors
   // Repeat until no NaNs remain
   bool done = false;
-  while(!done)
+  while (!done)
   {
     int num_nan = 0;
     bool nan_found = false;
-    for(int i = 0; i < correction_cloud_.points.size(); ++i)
+    for (int i = 0; i < correction_cloud_.points.size(); ++i)
     {
-
-
       // If value is NaN, find average of neighbors
-      if(std::isnan(correction_cloud_.points.at(i).x))
+      if (std::isnan(correction_cloud_.points.at(i).x))
       {
-
         ++num_nan;
         nan_found = true;
         double val = 0.0;
         int count = 0;
 
-        if((i+1) % (correction_cloud_.width) > 0 || i == 0) // add point to the right except when at the far right side
+        if ((i + 1) % (correction_cloud_.width) > 0 ||
+            i == 0)  // add point to the right except when at the far right side
         {
-          if(std::isnan(correction_cloud_.points.at(i+1).z) == 0)
+          if (std::isnan(correction_cloud_.points.at(i + 1).z) == 0)
           {
-            val += correction_cloud_.points.at(i+1).z;
+            val += correction_cloud_.points.at(i + 1).z;
             ++count;
           }
         }
 
-        if(i % correction_cloud_.width > 0 ) // add point to the left except when at the far left side
+        if (i % correction_cloud_.width > 0)  // add point to the left except when at the far left side
         {
-          if(std::isnan(correction_cloud_.points.at(i-1).z) == 0)
+          if (std::isnan(correction_cloud_.points.at(i - 1).z) == 0)
           {
-            val += correction_cloud_.points.at(i-1).z;
+            val += correction_cloud_.points.at(i - 1).z;
             ++count;
           }
         }
 
-        if(i > (correction_cloud_.width - 1) ) // add point to the top except when at the top row
+        if (i > (correction_cloud_.width - 1))  // add point to the top except when at the top row
         {
-          if(std::isnan(correction_cloud_.points.at(i-correction_cloud_.width).z) == 0)
+          if (std::isnan(correction_cloud_.points.at(i - correction_cloud_.width).z) == 0)
           {
-            val += correction_cloud_.points.at(i-correction_cloud_.width).z;
+            val += correction_cloud_.points.at(i - correction_cloud_.width).z;
             ++count;
           }
         }
 
-        if((i+1) < correction_cloud_.height * correction_cloud_.width - correction_cloud_.width ) // add point to the bottom except when at the bottom row
+        if ((i + 1) < correction_cloud_.height * correction_cloud_.width -
+                          correction_cloud_.width)  // add point to the bottom except when at the bottom row
         {
-          if(std::isnan(correction_cloud_.points.at(i+correction_cloud_.width).z) == 0)
+          if (std::isnan(correction_cloud_.points.at(i + correction_cloud_.width).z) == 0)
           {
-            val += correction_cloud_.points.at(i+correction_cloud_.width).z;
+            val += correction_cloud_.points.at(i + correction_cloud_.width).z;
             ++count;
           }
         }
 
-        if(count > 0)
+        if (count > 0)
         {
           pcl::PointXYZ pt;
           pt.x = 0;
@@ -400,31 +400,31 @@ bool DepthCalibrator::calibrateCameraPixelDepth(std_srvs::Empty::Request &reques
   correction_cloud_.is_dense = false;
 
   // Store depth correction results
-  if(save_data_)
+  if (save_data_)
   {
     std::string out_file = filepath_ + "/" + filename_ + ".pcd";
     ROS_INFO_STREAM("Done generating depth correction point cloud.  Saving results to " << out_file);
-    pcl::io::savePCDFile( out_file, correction_cloud_);
+    pcl::io::savePCDFile(out_file, correction_cloud_);
   }
 
   return true;
 }
 
-bool DepthCalibrator::setStoreCloud(std_srvs::Empty::Request &request, std_srvs::Empty::Response &response)
+bool DepthCalibrator::setStoreCloud(std_srvs::Empty::Request& request, std_srvs::Empty::Response& response)
 {
   geometry_msgs::Pose target_pose;
 
   try
   {
-    std::vector<double> plane_eq;
-    if(!findAveragePlane(plane_eq, target_pose))
+    std::vector< double > plane_eq;
+    if (!findAveragePlane(plane_eq, target_pose))
     {
       ROS_ERROR("Failed to get target pose.  Not storing depth data");
       return false;
     }
 
-    pcl::PointCloud<pcl::PointXYZ> avg_cloud;
-    if(!findAveragePointCloud(avg_cloud))
+    pcl::PointCloud< pcl::PointXYZ > avg_cloud;
+    if (!findAveragePointCloud(avg_cloud))
     {
       ROS_ERROR("Failed to get average point cloud.  Not storing depth data");
       return false;
@@ -440,19 +440,18 @@ bool DepthCalibrator::setStoreCloud(std_srvs::Empty::Request &request, std_srvs:
 
       ROS_INFO("Point cloud and image successfully collected");
     }
-
-
   }
-  catch(...)
+  catch (...)
   {
     ROS_ERROR("Error attempting to store point cloud");
   }
   return true;
 }
 
-void DepthCalibrator::updateInputData(const sensor_msgs::PointCloud2ConstPtr& cloud, const sensor_msgs::ImageConstPtr &image)
+void DepthCalibrator::updateInputData(const sensor_msgs::PointCloud2ConstPtr& cloud,
+                                      const sensor_msgs::ImageConstPtr& image)
 {
-  boost::lock_guard<boost::mutex> lock(data_lock_);
+  boost::lock_guard< boost::mutex > lock(data_lock_);
 
   sensor_msgs::PointCloud2 temp_cloud;
   last_image_ = *image;
@@ -461,27 +460,27 @@ void DepthCalibrator::updateInputData(const sensor_msgs::PointCloud2ConstPtr& cl
   pcl::fromROSMsg(temp_cloud, last_cloud_);
 }
 
-bool DepthCalibrator::findAveragePlane(std::vector<double>& plane_eq, geometry_msgs::Pose& target_pose)
+bool DepthCalibrator::findAveragePlane(std::vector< double >& plane_eq, geometry_msgs::Pose& target_pose)
 {
   bool rtn = false;
 
   plane_eq.clear();
   geometry_msgs::Pose temp_pose;
-  std::vector<double> a, b, c, d;
+  std::vector< double > a, b, c, d;
   int error = 0;
 
   // Find the target multiple times or until the error limit is reached
-  while(a.size() < num_views_ && error < num_attempts_)
+  while (a.size() < num_views_ && error < num_attempts_)
   {
-
-    if(!findTarget(10.0, temp_pose))
+    if (!findTarget(10.0, temp_pose))
     {
       ++error;
       continue;
     }
-    ROS_WARN("found target at xyz: (%.2f, %.2f, %.2f) wxyz: (%.2f, %.2f, %.2f, %.2f)", temp_pose.position.x, temp_pose.position.y, temp_pose.position.z,
-             temp_pose.orientation.w, temp_pose.orientation.x, temp_pose.orientation.y, temp_pose.orientation.z);
-    //Create plane equation from target pose
+    ROS_WARN("found target at xyz: (%.2f, %.2f, %.2f) wxyz: (%.2f, %.2f, %.2f, %.2f)", temp_pose.position.x,
+             temp_pose.position.y, temp_pose.position.z, temp_pose.orientation.w, temp_pose.orientation.x,
+             temp_pose.orientation.y, temp_pose.orientation.z);
+    // Create plane equation from target pose
     tf::Transform transform;
     tf::poseMsgToTF(temp_pose, transform);
 
@@ -494,17 +493,17 @@ bool DepthCalibrator::findAveragePlane(std::vector<double>& plane_eq, geometry_m
     a.push_back(pa);
     b.push_back(pb);
     c.push_back(pc);
-    d.push_back(-pa*transform.getOrigin().x() - pb*transform.getOrigin().y() - pc*transform.getOrigin().z());
+    d.push_back(-pa * transform.getOrigin().x() - pb * transform.getOrigin().y() - pc * transform.getOrigin().z());
   }
 
   target_pose = temp_pose;
 
-  if(error < num_attempts_)
+  if (error < num_attempts_)
   {
     // calculate the average plane equation parameters
     double avg_a, avg_b, avg_c, avg_d, std_a, std_b, std_c, std_d;
     avg_a = avg_b = avg_c = avg_d = std_a = std_b = std_c = std_d = 0;
-    for(int i = 0; i < a.size(); ++i)
+    for (int i = 0; i < a.size(); ++i)
     {
       avg_a += a[i];
       avg_b += b[i];
@@ -516,20 +515,20 @@ bool DepthCalibrator::findAveragePlane(std::vector<double>& plane_eq, geometry_m
     avg_c = avg_c / c.size();
     avg_d = avg_d / d.size();
 
-    for(int i = 0; i < a.size(); ++i)
+    for (int i = 0; i < a.size(); ++i)
     {
       std_a += pow(a[i] - avg_a, 2.0);
       std_b += pow(b[i] - avg_b, 2.0);
       std_c += pow(c[i] - avg_c, 2.0);
       std_d += pow(d[i] - avg_d, 2.0);
     }
-    std_a = sqrt(std_a/ (a.size()-1));
-    std_b = sqrt(std_a/ (a.size()-1));
-    std_c = sqrt(std_a/ (a.size()-1));
-    std_d = sqrt(std_a/ (a.size()-1));
+    std_a = sqrt(std_a / (a.size() - 1));
+    std_b = sqrt(std_a / (a.size() - 1));
+    std_c = sqrt(std_a / (a.size() - 1));
+    std_d = sqrt(std_a / (a.size() - 1));
 
     // If standard deviation is too large, return an error
-    if(std_a < std_dev_error_ && std_b < std_dev_error_ && std_c < std_dev_error_ && std_d < std_dev_error_)
+    if (std_a < std_dev_error_ && std_b < std_dev_error_ && std_c < std_dev_error_ && std_d < std_dev_error_)
     {
       plane_eq.push_back(avg_a);
       plane_eq.push_back(avg_b);
@@ -550,10 +549,10 @@ bool DepthCalibrator::findAveragePlane(std::vector<double>& plane_eq, geometry_m
   return rtn;
 }
 
-bool DepthCalibrator::findTarget(const double &final_cost, geometry_msgs::Pose& target_pose)
+bool DepthCalibrator::findTarget(const double& final_cost, geometry_msgs::Pose& target_pose)
 {
   bool rtn = true;
-  //Get target pose
+  // Get target pose
   target_finder::target_locaterRequest target_request;
   target_finder::target_locaterResponse target_response;
   target_request.allowable_cost_per_observation = 5000.0;
@@ -564,12 +563,12 @@ bool DepthCalibrator::findTarget(const double &final_cost, geometry_msgs::Pose& 
   target_request.roi.y_offset = 0;
   target_request.initial_pose = target_initial_pose_;
 
-  if(!get_target_pose_.call(target_request, target_response))
+  if (!get_target_pose_.call(target_request, target_response))
   {
     ROS_ERROR("Failed to get target pose.");
     rtn = false;
   }
-  else if(target_response.final_cost_per_observation > final_cost)
+  else if (target_response.final_cost_per_observation > final_cost)
   {
     ROS_ERROR("Target pose error too large (%.3f).", target_response.final_cost_per_observation);
     rtn = false;

--- a/rgbd_depth_correction/src/depth_correction.cpp
+++ b/rgbd_depth_correction/src/depth_correction.cpp
@@ -30,38 +30,40 @@
 
 #include <industrial_extrinsic_cal/yaml_utils.h>
 
-
-namespace rgbd_depth_correction{
-
+namespace rgbd_depth_correction
+{
 class DepthCorrectionNodelet : public nodelet::Nodelet
 {
 private:
+  bool use_depth_exp_; /**< @brief Flag to determine whether to use the depth coefficients or not */
+  double d1_, d2_;     /**< @brief The depth coefficients */
 
-  bool use_depth_exp_;  /**< @brief Flag to determine whether to use the depth coefficients or not */
-  double d1_, d2_;      /**< @brief The depth coefficients */
+  int version_; /**< @brief The version number found in the YAML file */
+  pcl::PointCloud< pcl::PointXYZ >
+      correction_cloud_; /**< @brief The depth correction point cloud containing the depth correction values */
 
-  int version_;  /**< @brief The version number found in the YAML file */
-  pcl::PointCloud<pcl::PointXYZ> correction_cloud_;  /**< @brief The depth correction point cloud containing the depth correction values */
-
-  ros::Subscriber pcl_sub_;          /**< @brief PCL point cloud subscriber */
-  ros::Publisher pcl_pub_;           /**< @brief PCL point cloud publisher for the corrected point cloud */
-  ros::ServiceServer depth_change_;  /**< @brief The service server for changing whether to use the depth coefficients or not */
+  ros::Subscriber pcl_sub_; /**< @brief PCL point cloud subscriber */
+  ros::Publisher pcl_pub_;  /**< @brief PCL point cloud publisher for the corrected point cloud */
+  ros::ServiceServer
+      depth_change_; /**< @brief The service server for changing whether to use the depth coefficients or not */
 
   /**
      * @brief PCL raw point cloud subscriber callback
      *
      * @param[in] cloud Latest point cloud received
      */
-  void pointcloudCallback(const pcl::PointCloud<pcl::PointXYZ>::ConstPtr& cloud);
+  void pointcloudCallback(const pcl::PointCloud< pcl::PointXYZ >::ConstPtr& cloud);
 
   /**
-     * @brief Give a pathway and file name, reads the version number and loads the appropriate depth correction parameters
+     * @brief Give a pathway and file name, reads the version number and loads the appropriate depth correction
+   * parameters
      *
      * @param[in] pathway The pathway to the file to be read
      * @param[in] yaml_file The name of the file to be read
-     * @return True if the YAML file was read correctly, false if there was an error or the file is not of the correct version
+     * @return True if the YAML file was read correctly, false if there was an error or the file is not of the correct
+   * version
      */
-  bool readYamlFile(const std::string & pathway, const std::string & yaml_file);
+  bool readYamlFile(const std::string& pathway, const std::string& yaml_file);
 
   /**
      * @brief Reads and loads the parameters for depth correction version one
@@ -71,22 +73,23 @@ private:
      */
   void loadVersionOne(const YAML::Node& doc, const std::string& file);
   /**
-     * @brief Peforms point cloud depth correction using the version one parameters and equations, then republishes the corrected cloud
+     * @brief Peforms point cloud depth correction using the version one parameters and equations, then republishes the
+   * corrected cloud
      *
      * @param[in] cloud The point cloud to be corrected and republished
      */
-  void correctionVersionOne(const pcl::PointCloud<pcl::PointXYZ>::ConstPtr &cloud);
+  void correctionVersionOne(const pcl::PointCloud< pcl::PointXYZ >::ConstPtr& cloud);
 
 public:
-
   /**
-     * @brief For debug testing, turns off/on the use of the depth correction coefficients to see how accurate the results are
+     * @brief For debug testing, turns off/on the use of the depth correction coefficients to see how accurate the
+   * results are
      *
      * @param[in] request Empty
      * @param[out] response Empty
      * @return always returns true
      */
-  bool setEnableDepth(std_srvs::Empty::Request &request, std_srvs::Empty::Response &response)
+  bool setEnableDepth(std_srvs::Empty::Request& request, std_srvs::Empty::Response& response)
   {
     use_depth_exp_ = !use_depth_exp_;
     ROS_INFO_STREAM("Using depth exponential correction: " << use_depth_exp_);
@@ -104,20 +107,21 @@ public:
 
     std::string filename, filepath;
 
-    if(!priv_nh.getParam("filepath", filepath))
+    if (!priv_nh.getParam("filepath", filepath))
     {
       ROS_ERROR("File pathway not provided.  Closing depth correction node.");
       return;
     }
 
     // Check for filename argument first, use 'get_serial' service if argument is not provided
-    if(priv_nh.getParam("filename", filename))
+    if (priv_nh.getParam("filename", filename))
     {
       ROS_INFO("Using provided camera file name argument '%s' for depth correction", filename.c_str());
     }
     else
     {
-      ROS_ERROR("Cannot open configuration files because parameter 'filename' not provided. Closing depth correction node.");
+      ROS_ERROR("Cannot open configuration files because parameter 'filename' not provided. Closing depth correction "
+                "node.");
       return;
     }
 
@@ -125,7 +129,7 @@ public:
 
     ROS_INFO_STREAM("Reading in yaml file " << filepath << filename << ".yaml");
 
-    if(!readYamlFile(filepath, filename))
+    if (!readYamlFile(filepath, filename))
     {
       ROS_ERROR("Error reading YAML config file.  Closing depth correction node.");
       return;
@@ -133,38 +137,39 @@ public:
 
     ROS_INFO("Done reading yaml file");
 
-    pcl_pub_ = nh.advertise<pcl::PointCloud<pcl::PointXYZ> >("out_cloud",1);
+    pcl_pub_ = nh.advertise< pcl::PointCloud< pcl::PointXYZ > >("out_cloud", 1);
     pcl_sub_ = nh.subscribe("in_cloud", 1, &DepthCorrectionNodelet::pointcloudCallback, this);
 
     depth_change_ = nh.advertiseService("change_depth_factor", &DepthCorrectionNodelet::setEnableDepth, this);
-
   }
 };
 
-void DepthCorrectionNodelet::pointcloudCallback(const pcl::PointCloud<pcl::PointXYZ>::ConstPtr &cloud)
+void DepthCorrectionNodelet::pointcloudCallback(const pcl::PointCloud< pcl::PointXYZ >::ConstPtr& cloud)
 {
-  switch(version_)
+  switch (version_)
   {
     case 1:
       correctionVersionOne(cloud);
       break;
     default:
-      ROS_ERROR_STREAM_THROTTLE(120, "Depth calibration file version does not match any known versions.  Not performing depth correction");
+      ROS_ERROR_STREAM_THROTTLE(120, "Depth calibration file version does not match any known versions.  Not "
+                                     "performing depth correction");
       break;
   }
 }
 
-bool DepthCorrectionNodelet::readYamlFile(const std::string &pathway, const std::string &yaml_file)
+bool DepthCorrectionNodelet::readYamlFile(const std::string& pathway, const std::string& yaml_file)
 {
   bool rtn = true;
   std::string file;
   file = pathway + yaml_file + ".yaml";
   YAML::Node doc;
-  if(!industrial_extrinsic_cal::yamlNodeFromFileName(file, doc)){
+  if (!industrial_extrinsic_cal::yamlNodeFromFileName(file, doc))
+  {
     ROS_ERROR("could not open yaml file %s", file.c_str());
     rtn = false;
   }
-  else if(!industrial_extrinsic_cal::parseInt(doc, "version", version_))
+  else if (!industrial_extrinsic_cal::parseInt(doc, "version", version_))
   {
     ROS_ERROR("Yaml file did not contain depth correction version information");
     rtn = false;
@@ -185,14 +190,14 @@ bool DepthCorrectionNodelet::readYamlFile(const std::string &pathway, const std:
   return rtn;
 }
 
-void DepthCorrectionNodelet::loadVersionOne(const YAML::Node &doc, const std::string &file)
+void DepthCorrectionNodelet::loadVersionOne(const YAML::Node& doc, const std::string& file)
 {
-  if(!industrial_extrinsic_cal::parseDouble(doc, "d1", d1_) )
+  if (!industrial_extrinsic_cal::parseDouble(doc, "d1", d1_))
   {
     ROS_ERROR("Yaml file did not contain depth correction parameter d1, setting to zero");
     d1_ = 0;
   }
-  if(!industrial_extrinsic_cal::parseDouble(doc, "d2", d2_))
+  if (!industrial_extrinsic_cal::parseDouble(doc, "d2", d2_))
   {
     ROS_ERROR("Yaml file did not contain depth correction parameter d2, setting to zero");
     d2_ = 0;
@@ -205,21 +210,22 @@ void DepthCorrectionNodelet::loadVersionOne(const YAML::Node &doc, const std::st
   pcl::io::loadPCDFile(pcd_file, correction_cloud_);
 }
 
-void DepthCorrectionNodelet::correctionVersionOne(const pcl::PointCloud<pcl::PointXYZ>::ConstPtr &cloud)
+void DepthCorrectionNodelet::correctionVersionOne(const pcl::PointCloud< pcl::PointXYZ >::ConstPtr& cloud)
 {
-  pcl::PointCloud<pcl::PointXYZ> corrected_cloud = *cloud;
-  if(correction_cloud_.points.size() == cloud->points.size())
+  pcl::PointCloud< pcl::PointXYZ > corrected_cloud = *cloud;
+  if (correction_cloud_.points.size() == cloud->points.size())
   {
-    for(int i = 0; i < corrected_cloud.points.size(); ++i)
+    for (int i = 0; i < corrected_cloud.points.size(); ++i)
     {
-      if(std::isnan(corrected_cloud.points.at(i).x) || std::isnan(correction_cloud_.points.at(i).z))
+      if (std::isnan(corrected_cloud.points.at(i).x) || std::isnan(correction_cloud_.points.at(i).z))
       {
         continue;
       }
 
-      if(use_depth_exp_)
+      if (use_depth_exp_)
       {
-        corrected_cloud.points.at(i).z += correction_cloud_.points.at(i).z * exp(d1_ + d2_ * corrected_cloud.points.at(i).z);
+        corrected_cloud.points.at(i).z +=
+            correction_cloud_.points.at(i).z * exp(d1_ + d2_ * corrected_cloud.points.at(i).z);
       }
       else
       {
@@ -229,12 +235,14 @@ void DepthCorrectionNodelet::correctionVersionOne(const pcl::PointCloud<pcl::Poi
   }
   else
   {
-    ROS_ERROR_STREAM_THROTTLE(30, "Depth correction cloud size and input point cloud size do not match.  Not performing depth correction");
+    ROS_ERROR_STREAM_THROTTLE(30, "Depth correction cloud size and input point cloud size do not match.  Not "
+                                  "performing depth correction");
   }
 
-  pcl::PointCloud<pcl::PointXYZ>::Ptr published_cloud = corrected_cloud.makeShared();
+  pcl::PointCloud< pcl::PointXYZ >::Ptr published_cloud = corrected_cloud.makeShared();
   pcl_pub_.publish(published_cloud);
 }
 
-PLUGINLIB_DECLARE_CLASS(rgbd_depth_correction, DepthCorrectionNodelet, rgbd_depth_correction::DepthCorrectionNodelet, nodelet::Nodelet);
+PLUGINLIB_DECLARE_CLASS(rgbd_depth_correction, DepthCorrectionNodelet, rgbd_depth_correction::DepthCorrectionNodelet,
+                        nodelet::Nodelet);
 }

--- a/target_finder/src/nodes/call_service.cpp
+++ b/target_finder/src/nodes/call_service.cpp
@@ -23,7 +23,7 @@
 #include <ros/ros.h>
 #include <ros/package.h>
 #include <ros/console.h>
-#include <target_finder/target_locater.h> 
+#include <target_finder/target_locater.h>
 #include <tf/transform_broadcaster.h>
 
 using std::string;
@@ -32,25 +32,28 @@ using std::vector;
 class callService
 {
 public:
-  callService(ros::NodeHandle nh): nh_(nh)
+  callService(ros::NodeHandle nh) : nh_(nh)
   {
-    client_ = nh_.serviceClient<target_finder::target_locater>("TargetLocateService");
-    ros::NodeHandle pnh("~") ;
-    if(!pnh.getParam("roi_width", roi_width_)){
+    client_ = nh_.serviceClient< target_finder::target_locater >("TargetLocateService");
+    ros::NodeHandle pnh("~");
+    if (!pnh.getParam("roi_width", roi_width_))
+    {
       roi_width_ = 1280;
     }
-    if(!pnh.getParam("roi_height", roi_height_)){
+    if (!pnh.getParam("roi_height", roi_height_))
+    {
       roi_height_ = 1024;
     }
-    if(!pnh.getParam("optical_frame", optical_frame_)){
+    if (!pnh.getParam("optical_frame", optical_frame_))
+    {
       optical_frame_ = "basler1_optical_frame";
     }
     setRequest();
-
   }
   bool callTheService();
   void copyResponseToRequest();
   void setRequest();
+
 private:
   ros::NodeHandle nh_;
   ros::ServiceClient client_;
@@ -64,18 +67,19 @@ private:
 void callService::copyResponseToRequest()
 {
   setRequest();
-  srv_.request.initial_pose.position.x        =  srv_.response.final_pose.position.x;
-  srv_.request.initial_pose.position.y        =  srv_.response.final_pose.position.y;
-  srv_.request.initial_pose.position.z        =  srv_.response.final_pose.position.z;
-  srv_.request.initial_pose.orientation.x	  =   srv_.response.final_pose.orientation.x;
-  srv_.request.initial_pose.orientation.y	  =   srv_.response.final_pose.orientation.y;
-  srv_.request.initial_pose.orientation.z	  =   srv_.response.final_pose.orientation.z;
-  srv_.request.initial_pose.orientation.w	  =   srv_.response.final_pose.orientation.w;
+  srv_.request.initial_pose.position.x = srv_.response.final_pose.position.x;
+  srv_.request.initial_pose.position.y = srv_.response.final_pose.position.y;
+  srv_.request.initial_pose.position.z = srv_.response.final_pose.position.z;
+  srv_.request.initial_pose.orientation.x = srv_.response.final_pose.orientation.x;
+  srv_.request.initial_pose.orientation.y = srv_.response.final_pose.orientation.y;
+  srv_.request.initial_pose.orientation.z = srv_.response.final_pose.orientation.z;
+  srv_.request.initial_pose.orientation.w = srv_.response.final_pose.orientation.w;
 }
 bool callService::callTheService()
 {
-  if(client_.call(srv_)){
-    double x,y,z,qx,qy,qz,qw;
+  if (client_.call(srv_))
+  {
+    double x, y, z, qx, qy, qz, qw;
     x = srv_.response.final_pose.position.x;
     y = srv_.response.final_pose.position.y;
     z = srv_.response.final_pose.position.z;
@@ -84,58 +88,54 @@ bool callService::callTheService()
     qz = srv_.response.final_pose.orientation.z;
     qw = srv_.response.final_pose.orientation.w;
     ROS_INFO("Pose: tx= %5.4lf  %5.4lf  %5.4lf quat= %5.3lf  %5.3lf  %5.3lf %5.3lf, cost= %5.3lf",
-	     srv_.response.final_pose.position.x,
-	     srv_.response.final_pose.position.y,
-	     srv_.response.final_pose.position.z,
-	     srv_.response.final_pose.orientation.x,
-	     srv_.response.final_pose.orientation.y,
-	     srv_.response.final_pose.orientation.z,
-	     srv_.response.final_pose.orientation.w,
-	     srv_.response.final_cost_per_observation);
+             srv_.response.final_pose.position.x, srv_.response.final_pose.position.y,
+             srv_.response.final_pose.position.z, srv_.response.final_pose.orientation.x,
+             srv_.response.final_pose.orientation.y, srv_.response.final_pose.orientation.z,
+             srv_.response.final_pose.orientation.w, srv_.response.final_cost_per_observation);
     tf::Transform camera_to_target;
-    tf::Quaternion quat(qx,qy,qz,qw);
-    camera_to_target.setOrigin(tf::Vector3(x,y,z));
+    tf::Quaternion quat(qx, qy, qz, qw);
+    camera_to_target.setOrigin(tf::Vector3(x, y, z));
     camera_to_target.setRotation(quat);
     tf::StampedTransform stf(camera_to_target, ros::Time::now(), optical_frame_.c_str(), "target_frame");
     tf_broadcaster_.sendTransform(stf);
-    return(true);
+    return (true);
   }
   ROS_ERROR("Target Location Failure");
-  return(false);
-
+  return (false);
 }
 void callService::setRequest()
 {
-    srv_.request.roi.x_offset =0;
-    srv_.request.roi.y_offset =0;
-    srv_.request.roi.width = roi_width_;
-    srv_.request.roi.height = roi_height_;
-    srv_.request.initial_pose.position.x = 0.0;
-    srv_.request.initial_pose.position.y = 0.1;
-    srv_.request.initial_pose.position.z = 1.0;
-    srv_.request.initial_pose.orientation.x = 1.0;
-    srv_.request.initial_pose.orientation.y = 0.0;
-    srv_.request.initial_pose.orientation.z = 0.0;
-    srv_.request.initial_pose.orientation.w = 0.00000000001;
-    srv_.request.allowable_cost_per_observation = 7.0;
+  srv_.request.roi.x_offset = 0;
+  srv_.request.roi.y_offset = 0;
+  srv_.request.roi.width = roi_width_;
+  srv_.request.roi.height = roi_height_;
+  srv_.request.initial_pose.position.x = 0.0;
+  srv_.request.initial_pose.position.y = 0.1;
+  srv_.request.initial_pose.position.z = 1.0;
+  srv_.request.initial_pose.orientation.x = 1.0;
+  srv_.request.initial_pose.orientation.y = 0.0;
+  srv_.request.initial_pose.orientation.z = 0.0;
+  srv_.request.initial_pose.orientation.w = 0.00000000001;
+  srv_.request.allowable_cost_per_observation = 7.0;
 }
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
   ros::init(argc, argv, "call_service");
   ros::NodeHandle nh;
   callService call_service(nh);
   ros::Rate loop_rate(10);
-  while(ros::ok()){
-    if(call_service.callTheService()){
+  while (ros::ok())
+  {
+    if (call_service.callTheService())
+    {
       call_service.copyResponseToRequest();
     }
-    else{
+    else
+    {
       call_service.setRequest();
     }
     ros::spinOnce();
     loop_rate.sleep();
   }
 }
-
-

--- a/target_finder/src/nodes/dual_camera_cs.cpp
+++ b/target_finder/src/nodes/dual_camera_cs.cpp
@@ -23,7 +23,7 @@
 #include <ros/ros.h>
 #include <ros/package.h>
 #include <ros/console.h>
-#include <target_finder/target_locater.h> 
+#include <target_finder/target_locater.h>
 #include <tf/transform_broadcaster.h>
 
 using std::string;
@@ -32,46 +32,55 @@ using std::vector;
 class callService
 {
 public:
-  callService(ros::NodeHandle nh): nh_(nh)
+  callService(ros::NodeHandle nh) : nh_(nh)
   {
-
-    ros::NodeHandle pnh("~") ;
-    std::string c1_cs, c2_cs;// the call service names for each camera
-    if(!pnh.getParam("camera1_target_locate_service", c1_cs)){
+    ros::NodeHandle pnh("~");
+    std::string c1_cs, c2_cs;  // the call service names for each camera
+    if (!pnh.getParam("camera1_target_locate_service", c1_cs))
+    {
       ROS_ERROR("must define camera1_target_locate_service parameter");
       exit(1);
     }
-    if(!pnh.getParam("camera2_target_locate_service", c2_cs)){
+    if (!pnh.getParam("camera2_target_locate_service", c2_cs))
+    {
       ROS_ERROR("must define camera1_target_locate_service parameter");
       exit(1);
     }
-    ROS_INFO("C1 service = %s",c1_cs.c_str());
-    ROS_INFO("C2 service = %s",c2_cs.c_str());
-    c1_client_ = nh_.serviceClient<target_finder::target_locater>(c1_cs.c_str());
-    c2_client_ = nh_.serviceClient<target_finder::target_locater>(c2_cs.c_str());
+    ROS_INFO("C1 service = %s", c1_cs.c_str());
+    ROS_INFO("C2 service = %s", c2_cs.c_str());
+    c1_client_ = nh_.serviceClient< target_finder::target_locater >(c1_cs.c_str());
+    c2_client_ = nh_.serviceClient< target_finder::target_locater >(c2_cs.c_str());
 
-    if(!pnh.getParam("c1_roi_width", c1_roi_width_)){
-     c1_roi_width_ = 1280;
+    if (!pnh.getParam("c1_roi_width", c1_roi_width_))
+    {
+      c1_roi_width_ = 1280;
     }
-    if(!pnh.getParam("c2_roi_width", c2_roi_width_)){
+    if (!pnh.getParam("c2_roi_width", c2_roi_width_))
+    {
       c2_roi_width_ = 1280;
     }
-    if(!pnh.getParam("c1_roi_height", c1_roi_height_)){
+    if (!pnh.getParam("c1_roi_height", c1_roi_height_))
+    {
       c1_roi_height_ = 1024;
     }
-    if(!pnh.getParam("c2_roi_height", c2_roi_height_)){
+    if (!pnh.getParam("c2_roi_height", c2_roi_height_))
+    {
       c2_roi_height_ = 1024;
     }
-    if(!pnh.getParam("c1_optical_frame", c1_optical_frame_)){
+    if (!pnh.getParam("c1_optical_frame", c1_optical_frame_))
+    {
       c1_optical_frame_ = "basler1_optical_frame";
     }
-    if(!pnh.getParam("c2_optical_frame", c2_optical_frame_)){
+    if (!pnh.getParam("c2_optical_frame", c2_optical_frame_))
+    {
       c2_optical_frame_ = "basler2_optical_frame";
     }
-    if(!pnh.getParam("c1_target_frame", c1_target_frame_)){
+    if (!pnh.getParam("c1_target_frame", c1_target_frame_))
+    {
       c1_target_frame_ = "target_frame";
     }
-    if(!pnh.getParam("c2_target_frame", c2_target_frame_)){
+    if (!pnh.getParam("c2_target_frame", c2_target_frame_))
+    {
       c2_target_frame_ = "c2_target_frame";
     }
     setRequest();
@@ -80,6 +89,7 @@ public:
   void copyResponseToRequest();
   void setRequest();
   bool resetC2();
+
 private:
   ros::NodeHandle nh_;
   ros::ServiceClient c1_client_, c2_client_;
@@ -95,29 +105,30 @@ private:
 void callService::copyResponseToRequest()
 {
   setRequest();
-  c1_srv_.request.initial_pose.position.x        =  c1_srv_.response.final_pose.position.x;
-  c1_srv_.request.initial_pose.position.y        =  c1_srv_.response.final_pose.position.y;
-  c1_srv_.request.initial_pose.position.z        =  c1_srv_.response.final_pose.position.z;
-  c1_srv_.request.initial_pose.orientation.x   =   c1_srv_.response.final_pose.orientation.x;
-  c1_srv_.request.initial_pose.orientation.y   =   c1_srv_.response.final_pose.orientation.y;
-  c1_srv_.request.initial_pose.orientation.z   =   c1_srv_.response.final_pose.orientation.z;
-  c1_srv_.request.initial_pose.orientation.w  =   c1_srv_.response.final_pose.orientation.w;
+  c1_srv_.request.initial_pose.position.x = c1_srv_.response.final_pose.position.x;
+  c1_srv_.request.initial_pose.position.y = c1_srv_.response.final_pose.position.y;
+  c1_srv_.request.initial_pose.position.z = c1_srv_.response.final_pose.position.z;
+  c1_srv_.request.initial_pose.orientation.x = c1_srv_.response.final_pose.orientation.x;
+  c1_srv_.request.initial_pose.orientation.y = c1_srv_.response.final_pose.orientation.y;
+  c1_srv_.request.initial_pose.orientation.z = c1_srv_.response.final_pose.orientation.z;
+  c1_srv_.request.initial_pose.orientation.w = c1_srv_.response.final_pose.orientation.w;
 
-  c2_srv_.request.initial_pose.position.x        =  c2_srv_.response.final_pose.position.x;
-  c2_srv_.request.initial_pose.position.y        =  c2_srv_.response.final_pose.position.y;
-  c2_srv_.request.initial_pose.position.z        =  c2_srv_.response.final_pose.position.z;
-  c2_srv_.request.initial_pose.orientation.x   =   c2_srv_.response.final_pose.orientation.x;
-  c2_srv_.request.initial_pose.orientation.y   =   c2_srv_.response.final_pose.orientation.y;
-  c2_srv_.request.initial_pose.orientation.z   =   c2_srv_.response.final_pose.orientation.z;
-  c2_srv_.request.initial_pose.orientation.w  =   c2_srv_.response.final_pose.orientation.w;
+  c2_srv_.request.initial_pose.position.x = c2_srv_.response.final_pose.position.x;
+  c2_srv_.request.initial_pose.position.y = c2_srv_.response.final_pose.position.y;
+  c2_srv_.request.initial_pose.position.z = c2_srv_.response.final_pose.position.z;
+  c2_srv_.request.initial_pose.orientation.x = c2_srv_.response.final_pose.orientation.x;
+  c2_srv_.request.initial_pose.orientation.y = c2_srv_.response.final_pose.orientation.y;
+  c2_srv_.request.initial_pose.orientation.z = c2_srv_.response.final_pose.orientation.z;
+  c2_srv_.request.initial_pose.orientation.w = c2_srv_.response.final_pose.orientation.w;
 }
 bool callService::callTheService()
 {
-  bool c1_target_found=false;
-  bool c2_target_found=false;
+  bool c1_target_found = false;
+  bool c2_target_found = false;
 
-  if(c1_client_.call(c1_srv_)){
-    double x,y,z,qx,qy,qz,qw;
+  if (c1_client_.call(c1_srv_))
+  {
+    double x, y, z, qx, qy, qz, qw;
     x = c1_srv_.response.final_pose.position.x;
     y = c1_srv_.response.final_pose.position.y;
     z = c1_srv_.response.final_pose.position.z;
@@ -126,24 +137,22 @@ bool callService::callTheService()
     qz = c1_srv_.response.final_pose.orientation.z;
     qw = c1_srv_.response.final_pose.orientation.w;
     ROS_INFO("Camera1 Pose: tx= %5.4lf  %5.4lf  %5.4lf quat= %5.3lf  %5.3lf  %5.3lf %5.3lf, cost= %5.3lf",
-	     c1_srv_.response.final_pose.position.x,
-	     c1_srv_.response.final_pose.position.y,
-	     c1_srv_.response.final_pose.position.z,
-	     c1_srv_.response.final_pose.orientation.x,
-	     c1_srv_.response.final_pose.orientation.y,
-	     c1_srv_.response.final_pose.orientation.z,
-	     c1_srv_.response.final_pose.orientation.w,
-	     c1_srv_.response.final_cost_per_observation);
+             c1_srv_.response.final_pose.position.x, c1_srv_.response.final_pose.position.y,
+             c1_srv_.response.final_pose.position.z, c1_srv_.response.final_pose.orientation.x,
+             c1_srv_.response.final_pose.orientation.y, c1_srv_.response.final_pose.orientation.z,
+             c1_srv_.response.final_pose.orientation.w, c1_srv_.response.final_cost_per_observation);
     tf::Transform camera_to_target;
-    tf::Quaternion quat(qx,qy,qz,qw);
-    camera_to_target.setOrigin(tf::Vector3(x,y,z));
+    tf::Quaternion quat(qx, qy, qz, qw);
+    camera_to_target.setOrigin(tf::Vector3(x, y, z));
     camera_to_target.setRotation(quat);
-    tf::StampedTransform stf(camera_to_target.inverse(), ros::Time::now(), c1_target_frame_.c_str(), c1_optical_frame_.c_str() );
+    tf::StampedTransform stf(camera_to_target.inverse(), ros::Time::now(), c1_target_frame_.c_str(),
+                             c1_optical_frame_.c_str());
     tf_broadcaster_.sendTransform(stf);
     c1_target_found = 1;
   }
-  if(c2_client_.call(c2_srv_)){
-    double x,y,z,qx,qy,qz,qw;
+  if (c2_client_.call(c2_srv_))
+  {
+    double x, y, z, qx, qy, qz, qw;
     x = c2_srv_.response.final_pose.position.x;
     y = c2_srv_.response.final_pose.position.y;
     z = c2_srv_.response.final_pose.position.z;
@@ -152,53 +161,46 @@ bool callService::callTheService()
     qz = c2_srv_.response.final_pose.orientation.z;
     qw = c2_srv_.response.final_pose.orientation.w;
     ROS_INFO("Camera1 Pose: tx= %5.4lf  %5.4lf  %5.4lf quat= %5.3lf  %5.3lf  %5.3lf %5.3lf, cost= %5.3lf",
-	     c2_srv_.response.final_pose.position.x,
-	     c2_srv_.response.final_pose.position.y,
-	     c2_srv_.response.final_pose.position.z,
-	     c2_srv_.response.final_pose.orientation.x,
-	     c2_srv_.response.final_pose.orientation.y,
-	     c2_srv_.response.final_pose.orientation.z,
-	     c2_srv_.response.final_pose.orientation.w,
-	     c2_srv_.response.final_cost_per_observation);
+             c2_srv_.response.final_pose.position.x, c2_srv_.response.final_pose.position.y,
+             c2_srv_.response.final_pose.position.z, c2_srv_.response.final_pose.orientation.x,
+             c2_srv_.response.final_pose.orientation.y, c2_srv_.response.final_pose.orientation.z,
+             c2_srv_.response.final_pose.orientation.w, c2_srv_.response.final_cost_per_observation);
     tf::Transform camera_to_target;
-    tf::Quaternion quat(qx,qy,qz,qw);
-    camera_to_target.setOrigin(tf::Vector3(x,y,z));
+    tf::Quaternion quat(qx, qy, qz, qw);
+    camera_to_target.setOrigin(tf::Vector3(x, y, z));
     camera_to_target.setRotation(quat);
-    tf::StampedTransform stf(camera_to_target, ros::Time::now(),  c2_optical_frame_.c_str(), c2_target_frame_.c_str());
+    tf::StampedTransform stf(camera_to_target, ros::Time::now(), c2_optical_frame_.c_str(), c2_target_frame_.c_str());
     tf_broadcaster_.sendTransform(stf);
     c2_target_found = true;
   }
 
   // resend camera1 to camera2 tf
   ROS_INFO("publishing %s to %s %f %f %f", c1_optical_frame_.c_str(), c2_optical_frame_.c_str(),
-	   camera1_to_camera2_.getOrigin().x(),
-	   camera1_to_camera2_.getOrigin().y(),
-	   camera1_to_camera2_.getOrigin().z());
+           camera1_to_camera2_.getOrigin().x(), camera1_to_camera2_.getOrigin().y(),
+           camera1_to_camera2_.getOrigin().z());
 
   tf::StampedTransform stf(camera1_to_camera2_, ros::Time::now(), c1_optical_frame_.c_str(), c2_optical_frame_.c_str());
   tf_broadcaster_.sendTransform(stf);
 
-  if(!c1_target_found)
-    ROS_ERROR("Target Location Failure camera1");
-  if(!c2_target_found)
-    ROS_ERROR("Target Location Failure camera2");
-  if(c1_target_found && c2_target_found) return(true);
-  return(false);
-
+  if (!c1_target_found) ROS_ERROR("Target Location Failure camera1");
+  if (!c2_target_found) ROS_ERROR("Target Location Failure camera2");
+  if (c1_target_found && c2_target_found) return (true);
+  return (false);
 }
 
 bool callService::resetC2()
 {
-  bool c1_target_found=false;
-  bool c2_target_found=false;
+  bool c1_target_found = false;
+  bool c2_target_found = false;
   tf::Transform c1_to_target;
   tf::Transform c2_to_target;
 
-  while(!c1_client_.call(c1_srv_)){
+  while (!c1_client_.call(c1_srv_))
+  {
     ROS_ERROR("C1 call failed");
     sleep(1);
   }
-  double x,y,z,qx,qy,qz,qw;
+  double x, y, z, qx, qy, qz, qw;
   x = c1_srv_.response.final_pose.position.x;
   y = c1_srv_.response.final_pose.position.y;
   z = c1_srv_.response.final_pose.position.z;
@@ -206,12 +208,13 @@ bool callService::resetC2()
   qy = c1_srv_.response.final_pose.orientation.y;
   qz = c1_srv_.response.final_pose.orientation.z;
   qw = c1_srv_.response.final_pose.orientation.w;
-  tf::Quaternion quat(qx,qy,qz,qw);
-  c1_to_target.setOrigin(tf::Vector3(x,y,z));
+  tf::Quaternion quat(qx, qy, qz, qw);
+  c1_to_target.setOrigin(tf::Vector3(x, y, z));
   c1_to_target.setRotation(quat);
   c1_target_found = 1;
-  
-  while(!c2_client_.call(c2_srv_)){
+
+  while (!c2_client_.call(c2_srv_))
+  {
     ROS_ERROR("C2 call failed");
     sleep(1);
   }
@@ -222,78 +225,83 @@ bool callService::resetC2()
   qy = c2_srv_.response.final_pose.orientation.y;
   qz = c2_srv_.response.final_pose.orientation.z;
   qw = c2_srv_.response.final_pose.orientation.w;
-  tf::Quaternion quat2(qx,qy,qz,qw);
-  c2_to_target.setOrigin(tf::Vector3(x,y,z));
+  tf::Quaternion quat2(qx, qy, qz, qw);
+  c2_to_target.setOrigin(tf::Vector3(x, y, z));
   c2_to_target.setRotation(quat2);
   c2_target_found = 1;
 
-  if(c1_target_found && c2_target_found){
+  if (c1_target_found && c2_target_found)
+  {
     camera1_to_camera2_ = c1_to_target * c2_to_target.inverse();
-    return(true);
+    return (true);
   }
-  else{
+  else
+  {
     ROS_ERROR("Target Location Failure Did not reset C1-C2 Transform");
   }
-  return(false);
+  return (false);
 }
 void callService::setRequest()
 {
-    c1_srv_.request.roi.x_offset =0;
-    c1_srv_.request.roi.y_offset =0;
-    c1_srv_.request.roi.width = c1_roi_width_;
-    c1_srv_.request.roi.height = c1_roi_height_;
-    c1_srv_.request.initial_pose.position.x = 0.0;
-    c1_srv_.request.initial_pose.position.y = 0.1;
-    c1_srv_.request.initial_pose.position.z = 1.0;
-    c1_srv_.request.initial_pose.orientation.x = 1.0;
-    c1_srv_.request.initial_pose.orientation.y = 0.0;
-    c1_srv_.request.initial_pose.orientation.z = 0.0;
-    c1_srv_.request.initial_pose.orientation.w = 0.00000000001;
-    c1_srv_.request.allowable_cost_per_observation = 7.0;
+  c1_srv_.request.roi.x_offset = 0;
+  c1_srv_.request.roi.y_offset = 0;
+  c1_srv_.request.roi.width = c1_roi_width_;
+  c1_srv_.request.roi.height = c1_roi_height_;
+  c1_srv_.request.initial_pose.position.x = 0.0;
+  c1_srv_.request.initial_pose.position.y = 0.1;
+  c1_srv_.request.initial_pose.position.z = 1.0;
+  c1_srv_.request.initial_pose.orientation.x = 1.0;
+  c1_srv_.request.initial_pose.orientation.y = 0.0;
+  c1_srv_.request.initial_pose.orientation.z = 0.0;
+  c1_srv_.request.initial_pose.orientation.w = 0.00000000001;
+  c1_srv_.request.allowable_cost_per_observation = 7.0;
 
-    c2_srv_.request.roi.x_offset =0;
-    c2_srv_.request.roi.y_offset =0;
-    c2_srv_.request.roi.width = c2_roi_width_;
-    c2_srv_.request.roi.height = c2_roi_height_;
-    c2_srv_.request.initial_pose.position.x = 0.0;
-    c2_srv_.request.initial_pose.position.y = 0.1;
-    c2_srv_.request.initial_pose.position.z = 1.0;
-    c2_srv_.request.initial_pose.orientation.x = 1.0;
-    c2_srv_.request.initial_pose.orientation.y = 0.0;
-    c2_srv_.request.initial_pose.orientation.z = 0.0;
-    c2_srv_.request.initial_pose.orientation.w = 0.00000000001;
-    c2_srv_.request.allowable_cost_per_observation = 7.0;
+  c2_srv_.request.roi.x_offset = 0;
+  c2_srv_.request.roi.y_offset = 0;
+  c2_srv_.request.roi.width = c2_roi_width_;
+  c2_srv_.request.roi.height = c2_roi_height_;
+  c2_srv_.request.initial_pose.position.x = 0.0;
+  c2_srv_.request.initial_pose.position.y = 0.1;
+  c2_srv_.request.initial_pose.position.z = 1.0;
+  c2_srv_.request.initial_pose.orientation.x = 1.0;
+  c2_srv_.request.initial_pose.orientation.y = 0.0;
+  c2_srv_.request.initial_pose.orientation.z = 0.0;
+  c2_srv_.request.initial_pose.orientation.w = 0.00000000001;
+  c2_srv_.request.allowable_cost_per_observation = 7.0;
 }
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
   ros::init(argc, argv, "call_service");
   ros::NodeHandle nh;
-    ros::NodeHandle pnh("~") ;
+  ros::NodeHandle pnh("~");
   callService call_service(nh);
   ros::Rate loop_rate(10);
-  while(!call_service.resetC2()){
+  while (!call_service.resetC2())
+  {
     sleep(3);
-  } // initialized camera1 to camera2 transform
-  while(ros::ok()){
-    if(call_service.callTheService()){
+  }  // initialized camera1 to camera2 transform
+  while (ros::ok())
+  {
+    if (call_service.callTheService())
+    {
       call_service.copyResponseToRequest();
     }
-    else{
+    else
+    {
       call_service.setRequest();
     }
 
     // recompute camera1 to camera2 transform on request
     bool reset_camera2_tf;
     nh.getParam("reset_camera2_tf", reset_camera2_tf);
-    if(reset_camera2_tf){ 
+    if (reset_camera2_tf)
+    {
       call_service.resetC2();
       nh.setParam("reset_camera2_tf", false);
     }
-    
+
     ros::spinOnce();
     loop_rate.sleep();
   }
 }
-
-

--- a/target_finder/src/nodes/grid_generator.cpp
+++ b/target_finder/src/nodes/grid_generator.cpp
@@ -23,9 +23,10 @@
 
 using std::string;
 
-typedef struct point3d{
-  double x,y,z;
-}Point3d;
+typedef struct point3d
+{
+  double x, y, z;
+} Point3d;
 
 int main(int argc, char** argv)
 {
@@ -40,68 +41,82 @@ int main(int argc, char** argv)
   std::string transform_interface;
   int target_type;
 
-  if(!pnh.getParam( "target_rows", rows)){
+  if (!pnh.getParam("target_rows", rows))
+  {
     ROS_ERROR("Must set param:  target_rows");
   }
-  if(!pnh.getParam( "target_cols", cols)){
+  if (!pnh.getParam("target_cols", cols))
+  {
     ROS_ERROR("Must set param:  target_cols");
   }
-  if(!pnh.getParam( "target_circle_dia", diameter)){
+  if (!pnh.getParam("target_circle_dia", diameter))
+  {
     ROS_ERROR("Must set param:  target_circle_dia");
   }
-  if(!pnh.getParam( "target_spacing", spacing)){
+  if (!pnh.getParam("target_spacing", spacing))
+  {
     ROS_ERROR("Must set param:  target_spacing");
   }
-  if(!pnh.getParam( "target_type", target_type)){
+  if (!pnh.getParam("target_type", target_type))
+  {
     ROS_ERROR("Must set param:  target_type");
   }
-  if(!pnh.getParam( "target_name", target_name)){
+  if (!pnh.getParam("target_name", target_name))
+  {
     ROS_ERROR("Must set param:  target_name");
   }
-  if(!pnh.getParam( "target_frame", target_frame)){
+  if (!pnh.getParam("target_frame", target_frame))
+  {
     ROS_ERROR("Must set param:  target_frame");
   }
-  if(!pnh.getParam( "target_file_path", target_file_path)){
+  if (!pnh.getParam("target_file_path", target_file_path))
+  {
     ROS_ERROR("Must set param:  target_file_path");
   }
-  if(!pnh.getParam( "transform_interface", transform_interface)){
+  if (!pnh.getParam("transform_interface", transform_interface))
+  {
     ROS_ERROR("Must set param:  transform_interface");
   }
   // generate points
-  std::vector<Point3d> pts;
+  std::vector< Point3d > pts;
   pts.clear();
-  for(int i=0; i<rows; i++){
-    for(int j=0; j<cols; j++){
+  for (int i = 0; i < rows; i++)
+  {
+    for (int j = 0; j < cols; j++)
+    {
       Point3d point;
-      point.x = j*spacing;
-      point.y = (rows -1 -i)*spacing;
+      point.x = j * spacing;
+      point.y = (rows - 1 - i) * spacing;
       point.z = 0.0;
       pts.push_back(point);
     }
   }
 
   // write target
-  FILE *fp;
-  if((fp=fopen(target_file_path.c_str(),"w")) !=NULL){
-    fprintf(fp,"---\n\n");
-    fprintf(fp,"static_targets:\n");
-    fprintf(fp,"-\n");
-    fprintf(fp,"     target_name: %s\n", target_name.c_str());
-    fprintf(fp,"     target_type: %d\n", target_type);
-    fprintf(fp,"     circle_dia: %f\n", diameter);
-    fprintf(fp,"     target_frame: %s\n", target_frame.c_str());
-    fprintf(fp,"     transform_interface: %s\n", transform_interface.c_str());
-    fprintf(fp,"     xyz_aaxis_pose: [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]\n");
-    fprintf(fp,"     target_rows: %d\n", rows);
-    fprintf(fp,"     target_cols: %d\n", cols);
-    fprintf(fp,"     num_points: %d\n", (int)pts.size());
-    fprintf(fp,"     points: \n");
-    BOOST_FOREACH(Point3d pt, pts){
+  FILE* fp;
+  if ((fp = fopen(target_file_path.c_str(), "w")) != NULL)
+  {
+    fprintf(fp, "---\n\n");
+    fprintf(fp, "static_targets:\n");
+    fprintf(fp, "-\n");
+    fprintf(fp, "     target_name: %s\n", target_name.c_str());
+    fprintf(fp, "     target_type: %d\n", target_type);
+    fprintf(fp, "     circle_dia: %f\n", diameter);
+    fprintf(fp, "     target_frame: %s\n", target_frame.c_str());
+    fprintf(fp, "     transform_interface: %s\n", transform_interface.c_str());
+    fprintf(fp, "     xyz_aaxis_pose: [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]\n");
+    fprintf(fp, "     target_rows: %d\n", rows);
+    fprintf(fp, "     target_cols: %d\n", cols);
+    fprintf(fp, "     num_points: %d\n", (int)pts.size());
+    fprintf(fp, "     points: \n");
+    BOOST_FOREACH (Point3d pt, pts)
+    {
       fprintf(fp, "     - pnt: [ %7.4lf,  %7.4lf,  %7.4lf]\n", pt.x, pt.y, pt.z);
     }
     fclose(fp);
   }
-  else{
+  else
+  {
     ROS_ERROR("Could not open target file %s", target_file_path.c_str());
   }
   return 1;

--- a/target_finder/src/nodes/target_locator.cpp
+++ b/target_finder/src/nodes/target_locator.cpp
@@ -23,8 +23,8 @@
 #include <industrial_extrinsic_cal/user_accept.h>
 #include <industrial_extrinsic_cal/ros_camera_observer.h>
 #include <industrial_extrinsic_cal/basic_types.h>
-#include <industrial_extrinsic_cal/ceres_costs_utils.h> 
-#include <industrial_extrinsic_cal/ceres_costs_utils.hpp> 
+#include <industrial_extrinsic_cal/ceres_costs_utils.h>
+#include <industrial_extrinsic_cal/ceres_costs_utils.hpp>
 #include <target_finder/target_locater.h>
 #include "ceres/ceres.h"
 #include "ceres/rotation.h"
@@ -43,80 +43,87 @@ using industrial_extrinsic_cal::Roi;
 using industrial_extrinsic_cal::Pose6d;
 using industrial_extrinsic_cal::Point3d;
 using target_finder::target_locater;
-class TargetLocatorService 
+class TargetLocatorService
 {
 public:
   TargetLocatorService(ros::NodeHandle nh);
-  ~TargetLocatorService()  {  } ;
-  bool executeCallBack( target_locater::Request &req, target_locater::Response &res);
-  void  initMCircleTarget(int rows, int cols, double circle_dia, double spacing);
+  ~TargetLocatorService(){};
+  bool executeCallBack(target_locater::Request& req, target_locater::Response& res);
+  void initMCircleTarget(int rows, int cols, double circle_dia, double spacing);
   void initBallsTarget();
 
 private:
   ros::NodeHandle nh_;
   ros::ServiceServer target_locate_server_;
-  shared_ptr<Target> target_;
+  shared_ptr< Target > target_;
   string image_topic_;
   string camera_name_;
   int target_type_;
   int target_rows_;
   int target_cols_;
-
 };
 
 TargetLocatorService::TargetLocatorService(ros::NodeHandle nh)
 {
-  
   nh_ = nh;
   ros::NodeHandle pnh("~");
 
   int rows, cols;
   double diameter, spacing;
-  if(!pnh.getParam( "image_topic", image_topic_)){
+  if (!pnh.getParam("image_topic", image_topic_))
+  {
     ROS_ERROR("Must set param:  image_topic");
   }
 
-  if(!pnh.getParam( "target_type", target_type_)){
+  if (!pnh.getParam("target_type", target_type_))
+  {
     ROS_ERROR("Must set param: target_type");
-
   }
 
-  if(!pnh.getParam( "camera_name", camera_name_)){
+  if (!pnh.getParam("camera_name", camera_name_))
+  {
     ROS_ERROR("Must set param: camera_name");
-
   }
 
-  if(target_type_ == pattern_options::Balls){
+  if (target_type_ == pattern_options::Balls)
+  {
     ROS_ERROR("initializing balls target");
     initBallsTarget();
   }
-  else if(target_type_ == pattern_options::ModifiedCircleGrid){
-    if(!pnh.getParam( "target_rows", target_rows_)){
+  else if (target_type_ == pattern_options::ModifiedCircleGrid)
+  {
+    if (!pnh.getParam("target_rows", target_rows_))
+    {
       ROS_ERROR("Must set param:  target_rows");
     }
-    if(!pnh.getParam( "target_cols", target_cols_)){
+    if (!pnh.getParam("target_cols", target_cols_))
+    {
       ROS_ERROR("Must set param:  target_cols");
     }
-    if(!pnh.getParam( "target_circle_dia", diameter)){
+    if (!pnh.getParam("target_circle_dia", diameter))
+    {
       ROS_ERROR("Must set param:  target_circle_dia");
     }
-    if(!pnh.getParam( "target_spacing", spacing)){
+    if (!pnh.getParam("target_spacing", spacing))
+    {
       ROS_ERROR("Must set param:  target_spacing");
     }
     initMCircleTarget(target_rows_, target_cols_, diameter, spacing);
   }
-  else{
+  else
+  {
     ROS_ERROR("Target type not supported, check your launch file, only 2, and 4 for MCircle, and Balls type targets");
   }
 
   std::string service_name;
-  if(!pnh.getParam("service_name", service_name)){
+  if (!pnh.getParam("service_name", service_name))
+  {
     service_name = "TargetLocateService";
   }
-  target_locate_server_ = nh_.advertiseService( service_name.c_str(), &TargetLocatorService::executeCallBack, this);
+  target_locate_server_ = nh_.advertiseService(service_name.c_str(), &TargetLocatorService::executeCallBack, this);
 }
 
-bool TargetLocatorService::executeCallBack( target_locater::Request &req, target_locater::Response &res)
+bool TargetLocatorService::executeCallBack(target_locater::Request& req, target_locater::Response& res)
 {
   ros::NodeHandle nh;
   CameraObservations camera_observations;
@@ -124,10 +131,11 @@ bool TargetLocatorService::executeCallBack( target_locater::Request &req, target
   ROSCameraObserver camera_observer(image_topic_, camera_name_);
 
   // get the focal length and optical center
-  double fx,fy,cx,cy; 
-  double k1,k2,k3,p1,p2;// unused 
-  int height, width; //unused
-  if(!camera_observer.pullCameraInfo(fx, fy, cx, cy, k1, k2, k3, p1, p2, width, height)){
+  double fx, fy, cx, cy;
+  double k1, k2, k3, p1, p2;  // unused
+  int height, width;          // unused
+  if (!camera_observer.pullCameraInfo(fx, fy, cx, cy, k1, k2, k3, p1, p2, width, height))
+  {
     ROS_ERROR("could not access camera info");
   }
   camera_observer.clearObservations();
@@ -141,32 +149,36 @@ bool TargetLocatorService::executeCallBack( target_locater::Request &req, target
   roi.y_max = req.roi.y_offset + req.roi.height;
 
   industrial_extrinsic_cal::Cost_function cost_type;
-  
+
   camera_observer.clearTargets();
   camera_observer.clearObservations();
 
   camera_observer.addTarget(target_, roi, cost_type);
   camera_observer.triggerCamera();
-  while (!camera_observer.observationsDone()) ;
+  while (!camera_observer.observationsDone())
+    ;
   camera_observer.getObservations(camera_observations);
-  int num_observations = (int) camera_observations.size();
-  if(num_observations != target_rows_* target_cols_){
+  int num_observations = (int)camera_observations.size();
+  if (num_observations != target_rows_ * target_cols_)
+  {
     ROS_ERROR("Target Locator could not find target %d", num_observations);
-    return(false);
+    return (false);
   }
 
   // set initial conditions
-  target_->pose_.setQuaternion(req.initial_pose.orientation.x, req.initial_pose.orientation.y, req.initial_pose.orientation.z, req.initial_pose.orientation.w );
-  target_->pose_.setOrigin(req.initial_pose.position.x, req.initial_pose.position.y, req.initial_pose.position.z );
+  target_->pose_.setQuaternion(req.initial_pose.orientation.x, req.initial_pose.orientation.y,
+                               req.initial_pose.orientation.z, req.initial_pose.orientation.w);
+  target_->pose_.setOrigin(req.initial_pose.position.x, req.initial_pose.position.y, req.initial_pose.position.z);
 
   Problem problem;
-  for(int i=0; i<num_observations; i++){
+  for (int i = 0; i < num_observations; i++)
+  {
     double image_x = camera_observations[i].image_loc_x;
     double image_y = camera_observations[i].image_loc_y;
-    Point3d point = target_->pts_[i]; // assume the correct ordering
+    Point3d point = target_->pts_[i];  // assume the correct ordering
     CostFunction* cost_function =
-      industrial_extrinsic_cal::CameraReprjErrorPK::Create(image_x, image_y, fx, fy, cx, cy, point);
-    problem.AddResidualBlock(cost_function, NULL , target_->pose_.pb_pose);
+        industrial_extrinsic_cal::CameraReprjErrorPK::Create(image_x, image_y, fx, fy, cx, cy, point);
+    problem.AddResidualBlock(cost_function, NULL, target_->pose_.pb_pose);
   }
   Solver::Options options;
   Solver::Summary summary;
@@ -175,46 +187,50 @@ bool TargetLocatorService::executeCallBack( target_locater::Request &req, target
   options.max_num_iterations = 1000;
   ceres::Solve(options, &problem, &summary);
 
-  if(summary.termination_type != ceres::NO_CONVERGENCE
-     ){
-
-    double error_per_observation = summary.final_cost/num_observations;
-    if(error_per_observation <= req.allowable_cost_per_observation){
+  if (summary.termination_type != ceres::NO_CONVERGENCE)
+  {
+    double error_per_observation = summary.final_cost / num_observations;
+    if (error_per_observation <= req.allowable_cost_per_observation)
+    {
       res.final_pose.position.x = target_->pose_.x;
       res.final_pose.position.y = target_->pose_.y;
       res.final_pose.position.z = target_->pose_.z;
-      res.final_cost_per_observation  = error_per_observation;
-      target_->pose_.getQuaternion(res.final_pose.orientation.x, res.final_pose.orientation.y, res.final_pose.orientation.z, res.final_pose.orientation.w);
+      res.final_cost_per_observation = error_per_observation;
+      target_->pose_.getQuaternion(res.final_pose.orientation.x, res.final_pose.orientation.y,
+                                   res.final_pose.orientation.z, res.final_pose.orientation.w);
 
       return true;
     }
-    else{
-      res.final_cost_per_observation  = error_per_observation;
+    else
+    {
+      res.final_cost_per_observation = error_per_observation;
       ROS_ERROR("allowable cost exceeded %f > %f", error_per_observation, req.allowable_cost_per_observation);
-      return(false);
+      return (false);
     }
   }
 }
 
 void TargetLocatorService::initMCircleTarget(int rows, int cols, double circle_dia, double spacing)
 {
-  target_ =  make_shared<industrial_extrinsic_cal::Target>();
+  target_ = make_shared< industrial_extrinsic_cal::Target >();
   target_->is_moving_ = true;
   target_->target_name_ = "modified_circle_target";
   target_->target_frame_ = "target_frame";
-  target_->target_type_ =  2;
-  target_->circle_grid_parameters_.pattern_rows =rows;
+  target_->target_type_ = 2;
+  target_->circle_grid_parameters_.pattern_rows = rows;
   target_->circle_grid_parameters_.pattern_cols = cols;
   target_->circle_grid_parameters_.circle_diameter = circle_dia;
-  target_->circle_grid_parameters_.is_symmetric = true; 
+  target_->circle_grid_parameters_.is_symmetric = true;
   // create a grid of points
   target_->pts_.clear();
-  target_->num_points_ = rows*cols;
-  for(int i=0; i<rows; i++){
-    for(int j=0; j<cols; j++){
+  target_->num_points_ = rows * cols;
+  for (int i = 0; i < rows; i++)
+  {
+    for (int j = 0; j < cols; j++)
+    {
       Point3d point;
-      point.x = j*spacing;
-      point.y = (rows -1 -i)*spacing;
+      point.x = j * spacing;
+      point.y = (rows - 1 - i) * spacing;
       point.z = 0.0;
       target_->pts_.push_back(point);
     }
@@ -223,16 +239,28 @@ void TargetLocatorService::initMCircleTarget(int rows, int cols, double circle_d
 
 void TargetLocatorService::initBallsTarget()
 {
-  target_ =  make_shared<industrial_extrinsic_cal::Target>();
+  target_ = make_shared< industrial_extrinsic_cal::Target >();
   target_->target_name_ = "four_ball_target";
   target_->target_frame_ = "target_frame";
-  target_->target_type_ =  4;
+  target_->target_type_ = 4;
   // create 4 points
   target_->pts_.clear();
   Point3d point_1, point_2, point_3, point_4, point_5;
-  point_1.x = 0.09;     point_2.x = 0.0;          point_3.x = -0.057;    point_4.x = 0.0;      point_5.x = 0.0;
-  point_1.y = 0.0;       point_2.y = -0.133;     point_3.y = 0.0;         point_4.y = 0.0;      point_4.y = 0.043; 
-  point_1.z = 0.0;       point_2.z = 0.0;          point_3.z = 0.0;         point_4.z = 0.058;   point_5.z = 0.0;
+  point_1.x = 0.09;
+  point_2.x = 0.0;
+  point_3.x = -0.057;
+  point_4.x = 0.0;
+  point_5.x = 0.0;
+  point_1.y = 0.0;
+  point_2.y = -0.133;
+  point_3.y = 0.0;
+  point_4.y = 0.0;
+  point_4.y = 0.043;
+  point_1.z = 0.0;
+  point_2.z = 0.0;
+  point_3.z = 0.0;
+  point_4.z = 0.058;
+  point_5.z = 0.0;
   target_->pts_.push_back(point_1);
   target_->pts_.push_back(point_2);
   target_->pts_.push_back(point_3);


### PR DESCRIPTION
In order to make the code more readable and easier to maintain, I have added a clang format file which I then applied to the code.  There are no code changes to this PR, only formatting changes.  The clang formatting can be reapplied to the repo in the future using this command (assuming clang 3.8 is installed): 
`find . -name '*.h' -or -name '*.hpp' -or -name '*.cpp' | xargs clang-format-3.8 -i -style=file $1`