### PR TITLE
Removed spaces in angle brackets

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -38,7 +38,7 @@ TabWidth:        2
 UseTab:          Never
 IndentFunctionDeclarationAfterType: false
 SpacesInParentheses: false
-SpacesInAngles:  true
+SpacesInAngles:  false
 SpaceInEmptyParentheses: false
 SpacesInCStyleCastParentheses: false
 SpaceAfterControlStatementKeyword: true

--- a/caljob_creator/src/main.cpp
+++ b/caljob_creator/src/main.cpp
@@ -48,7 +48,7 @@ private:
     os << header;
   }
 
-  void write_joint_scene(std::ostream& os, const std::vector< double >& joints) const
+  void write_joint_scene(std::ostream& os, const std::vector<double>& joints) const
   {
     os << "-\n";
     os << "     trigger: ROS_ROBOT_JOINT_VALUES_ACTION_TRIGGER\n";
@@ -139,18 +139,18 @@ int main(int argc, char** argv)
   int image_height;
   int image_width;
   std::string camera_name;
-  nh.param< std::string >("image_topic", image_topic_name, "/kinect2/rgb_rect/image");
-  nh.param< int >("image_width", image_width, 640);
-  nh.param< int >("image_height", image_height, 480);
-  nh.param< std::string >("camera_name", camera_name, "basler1");
+  nh.param<std::string>("image_topic", image_topic_name, "/kinect2/rgb_rect/image");
+  nh.param<int>("image_width", image_width, 640);
+  nh.param<int>("image_height", image_height, 480);
+  nh.param<std::string>("camera_name", camera_name, "basler1");
   std::string output_file_name;
-  nh.param< std::string >("output_file", output_file_name, "caljob.yaml");
+  nh.param<std::string>("output_file", output_file_name, "caljob.yaml");
 
   std::string joints_topic_name;
-  nh.param< std::string >("joints_topic", joints_topic_name, "motoman/joint_states");
+  nh.param<std::string>("joints_topic", joints_topic_name, "motoman/joint_states");
 
   std::string motion_type;
-  nh.param< std::string >("motion_type", motion_type, "joint");
+  nh.param<std::string>("motion_type", motion_type, "joint");
 
   std::string to_frame("none");
   std::string from_frame("none");
@@ -206,7 +206,7 @@ int main(int argc, char** argv)
       ROS_INFO("Attempting to capture robot state");
       // get robot joint state
       sensor_msgs::JointStateConstPtr joints =
-          ros::topic::waitForMessage< sensor_msgs::JointState >(joints_topic_name, ros::Duration(1.0));
+          ros::topic::waitForMessage<sensor_msgs::JointState>(joints_topic_name, ros::Duration(1.0));
 
       // get robot pose state
       ros::Time now = ros::Time::now();

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/calibration_job.hpp
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/calibration_job.hpp
@@ -50,8 +50,8 @@ public:
    static cameras get but one set of pose parameters
    */
   bool is_moving();
-  boost::shared_ptr< DummyCameraObserver > camera_observer_; /*!< processes images, does CameraObservations */
-  CameraParameters camera_parameters_;                       /*!< The intrinsic and extrinsic parameters */
+  boost::shared_ptr<DummyCameraObserver> camera_observer_; /*!< processes images, does CameraObservations */
+  CameraParameters camera_parameters_;                     /*!< The intrinsic and extrinsic parameters */
   //    ::std::ostream& operator<<(::std::ostream& os, const Camera& C){ return os<< "TODO";};
 
   std::string camera_name_; /*!< string camera_name_ unique name of a camera */
@@ -74,8 +74,8 @@ typedef struct
 /*! @brief unique observation command */
 typedef struct
 {
-  boost::shared_ptr< Camera > camera;
-  boost::shared_ptr< Target > target;
+  boost::shared_ptr<Camera> camera;
+  boost::shared_ptr<Target> target;
   Roi roi;
 } ObservationCmd;
 
@@ -116,8 +116,8 @@ public:
     return (trigger_);
   };
 
-  std::vector< ObservationCmd > observation_command_list_;      /*!< list of observations for a scene */
-  std::vector< boost::shared_ptr< Camera > > cameras_in_scene_; /*!< list of cameras in this scened */
+  std::vector<ObservationCmd> observation_command_list_;     /*!< list of observations for a scene */
+  std::vector<boost::shared_ptr<Camera> > cameras_in_scene_; /*!< list of cameras in this scened */
 
 private:
   Trigger trigger_; /*!< event to trigger the observations in this command */
@@ -129,15 +129,15 @@ private:
 /*! \brief moving cameras need a new pose with each scene in which they are used */
 typedef struct MovingCamera
 {
-  boost::shared_ptr< Camera > cam;  // must hold a copy of the camera extrinsic parameters
-  int scene_id;                     // but copy of intrinsics may be and unused duplicate
+  boost::shared_ptr<Camera> cam;  // must hold a copy of the camera extrinsic parameters
+  int scene_id;                   // but copy of intrinsics may be and unused duplicate
 } MovingCamera;
 
 /*! \brief moving  need a new pose with each scene in which they are used */
 typedef struct MovingTarget
 {
-  boost::shared_ptr< Target > targ;  // must hold a copy of the target pose parameters,
-  int scene_id;                      // but point parameters may be unused duplicates
+  boost::shared_ptr<Target> targ;  // must hold a copy of the target pose parameters,
+  int scene_id;                    // but point parameters may be unused duplicates
 } MovingTarget;
 
 class ObservationDataPoint
@@ -200,7 +200,7 @@ public:
 
   void addObservationPoint(ObservationDataPoint new_data_point);
 
-  std::vector< ObservationDataPoint > items;
+  std::vector<ObservationDataPoint> items;
 };
 
 /** \brief These blocks of data hold the ceres parameters upon which the optimizaition proceeds
@@ -224,27 +224,27 @@ public:
    *  \param camera_to_add this is the camera added to the list
    *  \return true on success
    */
-  bool addStaticCamera(boost::shared_ptr< Camera > camera_to_add);
+  bool addStaticCamera(boost::shared_ptr<Camera> camera_to_add);
 
   /*! \brief adds a static target to job's list of static targets
    *  \param target_to_add this is the target added to the list
    *  \return true on success
    */
-  bool addStaticTarget(boost::shared_ptr< Target > target_to_add);
+  bool addStaticTarget(boost::shared_ptr<Target> target_to_add);
 
   /*! \brief adds a moving camera to job's list of cameras
    *  \param camera_to_add this is the camera added to the list
    *  \param scene_id the scene's id, only one camera of given name existe in each scene
    *  \return true on success
    */
-  bool addMovingCamera(boost::shared_ptr< Camera > camera_to_add, int scene_id);
+  bool addMovingCamera(boost::shared_ptr<Camera> camera_to_add, int scene_id);
 
   /*! \brief adds a static target to job's list of static targets
    *  \param target_to_add this is the target added to the list
    *  \param scene_id the scene's id, only one target of given name exist in each scene
    *  \return true on success
    */
-  bool addMovingTarget(boost::shared_ptr< Target > target_to_add, int scene_id);
+  bool addMovingTarget(boost::shared_ptr<Target> target_to_add, int scene_id);
 
   /*! @brief gets a pointer to the intrinsic parameters of a static camera
    *  @param camera_name the camera's name
@@ -314,10 +314,10 @@ public:
   P_BLOCK getMovingTargetPointParameterBlock(std::string target_name, int pnt_id);
 
   // private:
-  std::vector< boost::shared_ptr< Camera > > static_cameras_;       /*!< all non-moving cameras in job */
-  std::vector< boost::shared_ptr< MovingCamera > > moving_cameras_; /*! only one camera of a given name per scene */
-  std::vector< boost::shared_ptr< Target > > static_targets_;       /*!< all non-moving targets in job */
-  std::vector< boost::shared_ptr< MovingTarget > > moving_targets_; /*! only one target of a given name per scene */
+  std::vector<boost::shared_ptr<Camera> > static_cameras_;       /*!< all non-moving cameras in job */
+  std::vector<boost::shared_ptr<MovingCamera> > moving_cameras_; /*! only one camera of a given name per scene */
+  std::vector<boost::shared_ptr<Target> > static_targets_;       /*!< all non-moving targets in job */
+  std::vector<boost::shared_ptr<MovingTarget> > moving_targets_; /*! only one target of a given name per scene */
 };
 
 /*! @brief defines and exececutes the calibration script */
@@ -393,8 +393,8 @@ public:
    *  @param target a pointer to the target
    *  @return true if sucessful
    */
-  bool addObservationToCurrentScene(boost::shared_ptr< DummyCameraObserver > camera_observer,
-                                    boost::shared_ptr< Target > target);
+  bool addObservationToCurrentScene(boost::shared_ptr<DummyCameraObserver> camera_observer,
+                                    boost::shared_ptr<Target> target);
 
   /** @brief removes all cameras and targets from current scene
    *  @return true if sucessful
@@ -411,14 +411,14 @@ public:
 
   //    ::std::ostream& operator<<(::std::ostream& os, const CalibrationJob& C){ return os<< "TODO";}
 private:
-  std::string camera_def_file_name_;                    /*!< this file describes all cameras in job */
-  std::string target_def_file_name_;                    /*!< this file describes all targets in job */
-  std::string caljob_def_file_name_;                    /*!< this file describes all observations in job */
-  std::vector< ObservationScene > scene_list_;          /*!< contains list of scenes which define the job */
-  int current_scene_;                                   /*!< id of current scene under review or construction */
-  std::vector< DummyCameraObserver > camera_observers_; /*!< interface to images from cameras */
-  std::vector< Target > defined_target_set_;            /*!< TODO Not sure if I'll use this one */
-  CeresBlocks ceres_blocks_;                            /*!< This structure maintains the parameter sets for ceres */
+  std::string camera_def_file_name_;                  /*!< this file describes all cameras in job */
+  std::string target_def_file_name_;                  /*!< this file describes all targets in job */
+  std::string caljob_def_file_name_;                  /*!< this file describes all observations in job */
+  std::vector<ObservationScene> scene_list_;          /*!< contains list of scenes which define the job */
+  int current_scene_;                                 /*!< id of current scene under review or construction */
+  std::vector<DummyCameraObserver> camera_observers_; /*!< interface to images from cameras */
+  std::vector<Target> defined_target_set_;            /*!< TODO Not sure if I'll use this one */
+  CeresBlocks ceres_blocks_;                          /*!< This structure maintains the parameter sets for ceres */
   ceres::Problem problem_; /*!< This is the object which solves non-linear optimization problems */
 };
 

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/calibration_job_definition.h
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/calibration_job_definition.h
@@ -137,7 +137,7 @@ public:
    *    @param variables a list of cameras and targets
    *    @param covariance_file_name name of file to store the resulting matrix in
    */
-  bool computeCovariance(std::vector< CovarianceVariableRequest >& variables, std::string& covariance_file_name);
+  bool computeCovariance(std::vector<CovarianceVariableRequest>& variables, std::string& covariance_file_name);
 
   /** @brief set the flag to save observation data to a file indicated for post processing
    *    @param post_proc_file_name the name of the file to put the post processing data
@@ -154,7 +154,7 @@ public:
   };
 
   /*@brief get pointer to list of scenes*/
-  std::vector< ObservationScene >* getScenes()
+  std::vector<ObservationScene>* getScenes()
   {
     return &scene_list_;
   };
@@ -211,8 +211,8 @@ protected:
    *  @param target a pointer to the target
    *  @return true if successful
    */
-  bool addObservationToCurrentScene(boost::shared_ptr< ROSCameraObserver > camera_observer,
-                                    boost::shared_ptr< Target > target);
+  bool addObservationToCurrentScene(boost::shared_ptr<ROSCameraObserver> camera_observer,
+                                    boost::shared_ptr<Target> target);
 
   /** @brief removes all cameras and targets from current scene
    *  @return true if successful
@@ -223,7 +223,7 @@ protected:
    *  @param trig the trigger type to use for this scene
    *  @return true if successful
    */
-  bool appendNewScene(boost::shared_ptr< Trigger > trig);
+  bool appendNewScene(boost::shared_ptr<Trigger> trig);
 
   /** @brief each camera and each target have a transform interface, push the current values to the interface */
   void pushTransforms();
@@ -234,13 +234,13 @@ protected:
   void pullTransforms(int scene_id);
 
 private:
-  std::vector< ObservationDataPointList > observation_data_point_list_; /*!< a list of observation data points */
-  std::vector< ObservationScene > scene_list_; /*!< contains list of scenes which define the job */
-  std::string camera_def_file_name_;           /*!< this file describes all cameras in job */
-  std::string target_def_file_name_;           /*!< this file describes all targets in job */
-  std::string caljob_def_file_name_;           /*!< this file describes all observations in job */
-  int current_scene_;                          /*!< id of current scene under review or construction */
-  CeresBlocks ceres_blocks_;                   /*!< This structure maintains the parameter sets for ceres */
+  std::vector<ObservationDataPointList> observation_data_point_list_; /*!< a list of observation data points */
+  std::vector<ObservationScene> scene_list_; /*!< contains list of scenes which define the job */
+  std::string camera_def_file_name_;         /*!< this file describes all cameras in job */
+  std::string target_def_file_name_;         /*!< this file describes all targets in job */
+  std::string caljob_def_file_name_;         /*!< this file describes all observations in job */
+  int current_scene_;                        /*!< id of current scene under review or construction */
+  CeresBlocks ceres_blocks_;                 /*!< This structure maintains the parameter sets for ceres */
   ceres::Problem* problem_;              /*!< this is the object used to define the optimization problem for ceres */
   ceres::Solver::Summary ceres_summary_; /*!< object for displaying solver results */
   int total_observations_;               /*< number of observations/cost elements in problem */

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/caljob_yaml_parser.h
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/caljob_yaml_parser.h
@@ -21,7 +21,7 @@ namespace industrial_extrinsic_cal
  *   @param reference_frame the retured reference frame
  *   @param blocks the blocks containing pointers to all the camera and target parameters for ceres
  **/
-bool parseCaljob(std::string& caljob_input_file, std::vector< ObservationScene >& scene_list,
+bool parseCaljob(std::string& caljob_input_file, std::vector<ObservationScene>& scene_list,
                  std::string& reference_frame, CeresBlocks& blocks);
 
 /** @brief parses a single scene

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/camera_definition.h
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/camera_definition.h
@@ -67,7 +67,7 @@ public:
    *  Transform interfaces allow hardware or simulation to provide or accept pose information
    *  depending on whether they are a broadcaster or a listener
    */
-  void setTransformInterface(boost::shared_ptr< TransformInterface > tranform_interface);
+  void setTransformInterface(boost::shared_ptr<TransformInterface> tranform_interface);
 
   /*! \brief set the reference frame for the tranform interface.
    *  Because transform interfaces need to get created when the camera or target is created, we often don't know
@@ -86,12 +86,12 @@ public:
    *  what the reference frame is for the interface until later, so we need to set it
    * TODO since we have a get and set, why is it public?
    */
-  boost::shared_ptr< TransformInterface > getTransformInterface();
-  boost::shared_ptr< CameraObserver > camera_observer_;         /*!< processes images, does CameraObservations */
-  boost::shared_ptr< Trigger > trigger_;                        /*!< pointer to the trigger mechanism for this camera*/
-  CameraParameters camera_parameters_;                          /*!< The intrinsic and extrinsic parameters */
-  std::string camera_name_;                                     /*!< string camera_name_ unique name of a camera */
-  boost::shared_ptr< TransformInterface > transform_interface_; /**< interface to transform, tf for example  */
+  boost::shared_ptr<TransformInterface> getTransformInterface();
+  boost::shared_ptr<CameraObserver> camera_observer_;         /*!< processes images, does CameraObservations */
+  boost::shared_ptr<Trigger> trigger_;                        /*!< pointer to the trigger mechanism for this camera*/
+  CameraParameters camera_parameters_;                        /*!< The intrinsic and extrinsic parameters */
+  std::string camera_name_;                                   /*!< string camera_name_ unique name of a camera */
+  boost::shared_ptr<TransformInterface> transform_interface_; /**< interface to transform, tf for example  */
   Pose6d intermediate_frame_; /**< Sometimes there is an intermediate transform from ref to origin of intrinsics */
   bool is_moving_;            /*!< bool is_moving_  false for static cameras */
 };
@@ -100,8 +100,8 @@ public:
 /*! @brief unique observation command */
 typedef struct
 {
-  boost::shared_ptr< Camera > camera;
-  boost::shared_ptr< Target > target;
+  boost::shared_ptr<Camera> camera;
+  boost::shared_ptr<Target> target;
   Roi roi;
   Cost_function cost_type;
 } ObservationCmd;
@@ -110,8 +110,8 @@ typedef struct
 /*! \brief moving cameras need a new pose with each scene in which they are used */
 typedef struct MovingCamera
 {
-  boost::shared_ptr< Camera > cam;  // must hold a copy of the camera extrinsic parameters
-  int scene_id;                     // but copy of intrinsics may be and unused duplicate
+  boost::shared_ptr<Camera> cam;  // must hold a copy of the camera extrinsic parameters
+  int scene_id;                   // but copy of intrinsics may be and unused duplicate
 } MovingCamera;
 
 }  // end namespace industrial_extrinsic_cal

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/camera_observer.hpp
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/camera_observer.hpp
@@ -28,17 +28,17 @@ namespace industrial_extrinsic_cal
 /*! \brief An observation is the x,y image location of a target's point in an image*/
 typedef struct
 {
-  boost::shared_ptr< Target > target; /**< pointer to target who's point is observed */
-  int point_id;                       /**< point's id in target's point array */
-  double image_loc_x;                 /**< target point was found at image location x */
-  double image_loc_y;                 /**< target point image location y */
-  Cost_function cost_type;            /**< type of cost associated with this observation */
+  boost::shared_ptr<Target> target; /**< pointer to target who's point is observed */
+  int point_id;                     /**< point's id in target's point array */
+  double image_loc_x;               /**< target point was found at image location x */
+  double image_loc_y;               /**< target point image location y */
+  Cost_function cost_type;          /**< type of cost associated with this observation */
   Pose6d
       intermediate_frame; /**< sometimes one needs the transform from ref_frame to the frame of extrinics for camera */
 } Observation;
 
 /*! \brief A vector of observations made by a single camera of posibly multiple targets */
-typedef std::vector< Observation > CameraObservations;
+typedef std::vector<Observation> CameraObservations;
 
 /** @brief A camera observer is an object which given a set of targets and regions of interest, it provides observations
  *              of those targets. A camera obsever is configured with targets, then triggered, once observations are
@@ -54,7 +54,7 @@ public:
   /** @brief add a target to look for */
   /** @param targ a target to look for */
   /** @param roi Region of interest for target */
-  virtual bool addTarget(boost::shared_ptr< Target > targ, Roi& roi, Cost_function cost_type) = 0;
+  virtual bool addTarget(boost::shared_ptr<Target> targ, Roi& roi, Cost_function cost_type) = 0;
 
   /** @brief remove all targets */
   virtual void clearTargets() = 0;

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/camera_yaml_parser.h
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/camera_yaml_parser.h
@@ -17,21 +17,21 @@ namespace industrial_extrinsic_cal
  *   @param node, the yaml node
  *   @return a shared pointer to camera parsed
  **/
-boost::shared_ptr< Camera > parseSingleCamera(const YAML::Node& node);
+boost::shared_ptr<Camera> parseSingleCamera(const YAML::Node& node);
 /** @brief parses a transform interface
  *   @param node, the yaml node
  *   @param frame, the frame that the transform interface refers to
  *   @param pose, the initial value of the pose
  *   @return a shared pointer to transform interface parsed
  **/
-boost::shared_ptr< TransformInterface > parseTransformInterface(const YAML::Node& node, std::string& name,
-                                                                std::string& frame, Pose6d& pose);
+boost::shared_ptr<TransformInterface> parseTransformInterface(const YAML::Node& node, std::string& name,
+                                                              std::string& frame, Pose6d& pose);
 /** @brief parses a trigger
  *   @param node, the yaml node
  *   @param name name of trigger
  *   @return shared pointer to the trigger parsed
  **/
-boost::shared_ptr< Trigger > parseTrigger(const YAML::Node& node, std::string& name);
+boost::shared_ptr<Trigger> parseTrigger(const YAML::Node& node, std::string& name);
 /** @brief parses a Pose6d
  *   @param node, the yaml node
  *   @param pose as 6dof pose from parsed position and angle axis parameters xyz,wx,wy,wz
@@ -43,7 +43,7 @@ bool parsePose(const YAML::Node& node, Pose6d& pose);
  *   @param returned vector of shared pointers to cameras
  *   @return true if successful
  **/
-bool parseCameras(std::string& cameras_input_file, std::vector< boost::shared_ptr< Camera > >& cameras);
+bool parseCameras(std::string& cameras_input_file, std::vector<boost::shared_ptr<Camera> >& cameras);
 
 }  // end industrial_extrinsic_cal namespace
 

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/ceres_blocks.h
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/ceres_blocks.h
@@ -51,34 +51,34 @@ public:
    *  \param camera_to_add this is the camera added to the list
    *  \return true on success
    */
-  bool addStaticCamera(boost::shared_ptr< Camera > camera_to_add);
+  bool addStaticCamera(boost::shared_ptr<Camera> camera_to_add);
 
   /*! \brief adds a static target to job's list of static targets
    *  \param target_to_add this is the target added to the list
    *  \return true on success
    */
-  bool addStaticTarget(boost::shared_ptr< Target > target_to_add);
+  bool addStaticTarget(boost::shared_ptr<Target> target_to_add);
 
   /*! \brief adds a moving camera to job's list of cameras
    *  \param camera_to_add this is the camera added to the list
    *  \param scene_id the scene's id, only one camera of given name exist in each scene
    *  \return true on success
    */
-  bool addMovingCamera(boost::shared_ptr< Camera > camera_to_add, int scene_id);
+  bool addMovingCamera(boost::shared_ptr<Camera> camera_to_add, int scene_id);
 
   /*! \brief adds a static target to job's list of static targets
    *  \param target_to_add this is the target added to the list
    *  \param scene_id the scene's id, only one target of given name exist in each scene
    *  \return true on success
    */
-  bool addMovingTarget(boost::shared_ptr< Target > target_to_add, int scene_id);
+  bool addMovingTarget(boost::shared_ptr<Target> target_to_add, int scene_id);
 
   /*! \brief grabs a camera from the camera list given the camera name
    *  \param camera_name is the name of the camera
    *  \param camera this is the camera from the list, either moving or static
    *  \return true on success
    */
-  const boost::shared_ptr< Camera > getCameraByName(const std::string& camera_name);
+  const boost::shared_ptr<Camera> getCameraByName(const std::string& camera_name);
 
   /*!
    * \brief grabs a target from the target list given the target name
@@ -87,7 +87,7 @@ public:
    * @param scene_id, when a target is moving, it has a separate object for each scene
    * @return shared pointer to target
    */
-  const boost::shared_ptr< Target > getTargetByName(const std::string& target_name, int scene_id = 0);
+  const boost::shared_ptr<Target> getTargetByName(const std::string& target_name, int scene_id = 0);
 
   /*! @brief gets a pointer to the intrinsic parameters of a static camera
    *  @param camera_name the camera's name
@@ -198,10 +198,10 @@ public:
     return (reference_frame_);
   };
 
-  std::vector< boost::shared_ptr< Camera > > static_cameras_;       /*!< all non-moving cameras in job */
-  std::vector< boost::shared_ptr< MovingCamera > > moving_cameras_; /*! only one camera of a given name per scene */
-  std::vector< boost::shared_ptr< Target > > static_targets_;       /*!< all non-moving targets in job */
-  std::vector< boost::shared_ptr< MovingTarget > > moving_targets_; /*! only one target of a given name per scene */
+  std::vector<boost::shared_ptr<Camera> > static_cameras_;       /*!< all non-moving cameras in job */
+  std::vector<boost::shared_ptr<MovingCamera> > moving_cameras_; /*! only one camera of a given name per scene */
+  std::vector<boost::shared_ptr<Target> > static_targets_;       /*!< all non-moving targets in job */
+  std::vector<boost::shared_ptr<MovingTarget> > moving_targets_; /*! only one target of a given name per scene */
   std::string reference_frame_; /*! name of reference frame, typically a ROS tf frame */
 
 };  // end class

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/ceres_costs_utils.hpp
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/ceres_costs_utils.hpp
@@ -33,9 +33,9 @@ namespace industrial_extrinsic_cal
  *   @param R1 second rotation matrix in column major order
  *   @param R3 matrix product of R1*R2
  */
-template < typename T >
+template <typename T>
 void rotationProduct(const T R1[9], const T R2[9], T R3[9]);
-template < typename T >
+template <typename T>
 inline void rotationProduct(const T R1[9], const T R2[9], T R3[9])
 {
   // We assume that the rotation matrices are in column major order
@@ -66,9 +66,9 @@ inline void rotationProduct(const T R1[9], const T R2[9], T R3[9])
  *   @param p2 tangential distortion coefficient p2
  */
 
-template < typename T >
+template <typename T>
 void extractCameraIntrinsics(const T intrinsics[9], T& fx, T& fy, T& cx, T& cy, T& k1, T& k2, T& k3, T& p1, T& p2);
-template < typename T >
+template <typename T>
 inline void extractCameraIntrinsics(const T intrinsics[9], T& fx, T& fy, T& cx, T& cy, T& k1, T& k2, T& k3, T& p1,
                                     T& p2)
 {
@@ -92,9 +92,9 @@ inline void extractCameraIntrinsics(const T intrinsics[9], T& fx, T& fy, T& cx, 
  *   @param cy optical center in y
  */
 
-template < typename T >
+template <typename T>
 void extractCameraIntrinsics(const T intrinsics[4], T& fx, T& fy, T& cx, T& cy);
-template < typename T >
+template <typename T>
 inline void extractCameraIntrinsics(const T intrinsics[4], T& fx, T& fy, T& cx, T& cy)
 {
   fx = intrinsics[0]; /** focal length x */
@@ -112,9 +112,9 @@ inline void extractCameraIntrinsics(const T intrinsics[4], T& fx, T& fy, T& cx, 
  *   @param ay, angle axis y
  *   @param az, angle axis z
  */
-template < typename T >
+template <typename T>
 void extractCameraExtrinsics(const T extrinsics[6], T& x, T& y, T& z, T& ax, T& ay, T& az);
-template < typename T >
+template <typename T>
 inline void extractCameraExtrinsics(const T extrinsics[6], T& x, T& y, T& z, T& ax, T& ay, T& az)
 {
   ax = extrinsics[0]; /** angle axis x */
@@ -130,9 +130,9 @@ inline void extractCameraExtrinsics(const T extrinsics[6], T& x, T& y, T& z, T& 
  *  @param RI the output inverse rotation
  */
 
-template < typename T >
+template <typename T>
 void rotationInverse(const T R[9], const T RI[9]);
-template < typename T >
+template <typename T>
 inline void rotationInverse(const T R[9], T RI[9])
 {
   RI[0] = R[0];
@@ -153,9 +153,9 @@ inline void rotationInverse(const T R[9], T RI[9])
  *  @param t_point the transformed point
  */
 
-template < typename T >
+template <typename T>
 inline void transformPoint(const T angle_axis[3], const T tx[3], const T point[3], T t_point[3]);
-template < typename T >
+template <typename T>
 inline void transformPoint(const T angle_axis[3], const T tx[3], const T point[3], T t_point[3])
 {
   ceres::AngleAxisRotatePoint(angle_axis, point, t_point);
@@ -170,9 +170,9 @@ inline void transformPoint(const T angle_axis[3], const T tx[3], const T point[3
  *  @param t_point the transformed point
  */
 
-template < typename T >
+template <typename T>
 inline void poseTransformPoint(const Pose6d& pose, const T point[3], T t_point[3]);
-template < typename T >
+template <typename T>
 inline void poseTransformPoint(const Pose6d& pose, const T point[3], T t_point[3])
 {
   T angle_axis[3];
@@ -191,9 +191,9 @@ inline void poseTransformPoint(const Pose6d& pose, const T point[3], T t_point[3
  *  @param point the original point in a Point3d form
  *  @param t_point the transformed point
  */
-template < typename T >
+template <typename T>
 void transformPoint3d(const T angle_axis[3], const T tx[3], const Point3d& point, T t_point[3]);
-template < typename T >
+template <typename T>
 inline void transformPoint3d(const T angle_axis[3], const T tx[3], const Point3d& point, T t_point[3])
 {
   T point_[3];
@@ -210,9 +210,9 @@ inline void transformPoint3d(const T angle_axis[3], const T tx[3], const Point3d
  *  @param pose the input pose
  *  @param pose the output rotatation matrix
  */
-template < typename T >
+template <typename T>
 void poseRotationMatrix(const Pose6d& pose, T R[9]);
-template < typename T >
+template <typename T>
 inline void poseRotationMatrix(const Pose6d& pose, T R[9])
 {
   T angle_axis[3];
@@ -238,10 +238,10 @@ inline void poseRotationMatrix(const Pose6d& pose, T R[9])
  *  @param residual the output or difference between where the point should appear given the parameters, and where it
  * was observed
  */
-template < typename T >
+template <typename T>
 void cameraPntResidualDist(T point[3], T& k1, T& k2, T& k3, T& p1, T& p2, T& fx, T& fy, T& cx, T& cy, T& ox, T& oy,
                            T residual[2]);
-template < typename T >
+template <typename T>
 inline void cameraPntResidualDist(T point[3], T& k1, T& k2, T& k3, T& p1, T& p2, T& fx, T& fy, T& cx, T& cy, T& ox,
                                   T& oy, T residual[2])
 {
@@ -297,9 +297,9 @@ inline void cameraPntResidualDist(T point[3], T& k1, T& k2, T& k3, T& p1, T& p2,
  *  @param ox observation in x
  *  @param oy observation in y
  */
-template < typename T >
+template <typename T>
 void projectPntNoDistortion(T point[3], T& fx, T& fy, T& cx, T& cy, T& ox, T& oy);
-template < typename T >
+template <typename T>
 inline void projectPntNoDistortion(T point[3], T& fx, T& fy, T& cx, T& cy, T& ox, T& oy)
 {
   T xp1 = point[0];
@@ -344,10 +344,10 @@ inline void projectPntNoDistortion(T point[3], T& fx, T& fy, T& cx, T& cy, T& ox
  *  @param residual the output or difference between where the point should appear given the parameters, and where it
  * was observed
  */
-template < typename T >
+template <typename T>
 void cameraCircResidualDist(T point[3], T& circle_diameter, T R_TtoC[9], T& k1, T& k2, T& k3, T& p1, T& p2, T& fx,
                             T& fy, T& cx, T& cy, T& ox, T& oy, T residual[2]);
-template < typename T >
+template <typename T>
 inline void cameraCircResidualDist(T point[3], T& circle_diameter, T R_TtoC[9], T& k1, T& k2, T& k3, T& p1, T& p2,
                                    T& fx, T& fy, T& cx, T& cy, T& ox, T& oy, T residual[2])
 {
@@ -461,10 +461,10 @@ inline void cameraCircResidualDist(T point[3], T& circle_diameter, T R_TtoC[9], 
  *  @param residual the output or difference between where the point should appear given the parameters, and where it
  * was observed
  */
-template < typename T >
+template <typename T>
 void cameraCircResidual(T point[3], T& circle_diameter, T R_TtoC[9], T& fx, T& fy, T& cx, T& cy, T& ox, T& oy,
                         T residual[2]);
-template < typename T >
+template <typename T>
 inline void cameraCircResidual(T point[3], T& circle_diameter, T R_TtoC[9], T& fx, T& fy, T& cx, T& cy, T& ox, T& oy,
                                T residual[2])
 {
@@ -557,9 +557,9 @@ inline void cameraCircResidual(T point[3], T& circle_diameter, T R_TtoC[9], T& f
  * was observed
  */
 
-template < typename T >
+template <typename T>
 void cameraPntResidual(T point[3], T& fx, T& fy, T& cx, T& cy, T& ox, T& oy, T residual[2]);
-template < typename T >
+template <typename T>
 inline void cameraPntResidual(T point[3], T& fx, T& fy, T& cx, T& cy, T& ox, T& oy, T residual[2])
 {
   T xp1 = point[0];
@@ -590,7 +590,7 @@ public:
   {
   }
 
-  template < typename T >
+  template <typename T>
   bool operator()(const T* const c_p1, /** extrinsic parameters */
                   const T* c_p2,       /** intrinsic parameters */
                   const T* point,      /** point being projected, has 3 parameters */
@@ -617,7 +617,7 @@ public:
   /** the client code. */
   static ceres::CostFunction* Create(const double o_x, const double o_y)
   {
-    return (new ceres::AutoDiffCostFunction< CameraReprjErrorWithDistortion, 2, 6, 9, 3 >(
+    return (new ceres::AutoDiffCostFunction<CameraReprjErrorWithDistortion, 2, 6, 9, 3>(
         new CameraReprjErrorWithDistortion(o_x, o_y)));
   }
   double ox_; /** observed x location of object in image */
@@ -635,7 +635,7 @@ public:
   {
   }
 
-  template < typename T >
+  template <typename T>
   bool operator()(const T* const c_p1, /** extrinsic parameters */
                   const T* c_p2,       /** intrinsic parameters */
                   T* residual) const
@@ -661,7 +661,7 @@ public:
   /** the client code. */
   static ceres::CostFunction* Create(const double o_x, const double o_y, Point3d point)
   {
-    return (new ceres::AutoDiffCostFunction< CameraReprjErrorWithDistortionPK, 2, 6, 9 >(
+    return (new ceres::AutoDiffCostFunction<CameraReprjErrorWithDistortionPK, 2, 6, 9>(
         new CameraReprjErrorWithDistortionPK(o_x, o_y, point)));
   }
   double ox_;     /** observed x location of object in image */
@@ -679,7 +679,7 @@ public:
   {
   }
 
-  template < typename T >
+  template <typename T>
   bool operator()(const T* const c_p1, /** extrinsic parameters */
                   const T* point,      /** point being projected, yes this is has 3 parameters */
                   T* residual) const
@@ -708,8 +708,7 @@ public:
   static ceres::CostFunction* Create(const double o_x, const double o_y, const double fx, const double fy,
                                      const double cx, const double cy)
   {
-    return (
-        new ceres::AutoDiffCostFunction< CameraReprjError, 2, 6, 3 >(new CameraReprjError(o_x, o_y, fx, fy, cx, cy)));
+    return (new ceres::AutoDiffCostFunction<CameraReprjError, 2, 6, 3>(new CameraReprjError(o_x, o_y, fx, fy, cx, cy)));
   }
   double ox_; /** observed x location of object in image */
   double oy_; /** observed y location of object in image */
@@ -727,7 +726,7 @@ public:
   {
   }
 
-  template < typename T >
+  template <typename T>
   bool operator()(const T* point, /** point being projected, yes this is has 3 parameters */
                   T* residual) const
   {
@@ -753,7 +752,7 @@ public:
   static ceres::CostFunction* Create(const double o_x, const double o_y, const double fx, const double fy,
                                      const double cx, const double cy, const Pose6d camera_pose)
   {
-    return (new ceres::AutoDiffCostFunction< TriangulationError, 2, 3 >(
+    return (new ceres::AutoDiffCostFunction<TriangulationError, 2, 3>(
         new TriangulationError(o_x, o_y, fx, fy, cx, cy, camera_pose)));
   }
   double ox_;          /** observed x location of object in image */
@@ -775,7 +774,7 @@ public:
   {
   }
 
-  template < typename T >
+  template <typename T>
   bool operator()(const T* const c_p1, /** extrinsic parameters */
                   T* residual) const
   {
@@ -803,7 +802,7 @@ public:
   static ceres::CostFunction* Create(const double o_x, const double o_y, const double fx, const double fy,
                                      const double cx, const double cy, const Point3d point)
   {
-    return (new ceres::AutoDiffCostFunction< CameraReprjErrorPK, 2, 6 >(
+    return (new ceres::AutoDiffCostFunction<CameraReprjErrorPK, 2, 6>(
         new CameraReprjErrorPK(o_x, o_y, fx, fy, cx, cy, point)));
   }
   double ox_;     /** observed x location of object in image */
@@ -826,7 +825,7 @@ public:
   {
   }
 
-  template < typename T >
+  template <typename T>
   bool operator()(const T* const c_p1,  /** extrinsic parameters */
                   const T* const c_p2,  /** 6Dof transform of target points into world frame */
                   const T* const point, /** point described in target frame */
@@ -862,7 +861,7 @@ public:
                                      const double cx, const double cy)
 
   {
-    return (new ceres::AutoDiffCostFunction< TargetCameraReprjError, 2, 6, 6, 3 >(
+    return (new ceres::AutoDiffCostFunction<TargetCameraReprjError, 2, 6, 6, 3>(
         new TargetCameraReprjError(o_x, o_y, fx, fy, cx, cy)));
   }
   double ox_; /** observed x location of object in image */
@@ -884,7 +883,7 @@ public:
   {
   }
 
-  template < typename T >
+  template <typename T>
   bool operator()(const T* const c_p1, /** extrinsic parameters */
                   const T* const c_p2, /** 6Dof transform of target points into world frame */
                   T* residual) const
@@ -918,7 +917,7 @@ public:
                                      const double cx, const double cy, const Point3d point)
 
   {
-    return (new ceres::AutoDiffCostFunction< TargetCameraReprjErrorPK, 2, 6, 6 >(
+    return (new ceres::AutoDiffCostFunction<TargetCameraReprjErrorPK, 2, 6, 6>(
         new TargetCameraReprjErrorPK(o_x, o_y, fx, fy, cx, cy, point)));
   }
   double ox_;     /** observed x location of object in image */
@@ -941,7 +940,7 @@ public:
   {
   }
 
-  template < typename T >
+  template <typename T>
   bool operator()(const T* const c_p1,  /** extrinsic parameters */
                   const T* const c_p2,  /** 6Dof transform of target points into world frame */
                   const T* const point, /** point described in target frame that is being seen */
@@ -978,7 +977,7 @@ public:
                                      const double cx, const double cy, Pose6d pose)
 
   {
-    return (new ceres::AutoDiffCostFunction< LinkTargetCameraReprjError, 2, 6, 6, 3 >(
+    return (new ceres::AutoDiffCostFunction<LinkTargetCameraReprjError, 2, 6, 6, 3>(
         new LinkTargetCameraReprjError(ox, oy, fx, fy, cx, cy, pose)));
   }
   double ox_;        /** observed x location of object in image */
@@ -1002,7 +1001,7 @@ public:
   {
   }
 
-  template < typename T >
+  template <typename T>
   bool operator()(const T* const c_p1, /** extrinsic parameters */
                   const T* const c_p2, /** 6Dof transform of target points into world frame */
                   T* residual) const
@@ -1038,7 +1037,7 @@ public:
                                      const double cx, const double cy, Pose6d pose, Point3d point)
 
   {
-    return (new ceres::AutoDiffCostFunction< LinkTargetCameraReprjErrorPK, 2, 6, 6 >(
+    return (new ceres::AutoDiffCostFunction<LinkTargetCameraReprjErrorPK, 2, 6, 6>(
         new LinkTargetCameraReprjErrorPK(o_x, o_y, fx, fy, cx, cy, pose, point)));
   }
   double ox_;        /** observed x location of object in image */
@@ -1063,7 +1062,7 @@ public:
   {
   }
 
-  template < typename T >
+  template <typename T>
   bool operator()(const T* const c_p1, /** extrinsic parameters */
                   T* residual) const
   {
@@ -1097,7 +1096,7 @@ public:
                                      const double cx, const double cy, Pose6d target_pose, Point3d point)
 
   {
-    return (new ceres::AutoDiffCostFunction< PosedTargetCameraReprjErrorPK, 2, 6 >(
+    return (new ceres::AutoDiffCostFunction<PosedTargetCameraReprjErrorPK, 2, 6>(
         new PosedTargetCameraReprjErrorPK(o_x, o_y, fx, fy, cx, cy, target_pose, point)));
   }
   double ox_;          /** observed x location of object in image */
@@ -1122,7 +1121,7 @@ public:
     link_posei_ = link_pose_.getInverse();
   }
 
-  template < typename T >
+  template <typename T>
   bool operator()(const T* const c_p1,  /** extrinsic parameters */
                   const T* const c_p2,  /** 6Dof transform of target points into world frame */
                   const T* const point, /** point described in target frame that is being seen */
@@ -1159,7 +1158,7 @@ public:
                                      const double cx, const double cy, Pose6d pose)
 
   {
-    return (new ceres::AutoDiffCostFunction< LinkCameraTargetReprjError, 2, 6, 6, 3 >(
+    return (new ceres::AutoDiffCostFunction<LinkCameraTargetReprjError, 2, 6, 6, 3>(
         new LinkCameraTargetReprjError(ox, oy, fx, fy, cx, cy, pose)));
   }
   double ox_;         /*!< observed x location of object in image */
@@ -1185,7 +1184,7 @@ public:
     link_posei_ = link_pose_.getInverse();
   }
 
-  template < typename T >
+  template <typename T>
   bool operator()(const T* const c_p1, /** extrinsic parameters */
                   const T* const c_p2, /** 6Dof transform of target points into world frame */
                   T* residual) const
@@ -1221,7 +1220,7 @@ public:
                                      const double cx, const double cy, Pose6d pose, Point3d pnt)
 
   {
-    return (new ceres::AutoDiffCostFunction< LinkCameraTargetReprjErrorPK, 2, 6, 6 >(
+    return (new ceres::AutoDiffCostFunction<LinkCameraTargetReprjErrorPK, 2, 6, 6>(
         new LinkCameraTargetReprjErrorPK(o_x, o_y, fx, fy, cx, cy, pose, pnt)));
   }
   double ox_;         /** observed x location of object in image */
@@ -1244,7 +1243,7 @@ public:
   {
   }
 
-  template < typename T >
+  template <typename T>
   bool operator()(const T* const c_p1,  /** extrinsic parameters [6]*/
                   const T* const c_p2,  /** intrinsic parameters of camera fx,fy,cx,cy,k1,k2,k2,p1,p2 [9]*/
                   const T* const point, /** point described in target frame that is being seen [3]*/
@@ -1276,7 +1275,7 @@ public:
   /** the client code. */
   static ceres::CostFunction* Create(const double o_x, const double o_y, const double c_dia)
   {
-    return (new ceres::AutoDiffCostFunction< CircleCameraReprjErrorWithDistortion, 2, 6, 9, 3 >(
+    return (new ceres::AutoDiffCostFunction<CircleCameraReprjErrorWithDistortion, 2, 6, 9, 3>(
         new CircleCameraReprjErrorWithDistortion(o_x, o_y, c_dia)));
   }
   double ox_;               /** observed x location of object in image */
@@ -1293,7 +1292,7 @@ public:
   {
   }
 
-  template < typename T >
+  template <typename T>
   bool operator()(const T* const c_p1, /** extrinsic parameters [6] */
                   const T* const c_p2, /** intrinsic parameters of camera fx,fy,cx,cy,k1,k2,k2,p1,p2 [9] */
                   T* residual) const
@@ -1328,7 +1327,7 @@ public:
   /** the client code. */
   static ceres::CostFunction* Create(const double o_x, const double o_y, const double c_dia, Point3d point)
   {
-    return (new ceres::AutoDiffCostFunction< CircleCameraReprjErrorWithDistortionPK, 2, 6, 9 >(
+    return (new ceres::AutoDiffCostFunction<CircleCameraReprjErrorWithDistortionPK, 2, 6, 9>(
         new CircleCameraReprjErrorWithDistortionPK(o_x, o_y, c_dia, point)));
   }
   double ox_;               /** observed x location of object in image */
@@ -1345,7 +1344,7 @@ public:
   {
   }
 
-  template < typename T >
+  template <typename T>
   bool operator()(const T* const c_p1,  /** extrinsic parameters [6]*/
                   const T* const point, /** point described in target frame that is being seen [3]*/
                   T* residual) const
@@ -1379,7 +1378,7 @@ public:
   static ceres::CostFunction* Create(const double o_x, const double o_y, const double c_dia, const double fx,
                                      const double fy, const double cx, const double cy)
   {
-    return (new ceres::AutoDiffCostFunction< CircleCameraReprjError, 2, 6, 3 >(
+    return (new ceres::AutoDiffCostFunction<CircleCameraReprjError, 2, 6, 3>(
         new CircleCameraReprjError(o_x, o_y, c_dia, fx, fy, cx, cy)));
   }
   double ox_;              /** observed x location of object in image */
@@ -1400,7 +1399,7 @@ public:
   {
   }
 
-  template < typename T >
+  template <typename T>
   bool operator()(const T* const c_p1, /** extrinsic parameters [6] */
                   T* residual) const
   {
@@ -1433,7 +1432,7 @@ public:
   static ceres::CostFunction* Create(const double o_x, const double o_y, const double c_dia, const double fx,
                                      const double fy, const double cx, const double cy, Point3d point)
   {
-    return (new ceres::AutoDiffCostFunction< CircleCameraReprjErrorPK, 2, 6 >(
+    return (new ceres::AutoDiffCostFunction<CircleCameraReprjErrorPK, 2, 6>(
         new CircleCameraReprjErrorPK(o_x, o_y, c_dia, fx, fy, cx, cy, point)));
   }
   double ox_;               /** observed x location of object in image */
@@ -1454,7 +1453,7 @@ public:
   {
   }
 
-  template < typename T >
+  template <typename T>
   bool operator()(const T* const c_p1,  /** extrinsic parameters [6]*/
                   const T* const c_p2,  /** intrinsic parameters of camera fx,fy,cx,cy,k1,k2,k2,p1,p2 [9]*/
                   const T* const c_p3,  /** 6Dof transform of target into world frame [6]*/
@@ -1497,7 +1496,7 @@ public:
   /** the client code. */
   static ceres::CostFunction* Create(const double o_x, const double o_y, const double c_dia)
   {
-    return (new ceres::AutoDiffCostFunction< FixedCircleTargetCameraReprjErrorWithDistortion, 2, 6, 6, 9, 3 >(
+    return (new ceres::AutoDiffCostFunction<FixedCircleTargetCameraReprjErrorWithDistortion, 2, 6, 6, 9, 3>(
         new FixedCircleTargetCameraReprjErrorWithDistortion(o_x, o_y, c_dia)));
   }
   double ox_;               /** observed x location of object in image */
@@ -1513,7 +1512,7 @@ public:
   {
   }
 
-  template < typename T >
+  template <typename T>
   bool operator()(const T* const c_p1, /** extrinsic parameters [6]*/
                   const T* const c_p2, /** intrinsic parameters of camera fx,fy,cx,cy,k1,k2,k2,p1,p2 [9]*/
                   const T* const c_p3, /** 6Dof transform of target into world frame [6]*/
@@ -1555,7 +1554,7 @@ public:
   /** the client code. */
   static ceres::CostFunction* Create(const double o_x, const double o_y, const double c_dia, Point3d point)
   {
-    return (new ceres::AutoDiffCostFunction< FixedCircleTargetCameraReprjErrorWithDistortionPK, 2, 6, 9, 3 >(
+    return (new ceres::AutoDiffCostFunction<FixedCircleTargetCameraReprjErrorWithDistortionPK, 2, 6, 9, 3>(
         new FixedCircleTargetCameraReprjErrorWithDistortionPK(o_x, o_y, c_dia, point)));
   }
   double ox_;              /** observed x location of object in image */
@@ -1572,7 +1571,7 @@ public:
   {
   }
 
-  template < typename T >
+  template <typename T>
   bool operator()(const T* const c_p1,  /** extrinsic parameters [6]*/
                   const T* const c_p2,  /** intrinsic parameters of camera fx,fy,cx,cy,k1,k2,k2,p1,p2 [9]*/
                   const T* const point, /** point described in target frame that is being seen [3]*/
@@ -1605,7 +1604,7 @@ public:
   /** the client code. */
   static ceres::CostFunction* Create(const double o_x, const double o_y, const double c_dia)
   {
-    return (new ceres::AutoDiffCostFunction< CircleTargetCameraReprjErrorWithDistortion, 2, 6, 9, 3 >(
+    return (new ceres::AutoDiffCostFunction<CircleTargetCameraReprjErrorWithDistortion, 2, 6, 9, 3>(
         new CircleTargetCameraReprjErrorWithDistortion(o_x, o_y, c_dia)));
   }
   double ox_;               /** observed x location of object in image */
@@ -1623,7 +1622,7 @@ public:
   {
   }
 
-  template < typename T >
+  template <typename T>
   bool operator()(const T* const c_p1, /** extrinsic parameters [6] */
                   const T* const c_p2, /** intrinsic parameters[9] */
                   T* residual) const
@@ -1659,7 +1658,7 @@ public:
   /** the client code. */
   static ceres::CostFunction* Create(const double& o_x, const double& o_y, const double& c_dia, Point3d& point)
   {
-    return (new ceres::AutoDiffCostFunction< SimpleCircleTargetCameraReprjErrorWithDistortionPK, 2, 6, 9 >(
+    return (new ceres::AutoDiffCostFunction<SimpleCircleTargetCameraReprjErrorWithDistortionPK, 2, 6, 9>(
         new SimpleCircleTargetCameraReprjErrorWithDistortionPK(o_x, o_y, c_dia, point)));
   }
   double ox_;               /** observed x location of object in image */
@@ -1677,7 +1676,7 @@ public:
   {
   }
 
-  template < typename T >
+  template <typename T>
   bool operator()(const T* const c_p1, /** extrinsic parameters [6] */
                   const T* const c_p2, /** 6Dof transform of target into world frame [6] */
                   const T* const c_p3, /** intrinsic parameters of camera fx,fy,cx,cy,k1,k2,k2,p1,p2 [9] */
@@ -1719,7 +1718,7 @@ public:
   /** the client code. */
   static ceres::CostFunction* Create(const double o_x, const double o_y, const double c_dia, Point3d point)
   {
-    return (new ceres::AutoDiffCostFunction< CircleTargetCameraReprjErrorWithDistortionPK, 2, 6, 6, 9 >(
+    return (new ceres::AutoDiffCostFunction<CircleTargetCameraReprjErrorWithDistortionPK, 2, 6, 6, 9>(
         new CircleTargetCameraReprjErrorWithDistortionPK(o_x, o_y, c_dia, point)));
   }
   double ox_;               /** observed x location of object in image */
@@ -1736,7 +1735,7 @@ public:
   {
   }
 
-  template < typename T >
+  template <typename T>
   bool operator()(const T* const c_p1,  /** extrinsic parameters [6]*/
                   const T* const c_p2,  /** 6Dof transform of target into world frame [6]*/
                   const T* const point, /** point described in target frame that is being seen [3]*/
@@ -1781,7 +1780,7 @@ public:
   static ceres::CostFunction* Create(const double o_x, const double o_y, const double c_dia, const double fx,
                                      const double fy, const double cx, const double cy)
   {
-    return (new ceres::AutoDiffCostFunction< CircleTargetCameraReprjError, 2, 6, 6, 3 >(
+    return (new ceres::AutoDiffCostFunction<CircleTargetCameraReprjError, 2, 6, 6, 3>(
         new CircleTargetCameraReprjError(o_x, o_y, c_dia, fx, fy, cx, cy)));
   }
   double ox_;               /** observed x location of object in image */
@@ -1802,7 +1801,7 @@ public:
   {
   }
 
-  template < typename T >
+  template <typename T>
   bool operator()(const T* const c_p1, /** extrinsic parameters [6] */
                   const T* const c_p2, /** 6Dof transform of target into world frame [6] */
                   T* residual) const
@@ -1846,7 +1845,7 @@ public:
   static ceres::CostFunction* Create(const double o_x, const double o_y, const double c_dia, const double fx,
                                      const double fy, const double cx, const double cy, Point3d point)
   {
-    return (new ceres::AutoDiffCostFunction< CircleTargetCameraReprjErrorPK, 2, 6, 6 >(
+    return (new ceres::AutoDiffCostFunction<CircleTargetCameraReprjErrorPK, 2, 6, 6>(
         new CircleTargetCameraReprjErrorPK(o_x, o_y, c_dia, fx, fy, cx, cy, point)));
   }
   double ox_;               /** observed x location of object in image */
@@ -1868,7 +1867,7 @@ public:
   {
   }
 
-  template < typename T >
+  template <typename T>
   bool operator()(const T* const c_p1,  /** extrinsic parameters [6]*/
                   const T* const c_p2,  /** 6Dof transform of target into world frame [6]*/
                   const T* const point, /** point described in target frame that is being seen [3]*/
@@ -1919,7 +1918,7 @@ public:
   static ceres::CostFunction* Create(const double o_x, const double o_y, const double c_dia, const double fx,
                                      const double fy, const double cx, const double cy, const Pose6d pose)
   {
-    return (new ceres::AutoDiffCostFunction< LinkCircleTargetCameraReprjError, 2, 6, 6, 3 >(
+    return (new ceres::AutoDiffCostFunction<LinkCircleTargetCameraReprjError, 2, 6, 6, 3>(
         new LinkCircleTargetCameraReprjError(o_x, o_y, c_dia, fx, fy, cx, cy, pose)));
   }
   double ox_;              /** observed x location of object in image */
@@ -1949,7 +1948,7 @@ public:
   {
   }
 
-  template < typename T >
+  template <typename T>
   bool operator()(const T* const c_p1, /** extrinsic parameters [6] */
                   const T* const c_p2, /** 6Dof transform of target into world frame [6] */
                   T* residual) const
@@ -2000,7 +1999,7 @@ public:
                                      const double fy, const double cx, const double cy, const Pose6d pose,
                                      Point3d point)
   {
-    return (new ceres::AutoDiffCostFunction< LinkCircleTargetCameraReprjErrorPK, 2, 6, 6 >(
+    return (new ceres::AutoDiffCostFunction<LinkCircleTargetCameraReprjErrorPK, 2, 6, 6>(
         new LinkCircleTargetCameraReprjErrorPK(o_x, o_y, c_dia, fx, fy, cx, cy, pose, point)));
   }
   double ox_;               /** observed x location of object in image */
@@ -2024,7 +2023,7 @@ public:
     link_posei_ = link_pose_.getInverse();
   }
 
-  template < typename T >
+  template <typename T>
   bool operator()(const T* const c_p1,  /** extrinsic parameters [6]*/
                   const T* const c_p2,  /** 6Dof transform of target into world frame [6]*/
                   const T* const point, /** point described in target frame that is being seen [3]*/
@@ -2075,7 +2074,7 @@ public:
   static ceres::CostFunction* Create(const double o_x, const double o_y, const double c_dia, double fx, double fy,
                                      double cx, double cy, const Pose6d pose)
   {
-    return (new ceres::AutoDiffCostFunction< LinkCameraCircleTargetReprjError, 2, 6, 6, 3 >(
+    return (new ceres::AutoDiffCostFunction<LinkCameraCircleTargetReprjError, 2, 6, 6, 3>(
         new LinkCameraCircleTargetReprjError(o_x, o_y, c_dia, fx, fy, cx, cy, pose)));
   }
   double ox_;              /** observed x location of object in image */
@@ -2182,7 +2181,7 @@ public:
     //      cameraCircResidual(camera_point, circle_diameter, R_TtoC, fx, fy,cx,cy, ox, oy, residual);
     cameraPntResidual(camera_point, fx, fy, cx, cy, ox, oy, residual);
   }
-  template < typename T >
+  template <typename T>
   bool operator()(const T* const c_p1, /** extrinsic parameters [6] */
                   const T* const c_p2, /** 6Dof transform of target into world frame [6] */
                   T* residual) const
@@ -2234,7 +2233,7 @@ public:
                                      const double& fy, const double& cx, const double& cy, const Pose6d& pose,
                                      Point3d& point)
   {
-    return (new ceres::AutoDiffCostFunction< LinkCameraCircleTargetReprjErrorPK, 2, 6, 6 >(
+    return (new ceres::AutoDiffCostFunction<LinkCameraCircleTargetReprjErrorPK, 2, 6, 6>(
         new LinkCameraCircleTargetReprjErrorPK(o_x, o_y, c_dia, fx, fy, cx, cy, pose, point)));
   }
   double ox_;               /** observed x location of object in image */
@@ -2303,7 +2302,7 @@ public:
     double oy = oy_;
     cameraCircResidual(camera_point, circle_diameter, R_mount_to_target, fx, fy, cx, cy, ox, oy, resid);
   }
-  template < typename T >
+  template <typename T>
   bool operator()(const T* const c_p1, /** extrinsic parameters [6] */
                   T* residual) const
   {
@@ -2349,7 +2348,7 @@ public:
                                      const double& fy, const double& cx, const double& cy, const Pose6d& target_pose,
                                      const Pose6d& camera_mounting_pose, Point3d& point)
   {
-    return (new ceres::AutoDiffCostFunction< FixedCircleTargetCameraReprjErrorPK, 2, 6 >(
+    return (new ceres::AutoDiffCostFunction<FixedCircleTargetCameraReprjErrorPK, 2, 6>(
         new FixedCircleTargetCameraReprjErrorPK(o_x, o_y, c_dia, fx, fy, cx, cy, target_pose, camera_mounting_pose,
                                                 point)));
   }
@@ -2374,7 +2373,7 @@ public:
   {
   }
 
-  template < typename T >
+  template <typename T>
   bool operator()(const T* const c_p1, /**intrinsics [9] */
                   const T* const c_p2, /**target_pose [6] */
                   T* residual) const
@@ -2401,7 +2400,7 @@ public:
   /** the client code. */
   static ceres::CostFunction* Create(const double o_x, const double o_y, const double rail_position, Point3d point)
   {
-    return (new ceres::AutoDiffCostFunction< RailICal, 2, 9, 6 >(new RailICal(o_x, o_y, rail_position, point)));
+    return (new ceres::AutoDiffCostFunction<RailICal, 2, 9, 6>(new RailICal(o_x, o_y, rail_position, point)));
   }
   double ox_;            /** observed x location of object in image */
   double oy_;            /** observed y location of object in image */

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/circle_cost_utils.hpp
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/circle_cost_utils.hpp
@@ -31,7 +31,7 @@ public:
    *    @param point  point being viewd described in target frame that is being seen [3]
    *    @output resid the error between the observation and the reprojected values given the parameters
    */
-  template < typename T >
+  template <typename T>
   bool operator()(const T* const c_p1, const T* const c_p2, const T* const c_p3, const T* const point, T* resid) const;
 
   /**  @brief Factory to hide the construction of the CostFunction object from the client code
@@ -41,7 +41,7 @@ public:
    */
   static ceres::CostFunction* Create(const double o_x, const double o_y, const double c_dia)
   {
-    return (new ceres::AutoDiffCostFunction< CircleTargetCameraReprjErrorOLD, 2, 6, 6, 9, 3 >(
+    return (new ceres::AutoDiffCostFunction<CircleTargetCameraReprjErrorOLD, 2, 6, 6, 9, 3>(
         new CircleTargetCameraReprjErrorOLD(o_x, o_y, c_dia)));
   }
 
@@ -52,7 +52,7 @@ private:
 };
 
 // member function definitions
-template < typename T >
+template <typename T>
 bool industrial_extrinsic_cal::CircleTargetCameraReprjErrorOLD::operator()(const T* const c_p1, const T* const c_p2,
                                                                            const T* const c_p3, const T* const point,
                                                                            T* resid) const
@@ -226,7 +226,7 @@ public:
    *    @param point  point being viewd described in target frame that is being seen [3]
    *    @output resid the error between the observation and the reprojected values given the parameters
    */
-  template < typename T >
+  template <typename T>
   bool operator()(const T* const c_p1,  /**< extrinsic parameters [6]*/
                   const T* const c_p2,  /**< 6Dof transform of target into world frame [6]*/
                   const T* const point, /**< point described in target frame that is being seen [3]*/
@@ -244,7 +244,7 @@ public:
   static ceres::CostFunction* Create(const double o_x, const double o_y, const double c_dia, const double fx,
                                      const double fy, const double cx, const double cy)
   {
-    return (new ceres::AutoDiffCostFunction< CircleTargetCameraReprjErrorNoDistortionOLD, 2, 6, 6, 3 >(
+    return (new ceres::AutoDiffCostFunction<CircleTargetCameraReprjErrorNoDistortionOLD, 2, 6, 6, 3>(
         new CircleTargetCameraReprjErrorNoDistortionOLD(o_x, o_y, c_dia, fx, fy, cx, cy)));
   }
 
@@ -259,7 +259,7 @@ private:
 };
 
 // member function definitions
-template < typename T >
+template <typename T>
 bool industrial_extrinsic_cal::CircleTargetCameraReprjErrorNoDistortionOLD::
 operator()(const T* const c_p1, const T* const c_p2, const T* const point, T* resid) const
 {
@@ -409,7 +409,7 @@ public:
    *    @param c_p2  6Dof transform of target into world frame [6]
    *    @output resid the error between the observation and the reprojected values given the parameters
    */
-  template < typename T >
+  template <typename T>
   bool operator()(const T* const c_p1, /**< extrinsic parameters [6]*/
                   const T* const c_p2, /**< 6Dof transform of target into world frame [6]*/
                   T* resid) const;
@@ -430,7 +430,7 @@ public:
                                      const double fy, const double cx, const double cy, const double point_x,
                                      const double point_y, const double point_z)
   {
-    return (new ceres::AutoDiffCostFunction< CircleTargetCameraReprjErrorNoDFixedPointOLD, 2, 6, 6 >(
+    return (new ceres::AutoDiffCostFunction<CircleTargetCameraReprjErrorNoDFixedPointOLD, 2, 6, 6>(
         new CircleTargetCameraReprjErrorNoDFixedPointOLD(o_x, o_y, c_dia, fx, fy, cx, cy, point_x, point_y, point_z)));
   }
 
@@ -446,7 +446,7 @@ private:
 };
 
 // member function definitions
-template < typename T >
+template <typename T>
 bool industrial_extrinsic_cal::CircleTargetCameraReprjErrorNoDFixedPointOLD::operator()(const T* const c_p1,
                                                                                         const T* const c_p2,
                                                                                         T* resid) const

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/circle_detector.hpp
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/circle_detector.hpp
@@ -87,7 +87,7 @@ public:
     void write(FileStorage& fs) const;
   };
 
-  CV_WRAP static Ptr< CircleDetector > create(const CircleDetector::Params& parameters = CircleDetector::Params());
+  CV_WRAP static Ptr<CircleDetector> create(const CircleDetector::Params& parameters = CircleDetector::Params());
 };
 }
 #endif

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/mutable_joint_state_publisher.h
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/mutable_joint_state_publisher.h
@@ -76,7 +76,7 @@ public:
 private:
   bool loadFromYamlFile();
   std::string yaml_file_name_;
-  std::map< std::string, double > joints_;
+  std::map<std::string, double> joints_;
   ros::NodeHandle nh_;
   ros::Publisher joint_state_pub_;
   ros::ServiceServer get_server_;

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/observation_data_point.h
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/observation_data_point.h
@@ -112,7 +112,7 @@ public:
   void addObservationPoint(ObservationDataPoint new_data_point);
 
   /** @brief vector of observations */
-  std::vector< ObservationDataPoint > items_;
+  std::vector<ObservationDataPoint> items_;
 };
 
 }  // end namespace industrial_extrinsic_cal

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/observation_scene.h
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/observation_scene.h
@@ -35,7 +35,7 @@ public:
   /*! \brief Constructor,
    *   \param Trigger the type of trigger to initiate this observation
    */
-  ObservationScene(boost::shared_ptr< Trigger > trigger, int scene_id) : scene_id_(scene_id)
+  ObservationScene(boost::shared_ptr<Trigger> trigger, int scene_id) : scene_id_(scene_id)
   {
     trigger_ = trigger;
   };
@@ -61,7 +61,7 @@ public:
    * \brief Adds a camera to the scene
    * @param cameras_in_scene
    */
-  void addCameraToScene(boost::shared_ptr< Camera > cameras_in_scene);
+  void addCameraToScene(boost::shared_ptr<Camera> cameras_in_scene);
 
   /*!
    * \brief will populate the observation_command_list_
@@ -70,7 +70,7 @@ public:
    * @param roi the region of interest for this observation command
    * @param cost_type type of cost function to build with this observation
    */
-  void populateObsCmdList(boost::shared_ptr< Camera > camera, boost::shared_ptr< Target > target, Roi roi,
+  void populateObsCmdList(boost::shared_ptr<Camera> camera, boost::shared_ptr<Target> target, Roi roi,
                           Cost_function cost_type);
 
   /*! \brief gets the id of this scene */
@@ -80,7 +80,7 @@ public:
   };
 
   /*! \brief gets the trigger of this scene */
-  boost::shared_ptr< Trigger > get_trigger()
+  boost::shared_ptr<Trigger> get_trigger()
   {
     return (trigger_);
   };
@@ -98,17 +98,17 @@ public:
    * \brief set the trigger for this scene
    * @param trigger
    */
-  void setTrigger(boost::shared_ptr< Trigger > trigger)
+  void setTrigger(boost::shared_ptr<Trigger> trigger)
   {
     trigger_ = trigger;
   };
 
-  std::vector< ObservationCmd > observation_command_list_;      /*!< list of observations for a scene */
-  std::vector< boost::shared_ptr< Camera > > cameras_in_scene_; /*!< list of cameras in this scene */
+  std::vector<ObservationCmd> observation_command_list_;     /*!< list of observations for a scene */
+  std::vector<boost::shared_ptr<Camera> > cameras_in_scene_; /*!< list of cameras in this scene */
 
 private:
-  boost::shared_ptr< Trigger > trigger_; /*!< event to trigger the observations in this command */
-  int scene_id_;                         /*!< unique identifier of this scene */
+  boost::shared_ptr<Trigger> trigger_; /*!< event to trigger the observations in this command */
+  int scene_id_;                       /*!< unique identifier of this scene */
 };
 // end of class ObservationScene
 

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/points_yaml_parser.h
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/points_yaml_parser.h
@@ -12,7 +12,7 @@ namespace industrial_extrinsic_cal
  *  @param points the returned vector of points
  *  @return true if success, false otherwise
  */
-bool parsePoints(std::string& points_input_file, std::vector< industrial_extrinsic_cal::Point3d >& points);
+bool parsePoints(std::string& points_input_file, std::vector<industrial_extrinsic_cal::Point3d>& points);
 
 }  // end industrial_extrinsic_cal namespace
 

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/ros_camera_observer.h
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/ros_camera_observer.h
@@ -85,7 +85,7 @@ public:
    * @param cost_type type of cost function for observations of this target
    * @return true if successful, false if error in setting target or roi
    */
-  bool addTarget(boost::shared_ptr< Target > targ, Roi& roi, Cost_function cost_type);
+  bool addTarget(boost::shared_ptr<Target> targ, Roi& roi, Cost_function cost_type);
 
   /**
    * @brief remove all targets
@@ -159,12 +159,12 @@ private:
   /**
    *  @brief 2D values of corner/circle locations returned from cv methods
    */
-  std::vector< cv::Point2f > observation_pts_;
+  std::vector<cv::Point2f> observation_pts_;
 
   /**
    *  @brief private target which is initialized to input target
    */
-  boost::shared_ptr< Target > instance_target_;
+  boost::shared_ptr<Target> instance_target_;
 
   /**
    *  @brief private CameraObservations which are set at the end of getObservations and cleared
@@ -211,12 +211,12 @@ private:
   /**
    *  @brief circle_detector_ptr_ is a custom blob detector which localizes circles better than simple blob detection
    */
-  cv::Ptr< cv::CircleDetector > circle_detector_ptr_;
+  cv::Ptr<cv::CircleDetector> circle_detector_ptr_;
 
   /**
    *  @brief blob_detector_ptr_ is a simple blob detector
    */
-  cv::Ptr< cv::FeatureDetector > blob_detector_ptr_;
+  cv::Ptr<cv::FeatureDetector> blob_detector_ptr_;
 
   /**
    *  @brief new_image_collected, set after the trigger is done
@@ -322,7 +322,7 @@ private:
   ros::ServiceClient client_;
   sensor_msgs::SetCameraInfo srv_;
   ros::NodeHandle* rnh_;
-  dynamic_reconfigure::Server< industrial_extrinsic_cal::circle_grid_finderConfig >* server_;
+  dynamic_reconfigure::Server<industrial_extrinsic_cal::circle_grid_finderConfig>* server_;
 };
 
 }  // end industrial_extrinsic_cal namespace

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/ros_scene_triggers.h
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/ros_scene_triggers.h
@@ -57,7 +57,7 @@ private:
   std::string parameter_name_;
 };
 
-typedef actionlib::SimpleActionClient< industrial_extrinsic_cal::manual_triggerAction > Client;
+typedef actionlib::SimpleActionClient<industrial_extrinsic_cal::manual_triggerAction> Client;
 
 class ROSActionServerSceneTrigger : public SceneTrigger
 {

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/ros_transform_interface.h
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/ros_transform_interface.h
@@ -391,8 +391,8 @@ private:
                                          transform */
   ros::ServiceClient
       store_client_; /**< a client for calling the service to store the joint values associated with the transform */
-  std::vector< std::string > joint_names_;                                  /**< names of joints  */
-  std::vector< double > joint_values_;                                      /**< values of joints  */
+  std::vector<std::string> joint_names_;                                    /**< names of joints  */
+  std::vector<double> joint_values_;                                        /**< values of joints  */
   industrial_extrinsic_cal::get_mutable_joint_states::Request get_request_; /**< request when transform is part of a
                                                                                mutable set */
   industrial_extrinsic_cal::get_mutable_joint_states::Response
@@ -464,8 +464,8 @@ private:
                                      transform */
   ros::ServiceClient
       store_client_; /**< a client for calling the service to store the joint values associated with the transform */
-  std::vector< std::string > joint_names_; /**< names of joints  */
-  std::vector< double > joint_values_;     /**< values of joints  */
+  std::vector<std::string> joint_names_; /**< names of joints  */
+  std::vector<double> joint_values_;     /**< values of joints  */
   industrial_extrinsic_cal::get_mutable_joint_states::Request get_request_;
   industrial_extrinsic_cal::get_mutable_joint_states::Response get_response_;
   industrial_extrinsic_cal::set_mutable_joint_states::Request set_request_;
@@ -531,8 +531,8 @@ private:
                                      transform */
   ros::ServiceClient
       store_client_; /**< a client for calling the service to store the joint values associated with the transform */
-  std::vector< std::string > joint_names_; /**< names of joints  */
-  std::vector< double > joint_values_;     /**< values of joints  */
+  std::vector<std::string> joint_names_; /**< names of joints  */
+  std::vector<double> joint_values_;     /**< values of joints  */
   industrial_extrinsic_cal::get_mutable_joint_states::Request get_request_;
   industrial_extrinsic_cal::get_mutable_joint_states::Response get_response_;
   industrial_extrinsic_cal::set_mutable_joint_states::Request set_request_;

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/ros_triggers.h
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/ros_triggers.h
@@ -63,7 +63,7 @@ private:
   std::string parameter_name_;
 };
 
-typedef actionlib::SimpleActionClient< industrial_extrinsic_cal::manual_triggerAction > ManualClient;
+typedef actionlib::SimpleActionClient<industrial_extrinsic_cal::manual_triggerAction> ManualClient;
 
 class ROSActionServerTrigger : public Trigger
 {
@@ -108,7 +108,7 @@ private:
   std::string action_message_; /**< message sent to action server, often displayed by that server */
 };
 
-typedef actionlib::SimpleActionClient< industrial_extrinsic_cal::robot_joint_values_triggerAction >
+typedef actionlib::SimpleActionClient<industrial_extrinsic_cal::robot_joint_values_triggerAction>
     RobotJointValuesClient;
 
 class ROSRobotJointValuesActionServerTrigger : public Trigger
@@ -118,7 +118,7 @@ public:
    *  @param server name , name of server
    *  @param joint_values, vector of joint values describing the pose of the robot for the trigger
    */
-  ROSRobotJointValuesActionServerTrigger(const std::string& server_name, const std::vector< double >& joint_values)
+  ROSRobotJointValuesActionServerTrigger(const std::string& server_name, const std::vector<double>& joint_values)
   {
     server_name_ = server_name;
     joint_values_.clear();
@@ -162,12 +162,12 @@ public:
 
 private:
   RobotJointValuesClient* client_;
-  ros::NodeHandle nh_;                 /**< node handle */
-  std::string server_name_;            /**< name of server */
-  std::vector< double > joint_values_; /**< joint values */
+  ros::NodeHandle nh_;               /**< node handle */
+  std::string server_name_;          /**< name of server */
+  std::vector<double> joint_values_; /**< joint values */
 };
 
-typedef actionlib::SimpleActionClient< industrial_extrinsic_cal::robot_pose_triggerAction > Robot_Pose_Client;
+typedef actionlib::SimpleActionClient<industrial_extrinsic_cal::robot_pose_triggerAction> Robot_Pose_Client;
 
 class ROSRobotPoseActionServerTrigger : public Trigger
 {
@@ -216,10 +216,10 @@ public:
 
 private:
   Robot_Pose_Client* client_;
-  ros::NodeHandle nh_;                 /**< node handle */
-  std::string server_name_;            /**< name of server */
-  geometry_msgs::Pose pose_;           /**< pose of robot */
-  std::vector< double > joint_values_; /**< joint values */
+  ros::NodeHandle nh_;               /**< node handle */
+  std::string server_name_;          /**< name of server */
+  geometry_msgs::Pose pose_;         /**< pose of robot */
+  std::vector<double> joint_values_; /**< joint values */
 };
 
 class ROSCameraObserverTrigger : public Trigger
@@ -238,7 +238,7 @@ public:
     service_name_ = service_name;
     instructions_ = instructions;
     image_topic_ = image_topic;
-    client_ = nh_->serviceClient< industrial_extrinsic_cal::camera_observer_trigger >(service_name_.c_str());
+    client_ = nh_->serviceClient<industrial_extrinsic_cal::camera_observer_trigger>(service_name_.c_str());
     roi_ = roi;
   };
 

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/runtime_utils.h
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/runtime_utils.h
@@ -82,55 +82,55 @@ public:
   /**
    *  @brief name frame for target points
    */
-  std::vector< std::string > target_frame_;
+  std::vector<std::string> target_frame_;
   /**
    *  @brief name of camera frame in which observations were made
    */
-  std::vector< std::string > camera_optical_frame_;
+  std::vector<std::string> camera_optical_frame_;
   /**
    *  @brief name of camera frame which links camera optical frame to reference frame
    */
-  std::vector< std::string > camera_intermediate_frame_;
+  std::vector<std::string> camera_intermediate_frame_;
 
   // CalJob specific
   /**
    *  @brief set of initial extrinsics of camera(s)
    */
-  std::vector< industrial_extrinsic_cal::P_BLOCK > initial_extrinsics_;
+  std::vector<industrial_extrinsic_cal::P_BLOCK> initial_extrinsics_;
   /**
    *  @brief set of calibrated extrinsics of camera(s)
    */
-  std::vector< industrial_extrinsic_cal::P_BLOCK > calibrated_extrinsics_;
+  std::vector<industrial_extrinsic_cal::P_BLOCK> calibrated_extrinsics_;
   /**
    *  @brief set of calibrated extrinsics of target(s)
    */
-  std::vector< industrial_extrinsic_cal::P_BLOCK > target_poses_;
+  std::vector<industrial_extrinsic_cal::P_BLOCK> target_poses_;
 
   // TF specific
   /**
    *  @brief set of initial transform of camera(s)
    */
-  std::vector< tf::Transform > initial_transforms_;
+  std::vector<tf::Transform> initial_transforms_;
   /**
    *  @brief set of resultant calibrated transform of camera(s)
    */
-  std::vector< tf::Transform > calibrated_transforms_;
+  std::vector<tf::Transform> calibrated_transforms_;
   /**
    *  @brief set of transforms of from camera intermediate to camera optical frames
    */
-  std::vector< tf::StampedTransform > camera_internal_transforms_;
+  std::vector<tf::StampedTransform> camera_internal_transforms_;
   /**
    *  @brief set of transforms of from camera intermediate to camera optical frames
    */
-  std::vector< tf::StampedTransform > points_to_world_transforms_;
+  std::vector<tf::StampedTransform> points_to_world_transforms_;
   /**
    *  @brief set target transforms
    */
-  std::vector< tf::Transform > target_transforms_;
+  std::vector<tf::Transform> target_transforms_;
   /**
    *  @brief set of broadcasters for transform of camera(s) and target(s)
    */
-  std::vector< tf::TransformBroadcaster > broadcasters_;
+  std::vector<tf::TransformBroadcaster> broadcasters_;
   /**
    *  @brief set of listeners for transform from camera intermediate to camera optical frames
    */

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/target.h
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/target.h
@@ -40,10 +40,10 @@ public:
   void pullTransform();
 
   /*! \brief sets the transform interface */
-  void setTransformInterface(boost::shared_ptr< TransformInterface > tranform_interface);
+  void setTransformInterface(boost::shared_ptr<TransformInterface> tranform_interface);
 
   /*! \brief gets the transform interface, why we have this for a public member, I don't know*/
-  boost::shared_ptr< TransformInterface > getTransformInterface();
+  boost::shared_ptr<TransformInterface> getTransformInterface();
 
   /*! \brief sets the transform interface, reference frame*/
   void setTIReferenceFrame(std::string ref_frame);
@@ -57,22 +57,22 @@ public:
   };
 
   // TODO make many of these private with interfaces
-  Pose6d pose_;                /**< pose of target */
-  unsigned int num_points_;    /**< number of points in the point array */
-  std::vector< Point3d > pts_; /**< an array of points expressed relative to Pose p. */
-  bool is_moving_;             /**< observed in multiple locations or it fixed to ref frame */
-  std::string target_name_;    /**< Name of target */
-  std::string target_frame_;   /**< name of target's coordinate frame */
-  unsigned int target_type_;   /**< Type of target */
-  boost::shared_ptr< TransformInterface > transform_interface_; /**< interface to transform */
+  Pose6d pose_;              /**< pose of target */
+  unsigned int num_points_;  /**< number of points in the point array */
+  std::vector<Point3d> pts_; /**< an array of points expressed relative to Pose p. */
+  bool is_moving_;           /**< observed in multiple locations or it fixed to ref frame */
+  std::string target_name_;  /**< Name of target */
+  std::string target_frame_; /**< name of target's coordinate frame */
+  unsigned int target_type_; /**< Type of target */
+  boost::shared_ptr<TransformInterface> transform_interface_; /**< interface to transform */
 
 private:
 };
 /*! \brief moving  need a new pose with each scene in which they are used */
 typedef struct MovingTarget
 {
-  boost::shared_ptr< Target > targ_;  // must hold a copy of the target pose parameters,
-  int scene_id_;                      // but point parameters may be unused duplicates
+  boost::shared_ptr<Target> targ_;  // must hold a copy of the target pose parameters,
+  int scene_id_;                    // but point parameters may be unused duplicates
 } MovingTarget;
 
 }  // end of namespace

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/targets_yaml_parser.h
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/targets_yaml_parser.h
@@ -15,11 +15,11 @@ namespace industrial_extrinsic_cal
  *    @param targets vector of shared pointers to targets parsed
  *    @return true if successful
  */
-bool parseTargets(std::string& targets_input_file, std::vector< boost::shared_ptr< Target > >& targets);
+bool parseTargets(std::string& targets_input_file, std::vector<boost::shared_ptr<Target> >& targets);
 /** @brief parse a single target
  *    @param node, the yaml node from which to parse the target
  */
-boost::shared_ptr< Target > parseSingleTarget(const YAML::Node& node);
+boost::shared_ptr<Target> parseSingleTarget(const YAML::Node& node);
 }  // end industrial_extrinsic_cal namespace
 
 #endif

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/yaml_utils.h
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/yaml_utils.h
@@ -17,7 +17,7 @@ inline bool parseDouble(const YAML::Node& node, char const* var_name, double& va
 {
   if (node[var_name])
   {
-    var_value = node[var_name].as< double >();
+    var_value = node[var_name].as<double>();
     return true;
   }
   return false;
@@ -27,7 +27,7 @@ inline bool parseInt(const YAML::Node& node, char const* var_name, int& var_valu
 {
   if (node[var_name])
   {
-    var_value = node[var_name].as< int >();
+    var_value = node[var_name].as<int>();
     return true;
   }
   return false;
@@ -36,7 +36,7 @@ inline bool parseUInt(const YAML::Node& node, char const* var_name, unsigned int
 {
   if (node[var_name])
   {
-    var_value = node[var_name].as< unsigned int >();
+    var_value = node[var_name].as<unsigned int>();
     return true;
   }
   return false;
@@ -46,7 +46,7 @@ inline bool parseString(const YAML::Node& node, char const* var_name, std::strin
 {
   if (node[var_name])
   {
-    var_value = node[var_name].as< std::string >();
+    var_value = node[var_name].as<std::string>();
     return true;
   }
   return false;
@@ -62,7 +62,7 @@ inline bool parseBool(const YAML::Node& node, char const* var_name, bool& var_va
   return false;
 }
 
-inline bool parseVectorD(const YAML::Node& node, char const* var_name, std::vector< double >& var_value)
+inline bool parseVectorD(const YAML::Node& node, char const* var_name, std::vector<double>& var_value)
 {
   if (node[var_name])
   {
@@ -71,7 +71,7 @@ inline bool parseVectorD(const YAML::Node& node, char const* var_name, std::vect
     for (int i = 0; i < (int)n.size(); i++)
     {
       double value;
-      value = n[i].as< double >();
+      value = n[i].as<double>();
       var_value.push_back(value);
     }
     return true;
@@ -89,8 +89,8 @@ inline const YAML::Node parseNode(const YAML::Node& node, char const* var_name)
 }
 inline void parseKeyDValue(YAML::const_iterator& it, std::string& key, double& dvalue)
 {
-  key = it->first.as< std::string >();
-  dvalue = it->second.as< double >();
+  key = it->first.as<std::string>();
+  dvalue = it->second.as<double>();
 }
 
 inline bool yamlNodeFromFileName(std::string filename, YAML::Node& ynode)

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/yaml_utils_hydro.h
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/yaml_utils_hydro.h
@@ -63,7 +63,7 @@ inline bool parseBool(const YAML::Node& node, char const* var_name, bool& var_va
   return false;
 }
 
-inline bool parseVectorD(const YAML::Node& node, char const* var_name, std::vector< double >& var_value)
+inline bool parseVectorD(const YAML::Node& node, char const* var_name, std::vector<double>& var_value)
 {
   if (node.FindValue(var_name))
   {

--- a/industrial_extrinsic_cal/include/industrial_extrinsic_cal/yaml_utils_indigo.h
+++ b/industrial_extrinsic_cal/include/industrial_extrinsic_cal/yaml_utils_indigo.h
@@ -17,7 +17,7 @@ inline bool parseDouble(const YAML::Node& node, char const* var_name, double& va
 {
   if (node[var_name])
   {
-    var_value = node[var_name].as< double >();
+    var_value = node[var_name].as<double>();
     return true;
   }
   return false;
@@ -27,7 +27,7 @@ inline bool parseInt(const YAML::Node& node, char const* var_name, int& var_valu
 {
   if (node[var_name])
   {
-    var_value = node[var_name].as< int >();
+    var_value = node[var_name].as<int>();
     return true;
   }
   return false;
@@ -36,7 +36,7 @@ inline bool parseUInt(const YAML::Node& node, char const* var_name, unsigned int
 {
   if (node[var_name])
   {
-    var_value = node[var_name].as< unsigned int >();
+    var_value = node[var_name].as<unsigned int>();
     return true;
   }
   return false;
@@ -46,7 +46,7 @@ inline bool parseString(const YAML::Node& node, char const* var_name, std::strin
 {
   if (node[var_name])
   {
-    var_value = node[var_name].as< std::string >();
+    var_value = node[var_name].as<std::string>();
     return true;
   }
   return false;
@@ -62,7 +62,7 @@ inline bool parseBool(const YAML::Node& node, char const* var_name, bool& var_va
   return false;
 }
 
-inline bool parseVectorD(const YAML::Node& node, char const* var_name, std::vector< double >& var_value)
+inline bool parseVectorD(const YAML::Node& node, char const* var_name, std::vector<double>& var_value)
 {
   if (node[var_name])
   {
@@ -71,7 +71,7 @@ inline bool parseVectorD(const YAML::Node& node, char const* var_name, std::vect
     for (int i = 0; i < (int)n.size(); i++)
     {
       double value;
-      value = n[i].as< double >();
+      value = n[i].as<double>();
       var_value.push_back(value);
     }
     return true;
@@ -89,8 +89,8 @@ inline const YAML::Node parseNode(const YAML::Node& node, char const* var_name)
 }
 inline void parseKeyDValue(YAML::const_iterator& it, std::string& key, double& dvalue)
 {
-  key = it->first.as< std::string >();
-  dvalue = it->second.as< double >();
+  key = it->first.as<std::string>();
+  dvalue = it->second.as<double>();
 }
 
 inline bool yamlNodeFromFileName(std::string filename, YAML::Node& ynode)

--- a/industrial_extrinsic_cal/src/calibration_job_definition.cpp
+++ b/industrial_extrinsic_cal/src/calibration_job_definition.cpp
@@ -40,7 +40,7 @@ using industrial_extrinsic_cal::covariance_requests::CovarianceRequestType;
 namespace industrial_extrinsic_cal
 {
 /** @brief, a function used for debugging, and generating output for post processing */
-void writeObservationData(std::string file_name, std::vector< ObservationDataPointList > odl)
+void writeObservationData(std::string file_name, std::vector<ObservationDataPointList> odl)
 {
   FILE* fp = NULL;
   fp = fopen(file_name.c_str(), "w");
@@ -146,7 +146,7 @@ void CalibrationJob::postProcessingOff()
 bool CalibrationJob::loadCamera()
 {
   bool rtn = true;
-  std::vector< shared_ptr< Camera > > all_cameras;
+  std::vector<shared_ptr<Camera> > all_cameras;
   if (!parseCameras(camera_def_file_name_, all_cameras))
   {
     ROS_ERROR("failed to parse cameras from %s", camera_def_file_name_.c_str());
@@ -170,7 +170,7 @@ bool CalibrationJob::loadCamera()
 bool CalibrationJob::loadTarget()
 {
   bool rtn = true;
-  std::vector< shared_ptr< Target > > all_targets;
+  std::vector<shared_ptr<Target> > all_targets;
   if (!parseTargets(target_def_file_name_, all_targets))
   {
     ROS_ERROR("failed to parse targets from %s", target_def_file_name_.c_str());
@@ -237,7 +237,7 @@ bool CalibrationJob::runObservations()
     ROS_DEBUG_STREAM("Processing Scene " << scene_id + 1 << " of " << scene_list_.size());
     current_scene.get_trigger()->waitForTrigger();  // this indicates scene is ready to capture
     pullTransforms(scene_id);                       // gets transforms of targets and cameras from their interfaces
-    BOOST_FOREACH (shared_ptr< Camera > current_camera, current_scene.cameras_in_scene_)
+    BOOST_FOREACH (shared_ptr<Camera> current_camera, current_scene.cameras_in_scene_)
     {  // clear camera of existing observations
 
       current_camera->camera_observer_->clearObservations();  // clear any recorded data
@@ -248,7 +248,7 @@ bool CalibrationJob::runObservations()
 
       o_command.camera->camera_observer_->addTarget(o_command.target, o_command.roi, o_command.cost_type);
     }
-    BOOST_FOREACH (shared_ptr< Camera > current_camera, current_scene.cameras_in_scene_)
+    BOOST_FOREACH (shared_ptr<Camera> current_camera, current_scene.cameras_in_scene_)
     {  // trigger the cameras
       current_camera->camera_observer_->triggerCamera();
     }
@@ -264,7 +264,7 @@ bool CalibrationJob::runObservations()
 
     // for each camera in scene get a list of observations, and add camera parameters to ceres_blocks
     ObservationDataPointList listpercamera;
-    BOOST_FOREACH (shared_ptr< Camera > camera, current_scene.cameras_in_scene_)
+    BOOST_FOREACH (shared_ptr<Camera> camera, current_scene.cameras_in_scene_)
     {
       // wait until observation is done
       while (!camera->camera_observer_->observationsDone())
@@ -692,7 +692,7 @@ bool CalibrationJob::runOptimization()
 
 }  // end runOptimization
 
-bool CalibrationJob::computeCovariance(std::vector< CovarianceVariableRequest >& variables,
+bool CalibrationJob::computeCovariance(std::vector<CovarianceVariableRequest>& variables,
                                        std::string& covariance_file_name)
 {
   FILE* fp;
@@ -701,10 +701,10 @@ bool CalibrationJob::computeCovariance(std::vector< CovarianceVariableRequest >&
     ceres::Covariance::Options covariance_options;
     covariance_options.algorithm_type = ceres::DENSE_SVD;
     ceres::Covariance covariance(covariance_options);
-    std::vector< const double* > covariance_blocks;
-    std::vector< int > block_sizes;
-    std::vector< std::string > block_names;
-    std::vector< std::pair< const double*, const double* > > covariance_pairs;
+    std::vector<const double*> covariance_blocks;
+    std::vector<int> block_sizes;
+    std::vector<std::string> block_names;
+    std::vector<std::pair<const double*, const double*> > covariance_pairs;
 
     BOOST_FOREACH (CovarianceVariableRequest req, variables)
     {

--- a/industrial_extrinsic_cal/src/caljob_yaml_parser.cpp
+++ b/industrial_extrinsic_cal/src/caljob_yaml_parser.cpp
@@ -24,7 +24,7 @@ using boost::shared_ptr;
 using boost::make_shared;
 using YAML::Node;
 
-bool parseCaljob(std::string& caljob_input_file, vector< ObservationScene >& scene_list, string& reference_frame,
+bool parseCaljob(std::string& caljob_input_file, vector<ObservationScene>& scene_list, string& reference_frame,
                  CeresBlocks& blocks)
 {
   bool rtn = true;
@@ -68,7 +68,7 @@ ObservationScene parseSingleScene(const Node& node, int scene_id, CeresBlocks& b
     // parse the scene trigger
     std::string trigger_name;
     if (!parseString(node, "trigger", trigger_name)) ROS_ERROR("no trigger in scene");
-    boost::shared_ptr< Trigger > temp_trigger = parseTrigger(node, trigger_name);
+    boost::shared_ptr<Trigger> temp_trigger = parseTrigger(node, trigger_name);
     temp_scene.setTrigger(temp_trigger);
 
     // parse the observations
@@ -79,8 +79,8 @@ ObservationScene parseSingleScene(const Node& node, int scene_id, CeresBlocks& b
       std::string target_name;
       std::string cost_type_string;
       Cost_function cost_type;
-      shared_ptr< Camera > temp_cam = make_shared< Camera >();
-      shared_ptr< Target > temp_targ = make_shared< Target >();
+      shared_ptr<Camera> temp_cam = make_shared<Camera>();
+      shared_ptr<Target> temp_targ = make_shared<Target>();
       Roi temp_roi;
       if (!parseString(observation_node[i], "camera", camera_name)) ROS_ERROR("no camera_name in observation");
       if (!parseString(observation_node[i], "target", target_name)) ROS_ERROR("no target in observation");

--- a/industrial_extrinsic_cal/src/camera_definition.cpp
+++ b/industrial_extrinsic_cal/src/camera_definition.cpp
@@ -60,11 +60,11 @@ void Camera::pullTransform()
   camera_parameters_.position[1] = pose.y;
   camera_parameters_.position[2] = pose.z;
 }
-void Camera::setTransformInterface(boost::shared_ptr< TransformInterface > transform_interface)
+void Camera::setTransformInterface(boost::shared_ptr<TransformInterface> transform_interface)
 {
   transform_interface_ = transform_interface;
 }
-boost::shared_ptr< TransformInterface > Camera::getTransformInterface()
+boost::shared_ptr<TransformInterface> Camera::getTransformInterface()
 {
   return (transform_interface_);
 }

--- a/industrial_extrinsic_cal/src/camera_yaml_parser.cpp
+++ b/industrial_extrinsic_cal/src/camera_yaml_parser.cpp
@@ -22,7 +22,7 @@ using YAML::Node;
 
 namespace industrial_extrinsic_cal
 {
-bool parseCameras(std::string& cameras_input_file, vector< shared_ptr< Camera > >& cameras)
+bool parseCameras(std::string& cameras_input_file, vector<shared_ptr<Camera> >& cameras)
 {
   Node camera_doc;
   bool rtn = true;
@@ -42,7 +42,7 @@ bool parseCameras(std::string& cameras_input_file, vector< shared_ptr< Camera > 
     {
       for (unsigned int i = 0; i < camera_parameters.size(); i++)
       {
-        shared_ptr< Camera > temp_camera = parseSingleCamera(camera_parameters[i]);
+        shared_ptr<Camera> temp_camera = parseSingleCamera(camera_parameters[i]);
         cameras.push_back(temp_camera);
         n_static++;
       }
@@ -55,7 +55,7 @@ bool parseCameras(std::string& cameras_input_file, vector< shared_ptr< Camera > 
     {
       for (unsigned int i = 0; i < camera_parameters2.size(); i++)
       {
-        shared_ptr< Camera > temp_camera = parseSingleCamera(camera_parameters2[i]);
+        shared_ptr<Camera> temp_camera = parseSingleCamera(camera_parameters2[i]);
         temp_camera->is_moving_ = true;
         cameras.push_back(temp_camera);
         n_moving++;
@@ -76,9 +76,9 @@ bool parseCameras(std::string& cameras_input_file, vector< shared_ptr< Camera > 
   }
   return (rtn);
 }
-shared_ptr< Camera > parseSingleCamera(const Node& node)
+shared_ptr<Camera> parseSingleCamera(const Node& node)
 {
-  shared_ptr< Camera > temp_camera;
+  shared_ptr<Camera> temp_camera;
   try
   {
     string temp_name, temp_topic, camera_optical_frame, camera_housing_frame, camera_mounting_frame, parent_frame;
@@ -123,9 +123,9 @@ shared_ptr< Camera > parseSingleCamera(const Node& node)
     }
 
     // create a shared camera and a shared transform interface
-    temp_camera = boost::make_shared< Camera >(temp_name, temp_parameters, false);
+    temp_camera = boost::make_shared<Camera>(temp_name, temp_parameters, false);
     temp_camera->trigger_ = parseTrigger(node, trigger_name);
-    shared_ptr< TransformInterface > temp_ti =
+    shared_ptr<TransformInterface> temp_ti =
         parseTransformInterface(node, transform_interface, camera_optical_frame, pose);
     temp_camera->setTransformInterface(temp_ti);  // install the transform interface
     if (transform_available)
@@ -137,7 +137,7 @@ shared_ptr< Camera > parseSingleCamera(const Node& node)
     {
       temp_camera->pullTransform();
     }
-    temp_camera->camera_observer_ = boost::make_shared< ROSCameraObserver >(temp_topic, temp_name);
+    temp_camera->camera_observer_ = boost::make_shared<ROSCameraObserver>(temp_topic, temp_name);
   }
   catch (YAML::ParserException& e)
   {
@@ -157,38 +157,38 @@ shared_ptr< Camera > parseSingleCamera(const Node& node)
   return (temp_camera);
 }
 
-shared_ptr< Trigger > parseTrigger(const Node& node, string& name)
+shared_ptr<Trigger> parseTrigger(const Node& node, string& name)
 {
-  shared_ptr< Trigger > temp_trigger;
+  shared_ptr<Trigger> temp_trigger;
   std::string trig_param;
   std::string trig_action_server;
   std::string trig_action_msg;
   // handle all the different trigger cases
   if (name == string("NO_WAIT_TRIGGER"))
   {
-    temp_trigger = boost::make_shared< NoWaitTrigger >();
+    temp_trigger = boost::make_shared<NoWaitTrigger>();
   }
   else if (name == string("ROS_PARAM_TRIGGER"))
   {
     if (!parseString(node, "trig_param", trig_param)) ROS_ERROR("Can't read trig_param");
-    temp_trigger = boost::make_shared< ROSParamTrigger >(trig_param);
+    temp_trigger = boost::make_shared<ROSParamTrigger>(trig_param);
   }
   else if (name == string("ROS_ACTION_TRIGGER"))
   {
     if (!parseString(node, "trig_action_server", trig_action_server)) ROS_ERROR("Can't read trig_action_server");
     if (!parseString(node, "trig_action_msg", trig_action_msg)) ROS_ERROR("Can't read trig_action_msg");
-    temp_trigger = boost::make_shared< ROSActionServerTrigger >(trig_action_server, trig_action_msg);
+    temp_trigger = boost::make_shared<ROSActionServerTrigger>(trig_action_server, trig_action_msg);
   }
   else if (name == string("ROS_ROBOT_JOINT_VALUES_ACTION_TRIGGER"))
   {
     if (!parseString(node, "trig_action_server", trig_action_server)) ROS_ERROR("Can't read trig_action_server");
-    std::vector< double > joint_values;
+    std::vector<double> joint_values;
     if (!parseVectorD(node, "joint_values", joint_values)) ROS_ERROR("Can't read joint_values");
     if (joint_values.size() < 0)
     {
       ROS_ERROR("Couldn't read joint_values for ROS_ROBOT_JOINT_VALUES_ACTION_TRIGGER");
     }
-    temp_trigger = boost::make_shared< ROSRobotJointValuesActionServerTrigger >(trig_action_server, joint_values);
+    temp_trigger = boost::make_shared<ROSRobotJointValuesActionServerTrigger>(trig_action_server, joint_values);
   }
   else if (name == string("ROS_ROBOT_POSE_ACTION_TRIGGER"))
   {
@@ -197,7 +197,7 @@ shared_ptr< Trigger > parseTrigger(const Node& node, string& name)
       ROS_ERROR("Can't read trig_action_server");
     Pose6d pose;
     parsePose(trig_node, pose);
-    temp_trigger = boost::make_shared< ROSRobotPoseActionServerTrigger >(trig_action_server, pose);
+    temp_trigger = boost::make_shared<ROSRobotPoseActionServerTrigger>(trig_action_server, pose);
   }
   else if (name == string("ROS_CAMERA_OBSERVER_TRIGGER"))
   {
@@ -213,7 +213,7 @@ shared_ptr< Trigger > parseTrigger(const Node& node, string& name)
     if (!parseInt(trig_node[0], "roi_max_x", roi.x_max)) ROS_ERROR("Can't read roi_max_x");
     if (!parseInt(trig_node[0], "roi_min_y", roi.y_min)) ROS_ERROR("Can't read roi_min_y");
     if (!parseInt(trig_node[0], "roi_max_y", roi.y_max)) ROS_ERROR("Can't read roi_max_y");
-    temp_trigger = boost::make_shared< ROSCameraObserverTrigger >(service_name, instructions, image_topic, roi);
+    temp_trigger = boost::make_shared<ROSCameraObserverTrigger>(service_name, instructions, image_topic, roi);
   }
   else
   {
@@ -222,66 +222,66 @@ shared_ptr< Trigger > parseTrigger(const Node& node, string& name)
   return (temp_trigger);
 }
 
-shared_ptr< TransformInterface > parseTransformInterface(const Node& node, std::string& name, std::string& frame,
-                                                         Pose6d& pose)
+shared_ptr<TransformInterface> parseTransformInterface(const Node& node, std::string& name, std::string& frame,
+                                                       Pose6d& pose)
 {
-  shared_ptr< TransformInterface > temp_ti;
+  shared_ptr<TransformInterface> temp_ti;
   std::string camera_housing_frame;
   std::string camera_mounting_frame;
   if (name == std::string("ros_lti"))
   {  // this option makes no sense for a camera
-    temp_ti = boost::make_shared< ROSListenerTransInterface >(frame);
+    temp_ti = boost::make_shared<ROSListenerTransInterface>(frame);
   }
   else if (name == std::string("ros_bti"))
   {  // this option makes no sense for a camera
-    temp_ti = boost::make_shared< ROSBroadcastTransInterface >(frame);
+    temp_ti = boost::make_shared<ROSBroadcastTransInterface>(frame);
   }
   else if (name == std::string("ros_camera_lti"))
   {
-    temp_ti = boost::make_shared< ROSCameraListenerTransInterface >(frame);
+    temp_ti = boost::make_shared<ROSCameraListenerTransInterface>(frame);
   }
   else if (name == std::string("ros_camera_bti"))
   {
-    temp_ti = boost::make_shared< ROSCameraBroadcastTransInterface >(frame);
+    temp_ti = boost::make_shared<ROSCameraBroadcastTransInterface>(frame);
   }
   else if (name == std::string("ros_camera_housing_lti"))
   {
     if (!parseString(node, "camera_housing_frame", camera_housing_frame)) ROS_ERROR("Can't read camera_housing_frame");
-    temp_ti = boost::make_shared< ROSCameraHousingListenerTInterface >(frame, camera_housing_frame);
+    temp_ti = boost::make_shared<ROSCameraHousingListenerTInterface>(frame, camera_housing_frame);
   }
   else if (name == std::string("ros_camera_housing_bti"))
   {
     if (!parseString(node, "camera_housing_frame", camera_housing_frame)) ROS_ERROR("Can't read camera_housing_frame");
     if (!parseString(node, "camera_mounting_frame", camera_mounting_frame))
       ROS_ERROR("Can't read camera_mounting_frame");
-    temp_ti = boost::make_shared< ROSCameraHousingBroadcastTInterface >(frame, camera_housing_frame,
-                                                                        camera_mounting_frame, pose);
+    temp_ti = boost::make_shared<ROSCameraHousingBroadcastTInterface>(frame, camera_housing_frame,
+                                                                      camera_mounting_frame, pose);
   }
   else if (name == std::string("ros_camera_housing_cti"))
   {
     if (!parseString(node, "camera_housing_frame", camera_housing_frame)) ROS_ERROR("Can't read camera_housing_frame");
     if (!parseString(node, "camera_mounting_frame", camera_mounting_frame))
       ROS_ERROR("Can't read camera_mounting_frame");
-    temp_ti = boost::make_shared< ROSCameraHousingCalTInterface >(frame, camera_housing_frame, camera_mounting_frame);
+    temp_ti = boost::make_shared<ROSCameraHousingCalTInterface>(frame, camera_housing_frame, camera_mounting_frame);
   }
   else if (name == std::string("ros_scti"))
   {
     if (!parseString(node, "parent_frame", camera_mounting_frame)) ROS_ERROR("Can't read parent_frame");
-    temp_ti = boost::make_shared< ROSSimpleCalTInterface >(frame, camera_mounting_frame);
+    temp_ti = boost::make_shared<ROSSimpleCalTInterface>(frame, camera_mounting_frame);
   }
   else if (name == std::string("ros_camera_scti"))
   {
     if (!parseString(node, "parent_frame", camera_mounting_frame)) ROS_ERROR("Can't read parent_frame");
-    temp_ti = boost::make_shared< ROSSimpleCameraCalTInterface >(frame, camera_mounting_frame);
+    temp_ti = boost::make_shared<ROSSimpleCameraCalTInterface>(frame, camera_mounting_frame);
   }
   else if (name == std::string("default_ti"))
   {
-    temp_ti = boost::make_shared< DefaultTransformInterface >();
+    temp_ti = boost::make_shared<DefaultTransformInterface>();
   }
   else
   {
     ROS_ERROR("Unimplemented Transform Interface: %s", name.c_str());
-    temp_ti = boost::make_shared< DefaultTransformInterface >();
+    temp_ti = boost::make_shared<DefaultTransformInterface>();
   }
   return (temp_ti);
 }
@@ -289,7 +289,7 @@ shared_ptr< TransformInterface > parseTransformInterface(const Node& node, std::
 bool parsePose(const Node& node, Pose6d& pose)
 {
   bool rtn = true;
-  std::vector< double > temp_values;
+  std::vector<double> temp_values;
   if (parseVectorD(node, "xyz_quat_pose", temp_values))
   {
     if (temp_values.size() == 7)

--- a/industrial_extrinsic_cal/src/camera_yaml_parser_indigo.cpp
+++ b/industrial_extrinsic_cal/src/camera_yaml_parser_indigo.cpp
@@ -22,7 +22,7 @@ using YAML::Node;
 
 namespace industrial_extrinsic_cal
 {
-void parseCameras(ifstream& cameras_input_file, vector< shared_ptr< Camera > >& cameras)
+void parseCameras(ifstream& cameras_input_file, vector<shared_ptr<Camera> >& cameras)
 {
   Node camera_doc = YAML::LoadFile(cameras_input_file.c_str());
 
@@ -32,7 +32,7 @@ void parseCameras(ifstream& cameras_input_file, vector< shared_ptr< Camera > >& 
   ROS_INFO_STREAM("Found " << camera_parameters.size() << " static cameras ");
   for (unsigned int i = 0; i < camera_parameters.size(); i++)
   {
-    shared_ptr< Camera > temp_camera = parseSingleCamera(camera_parameters[i]);
+    shared_ptr<Camera> temp_camera = parseSingleCamera(camera_parameters[i]);
     cameras.push_back(temp_camera);
   }  // end if there are any cameras in file
 
@@ -41,52 +41,52 @@ void parseCameras(ifstream& cameras_input_file, vector< shared_ptr< Camera > >& 
   ROS_INFO_STREAM("Found " << camera_parameters.size() << " moving cameras ");
   for (unsigned int i = 0; i < camera_parameters.size(); i++)
   {
-    shared_ptr< Camera > temp_camera = parseSingleCamera(camera_parameters[i]);
+    shared_ptr<Camera> temp_camera = parseSingleCamera(camera_parameters[i]);
     temp_camera->is_moving_ = true;
     cameras.push_back(temp_camera);
   }
   ROS_INFO_STREAM("Successfully read in " << (int)cameras.size() << " cameras");
 }
 
-shared_ptr< Camera > parseSingleCamera(const Node& node)
+shared_ptr<Camera> parseSingleCamera(const Node& node)
 {
-  shared_ptr< Camera > temp_camera;
+  shared_ptr<Camera> temp_camera;
   try
   {
     string temp_name, temp_topic, camera_optical_frame, camera_housing_frame, camera_mounting_frame, parent_frame;
     string trigger_name, transform_interface;
     CameraParameters temp_parameters;
-    temp_name = node["camera_name"].as< std::string >();
-    trigger_name = node["trigger"].as< std::string >();
-    temp_topic = node["image_topic"].as< std::string >();
-    camera_optical_frame = node["camera_optical_frame"].as< std::string >();
-    transform_interface = node["transform_interface"].as< std::string() >();
-    temp_parameters.angle_axis[0] = node["angle_axis_ax"].as< double >();
-    temp_parameters.angle_axis[1] = node["angle_axis_ay"].as< double >();
-    temp_parameters.angle_axis[2] = node["angle_axis_az"].as< double >();
-    temp_parameters.position[0] = node["position_x"].as< double >();
-    temp_parameters.position[1] = node["position_y"].as< double >();
-    temp_parameters.position[2] = node["position_z"].as< double >();
-    temp_parameters.focal_length_x = node["focal_length_x"].as< double >();
-    temp_parameters.focal_length_y = node["focal_length_y"].as< double >();
-    temp_parameters.center_x = node["center_x"].as< double >();
-    temp_parameters.center_y = node["center_y"].as< double >();
-    temp_parameters.distortion_k1 = node["distortion_k1"].as< double >();
-    temp_parameters.distortion_k2 = node["distortion_k2"].as< double >();
-    temp_parameters.distortion_k3 = node["distortion_k3"].as< double >();
-    temp_parameters.distortion_p1 = node["distortion_p1"].as< double >();
-    temp_parameters.distortion_p2 = node["distortion_p2"].as< double >();
-    temp_parameters.height = node["image_height"].as< double >();
-    temp_parameters.width = node["image_width"].as< double >();
+    temp_name = node["camera_name"].as<std::string>();
+    trigger_name = node["trigger"].as<std::string>();
+    temp_topic = node["image_topic"].as<std::string>();
+    camera_optical_frame = node["camera_optical_frame"].as<std::string>();
+    transform_interface = node["transform_interface"].as<std::string()>();
+    temp_parameters.angle_axis[0] = node["angle_axis_ax"].as<double>();
+    temp_parameters.angle_axis[1] = node["angle_axis_ay"].as<double>();
+    temp_parameters.angle_axis[2] = node["angle_axis_az"].as<double>();
+    temp_parameters.position[0] = node["position_x"].as<double>();
+    temp_parameters.position[1] = node["position_y"].as<double>();
+    temp_parameters.position[2] = node["position_z"].as<double>();
+    temp_parameters.focal_length_x = node["focal_length_x"].as<double>();
+    temp_parameters.focal_length_y = node["focal_length_y"].as<double>();
+    temp_parameters.center_x = node["center_x"].as<double>();
+    temp_parameters.center_y = node["center_y"].as<double>();
+    temp_parameters.distortion_k1 = node["distortion_k1"].as<double>();
+    temp_parameters.distortion_k2 = node["distortion_k2"].as<double>();
+    temp_parameters.distortion_k3 = node["distortion_k3"].as<double>();
+    temp_parameters.distortion_p1 = node["distortion_p1"].as<double>();
+    temp_parameters.distortion_p2 = node["distortion_p2"].as<double>();
+    temp_parameters.height = node["image_height"].as<double>();
+    temp_parameters.width = node["image_width"].as<double>();
     Pose6d pose(temp_parameters.position[0], temp_parameters.position[1], temp_parameters.position[2],
                 temp_parameters.angle_axis[0], temp_parameters.angle_axis[1], temp_parameters.angle_axis[2]);
 
     // create a shared camera and a shared transform interface
-    temp_camera = make_shared< Camera >(temp_name, temp_parameters, false);
+    temp_camera = make_shared<Camera>(temp_name, temp_parameters, false);
     temp_camera->trigger_ = parseTrigger(node, trigger_name);
-    shared_ptr< TransformInterface > temp_ti = parseTransformInterface(node, transform_interface, camera_optical_frame);
+    shared_ptr<TransformInterface> temp_ti = parseTransformInterface(node, transform_interface, camera_optical_frame);
     temp_camera->setTransformInterface(temp_ti);  // install the transform interface
-    temp_camera->camera_observer_ = make_shared< ROSCameraObserver >(temp_topic);
+    temp_camera->camera_observer_ = make_shared<ROSCameraObserver>(temp_topic);
   }
   catch (YAML::ParserException& e)
   {
@@ -106,44 +106,44 @@ shared_ptr< Camera > parseSingleCamera(const Node& node)
   return (temp_camera);
 }
 
-shared_ptr< Trigger > parseTrigger(const Node& node, string& name)
+shared_ptr<Trigger> parseTrigger(const Node& node, string& name)
 {
-  shared_ptr< Trigger > temp_trigger;
+  shared_ptr<Trigger> temp_trigger;
   std::string trig_param;
   std::string trig_action_server;
   std::string trig_action_msg;
   // handle all the different trigger cases
   if (name == string("NO_WAIT_TRIGGER"))
   {
-    temp_trigger = make_shared< NoWaitTrigger >();
+    temp_trigger = make_shared<NoWaitTrigger>();
   }
   else if (name == string("ROS_PARAM_TRIGGER"))
   {
-    trig_param = node["trig_param"].at< std::string >();
-    temp_trigger = make_shared< ROSParamTrigger >(trig_param);
+    trig_param = node["trig_param"].at<std::string>();
+    temp_trigger = make_shared<ROSParamTrigger>(trig_param);
   }
   else if (name == string("ROS_ACTION_TRIGGER"))
   {
-    trig_action_server = node["trig_action_server"].at< std::string >();
-    trig_action_msg = node["trig_action_msg"].at< std::string >();
-    temp_trigger = make_shared< ROSActionServerTrigger >(trig_action_server, trig_action_msg);
+    trig_action_server = node["trig_action_server"].at<std::string>();
+    trig_action_msg = node["trig_action_msg"].at<std::string>();
+    temp_trigger = make_shared<ROSActionServerTrigger>(trig_action_server, trig_action_msg);
   }
   else if (name == string("ROS_ROBOT_JOINT_VALUES_ACTION_TRIGGER"))
   {
-    trig_action_server = node["trig_action_server"].at< std::string >();
-    std::vector< double > joint_values;
-    joint_values = node["joint_values"].at< double >();
+    trig_action_server = node["trig_action_server"].at<std::string>();
+    std::vector<double> joint_values;
+    joint_values = node["joint_values"].at<double>();
     if (joint_values.size() < 0)
     {
       ROS_ERROR("Couldn't read joint_values for ROS_ROBOT_JOINT_VALUES_ACTION_TRIGGER");
     }
-    temp_trigger = make_shared< ROSRobotJointValuesActionServerTrigger >(trig_action_server, joint_values);
+    temp_trigger = make_shared<ROSRobotJointValuesActionServerTrigger>(trig_action_server, joint_values);
   }
   else if (name == string("ROS_ROBOT_POSE_ACTION_TRIGGER"))
   {
-    trig_action_server = node["trig_action_server"].at< std::string >();
+    trig_action_server = node["trig_action_server"].at<std::string>();
     Pose6d pose = parsePose(node);
-    temp_trigger = make_shared< ROSRobotPoseActionServerTrigger >(trig_action_server, pose);
+    temp_trigger = make_shared<ROSRobotPoseActionServerTrigger>(trig_action_server, pose);
   }
   else
   {
@@ -152,71 +152,71 @@ shared_ptr< Trigger > parseTrigger(const Node& node, string& name)
   return (temp_trigger);
 }
 
-shared_ptr< TransformInterface > parseTransformInterface(const Node& node, std::string& name, std::string& frame)
+shared_ptr<TransformInterface> parseTransformInterface(const Node& node, std::string& name, std::string& frame)
 {
-  shared_ptr< TransformInterface > temp_ti;
+  shared_ptr<TransformInterface> temp_ti;
   std::string camera_housing_frame;
   std::string camera_mounting_frame;
   if (name == std::string("ros_lti"))
   {  // this option makes no sense for a camera
-    temp_ti = make_shared< ROSListenerTransInterface >(frame);
+    temp_ti = make_shared<ROSListenerTransInterface>(frame);
   }
   else if (name == std::string("ros_bti"))
   {  // this option makes no sense for a camera
     Pose6d pose = parsePose(node);
-    temp_ti = make_shared< ROSBroadcastTransInterface >(frame, pose);
+    temp_ti = make_shared<ROSBroadcastTransInterface>(frame, pose);
   }
   else if (name == std::string("ros_camera_lti"))
   {
-    temp_ti = make_shared< ROSCameraListenerTransInterface >(frame);
+    temp_ti = make_shared<ROSCameraListenerTransInterface>(frame);
   }
   else if (name == std::string("ros_camera_bti"))
   {
     Pose6d pose = parsePose(node);
-    temp_ti = make_shared< ROSCameraBroadcastTransInterface >(frame, pose);
+    temp_ti = make_shared<ROSCameraBroadcastTransInterface>(frame, pose);
   }
   else if (name == std::string("ros_camera_housing_lti"))
   {
-    camera_housing_frame = node["camera_housing_frame"].at< std::string >();
-    temp_ti = make_shared< ROSCameraHousingListenerTInterface >(frame, camera_housing_frame);
+    camera_housing_frame = node["camera_housing_frame"].at<std::string>();
+    temp_ti = make_shared<ROSCameraHousingListenerTInterface>(frame, camera_housing_frame);
   }
   else if (name == std::string("ros_camera_housing_bti"))
   {
     Pose6d pose = parsePose(node);
     camera_housing_frame;
-    = node["camera_housing_frame"].at< std::string >();
-    temp_ti = make_shared< ROSCameraHousingBroadcastTInterface >(frame, pose);
+    = node["camera_housing_frame"].at<std::string>();
+    temp_ti = make_shared<ROSCameraHousingBroadcastTInterface>(frame, pose);
   }
   else if (name == std::string("ros_camera_housing_cti"))
   {
     camera_housing_frame;
-    = node["camera_housing_frame"].at< std::string >();
+    = node["camera_housing_frame"].at<std::string>();
     camera_mounting_frame;
-    = node["camera_mounting_frame"].at< std::string >();
-    temp_ti = make_shared< ROSCameraHousingCalTInterface >(frame, camera_housing_frame, camera_mounting_frame);
+    = node["camera_mounting_frame"].at<std::string>();
+    temp_ti = make_shared<ROSCameraHousingCalTInterface>(frame, camera_housing_frame, camera_mounting_frame);
   }
   else if (name == std::string("ros_scti"))
   {
     camera_mounting_frame;
-    = node["parent_frame"].at< std::string >();
-    temp_ti = make_shared< ROSSimpleCalTInterface >(frame, camera_mounting_frame);
+    = node["parent_frame"].at<std::string>();
+    temp_ti = make_shared<ROSSimpleCalTInterface>(frame, camera_mounting_frame);
   }
   else if (name == std::string("ros_camera_scti"))
   {
     camera_mounting_frame;
-    = node["parent_frame"].at< std::string >();
-    temp_ti = make_shared< ROSSimpleCameraCalTInterface >(frame, camera_mounting_frame);
+    = node["parent_frame"].at<std::string>();
+    temp_ti = make_shared<ROSSimpleCameraCalTInterface>(frame, camera_mounting_frame);
   }
   else if (name == std::string("default_ti"))
   {
     Pose6d pose = parsePose(node);
-    temp_ti = make_shared< DefaultTransformInterface >(pose);
+    temp_ti = make_shared<DefaultTransformInterface>(pose);
   }
   else
   {
     Pose6d pose;
     ROS_ERROR("Unimplemented Transform Interface: %s", name.c_str());
-    temp_ti = make_shared< DefaultTransformInterface >(pose);
+    temp_ti = make_shared<DefaultTransformInterface>(pose);
   }
   return (temp_ti);
 }
@@ -224,14 +224,14 @@ shared_ptr< TransformInterface > parseTransformInterface(const Node& node, std::
 Pose6d parsePose(const Node& node)
 {
   Pose6d pose;
-  pose.x = ode["pose"][0].at< double >();
-  pose.y = ode["pose"][1].at< double >();
-  pose.z = ode["pose"][2].at< double >();
+  pose.x = ode["pose"][0].at<double>();
+  pose.y = ode["pose"][1].at<double>();
+  pose.z = ode["pose"][2].at<double>();
   double qx, qy, qz, qw;
-  qx = ode["pose"][3].at< double >();
-  qy = ode["pose"][4].at< double >();
-  qz = ode["pose"][5].at< double >();
-  qw = ode["pose"][6].at< double >();
+  qx = ode["pose"][3].at<double>();
+  qy = ode["pose"][4].at<double>();
+  qz = ode["pose"][5].at<double>();
+  qw = ode["pose"][6].at<double>();
   pose.setQuaternion(qx, qy, qz, qw);
   return (pose);
 }

--- a/industrial_extrinsic_cal/src/ceres_blocks.cpp
+++ b/industrial_extrinsic_cal/src/ceres_blocks.cpp
@@ -101,7 +101,7 @@ void CeresBlocks::clearCamerasTargets()
 P_BLOCK CeresBlocks::getStaticCameraParameterBlockIntrinsics(string camera_name)
 {
   // static cameras should have unique name
-  BOOST_FOREACH (shared_ptr< Camera > camera, static_cameras_)
+  BOOST_FOREACH (shared_ptr<Camera> camera, static_cameras_)
   {
     if (camera_name == camera->camera_name_)
     {
@@ -116,7 +116,7 @@ P_BLOCK CeresBlocks::getMovingCameraParameterBlockIntrinsics(string camera_name)
   // we use the intrinsic parameters from the first time the camera appears in the list
   // subsequent cameras with this name also have intrinsic parameters, but these are
   // never used as parameter blocks, only their extrinsics are used
-  BOOST_FOREACH (shared_ptr< MovingCamera > moving_camera, moving_cameras_)
+  BOOST_FOREACH (shared_ptr<MovingCamera> moving_camera, moving_cameras_)
   {
     if (camera_name == moving_camera->cam->camera_name_)
     {
@@ -129,7 +129,7 @@ P_BLOCK CeresBlocks::getMovingCameraParameterBlockIntrinsics(string camera_name)
 P_BLOCK CeresBlocks::getStaticCameraParameterBlockExtrinsics(string camera_name)
 {
   // static cameras should have unique name
-  BOOST_FOREACH (shared_ptr< Camera > camera, static_cameras_)
+  BOOST_FOREACH (shared_ptr<Camera> camera, static_cameras_)
   {
     if (camera_name == camera->camera_name_)
     {
@@ -142,7 +142,7 @@ P_BLOCK CeresBlocks::getStaticCameraParameterBlockExtrinsics(string camera_name)
 }
 P_BLOCK CeresBlocks::getMovingCameraParameterBlockExtrinsics(string camera_name, int scene_id)
 {
-  BOOST_FOREACH (shared_ptr< MovingCamera > camera, moving_cameras_)
+  BOOST_FOREACH (shared_ptr<MovingCamera> camera, moving_cameras_)
   {
     if (camera_name == camera->cam->camera_name_ && scene_id == camera->scene_id)
     {
@@ -154,7 +154,7 @@ P_BLOCK CeresBlocks::getMovingCameraParameterBlockExtrinsics(string camera_name,
 }
 P_BLOCK CeresBlocks::getStaticTargetPoseParameterBlock(string target_name)
 {
-  BOOST_FOREACH (shared_ptr< Target > target, static_targets_)
+  BOOST_FOREACH (shared_ptr<Target> target, static_targets_)
   {
     if (target_name == target->target_name_)
     {
@@ -166,7 +166,7 @@ P_BLOCK CeresBlocks::getStaticTargetPoseParameterBlock(string target_name)
 }
 P_BLOCK CeresBlocks::getStaticTargetPointParameterBlock(string target_name, int point_id)
 {
-  BOOST_FOREACH (shared_ptr< Target > target, static_targets_)
+  BOOST_FOREACH (shared_ptr<Target> target, static_targets_)
   {
     if (target_name == target->target_name_)
     {
@@ -178,7 +178,7 @@ P_BLOCK CeresBlocks::getStaticTargetPointParameterBlock(string target_name, int 
 }
 P_BLOCK CeresBlocks::getMovingTargetPoseParameterBlock(string target_name, int scene_id)
 {
-  BOOST_FOREACH (shared_ptr< MovingTarget > moving_target, moving_targets_)
+  BOOST_FOREACH (shared_ptr<MovingTarget> moving_target, moving_targets_)
   {
     if (target_name == moving_target->targ_->target_name_ && scene_id == moving_target->scene_id_)
     {
@@ -192,7 +192,7 @@ P_BLOCK CeresBlocks::getMovingTargetPointParameterBlock(string target_name, int 
 {
   // note scene_id unnecessary here since regarless of scene th point's location relative to
   // the target frame does not change
-  BOOST_FOREACH (shared_ptr< MovingTarget > moving_target, moving_targets_)
+  BOOST_FOREACH (shared_ptr<MovingTarget> moving_target, moving_targets_)
   {
     if (target_name == moving_target->targ_->target_name_)
     {
@@ -203,9 +203,9 @@ P_BLOCK CeresBlocks::getMovingTargetPointParameterBlock(string target_name, int 
   return (NULL);
 }
 
-bool CeresBlocks::addStaticCamera(shared_ptr< Camera > camera_to_add)
+bool CeresBlocks::addStaticCamera(shared_ptr<Camera> camera_to_add)
 {
-  BOOST_FOREACH (shared_ptr< Camera > cam, static_cameras_)
+  BOOST_FOREACH (shared_ptr<Camera> cam, static_cameras_)
   {
     if (cam->camera_name_ == camera_to_add->camera_name_) return (false);  // camera already exists
   }
@@ -218,9 +218,9 @@ bool CeresBlocks::addStaticCamera(shared_ptr< Camera > camera_to_add)
   // ROS_INFO_STREAM("Camera added to static_cameras_");
   return (true);
 }
-bool CeresBlocks::addStaticTarget(shared_ptr< Target > target_to_add)
+bool CeresBlocks::addStaticTarget(shared_ptr<Target> target_to_add)
 {
-  BOOST_FOREACH (shared_ptr< Target > targ, static_targets_)
+  BOOST_FOREACH (shared_ptr<Target> targ, static_targets_)
   {
     if (targ->target_name_ == target_to_add->target_name_)
     {
@@ -236,20 +236,20 @@ bool CeresBlocks::addStaticTarget(shared_ptr< Target > target_to_add)
 
   return (true);
 }
-bool CeresBlocks::addMovingCamera(shared_ptr< Camera > camera_to_add, int scene_id)
+bool CeresBlocks::addMovingCamera(shared_ptr<Camera> camera_to_add, int scene_id)
 {
-  BOOST_FOREACH (shared_ptr< MovingCamera > cam, moving_cameras_)
+  BOOST_FOREACH (shared_ptr<MovingCamera> cam, moving_cameras_)
   {
     if (cam->cam->camera_name_ == camera_to_add->camera_name_ && cam->scene_id == scene_id)
       return (false);  // camera already exists
   }
 
   // this next line allocates the memory for a moving camera
-  shared_ptr< MovingCamera > temp_moving_camera = boost::make_shared< MovingCamera >();
+  shared_ptr<MovingCamera> temp_moving_camera = boost::make_shared<MovingCamera>();
 
   // this next line allocates the memory for the actual camera
-  shared_ptr< Camera > temp_camera =
-      boost::make_shared< Camera >(camera_to_add->camera_name_, camera_to_add->camera_parameters_, true);
+  shared_ptr<Camera> temp_camera =
+      boost::make_shared<Camera>(camera_to_add->camera_name_, camera_to_add->camera_parameters_, true);
 
   // set things not done by constructor using values from camera_to_add
   temp_camera->setTransformInterface(camera_to_add->getTransformInterface());
@@ -262,9 +262,9 @@ bool CeresBlocks::addMovingCamera(shared_ptr< Camera > camera_to_add, int scene_
   moving_cameras_.push_back(temp_moving_camera);
   return (true);
 }
-bool CeresBlocks::addMovingTarget(shared_ptr< Target > target_to_add, int scene_id)
+bool CeresBlocks::addMovingTarget(shared_ptr<Target> target_to_add, int scene_id)
 {
-  BOOST_FOREACH (shared_ptr< MovingTarget > targ, moving_targets_)
+  BOOST_FOREACH (shared_ptr<MovingTarget> targ, moving_targets_)
   {
     if (targ->targ_->target_name_ == target_to_add->target_name_ && targ->scene_id_ == scene_id)
     {
@@ -275,8 +275,8 @@ bool CeresBlocks::addMovingTarget(shared_ptr< Target > target_to_add, int scene_
 
   // deep copy of target into moving target TODO test to see if using * or contents of notation can avoid all this
   // direct copy
-  shared_ptr< MovingTarget > temp_moving_target = boost::make_shared< MovingTarget >();
-  temp_moving_target->targ_ = boost::make_shared< Target >();
+  shared_ptr<MovingTarget> temp_moving_target = boost::make_shared<MovingTarget>();
+  temp_moving_target->targ_ = boost::make_shared<Target>();
   temp_moving_target->targ_->pose_ = target_to_add->pose_;
   temp_moving_target->targ_->num_points_ = target_to_add->num_points_;
   temp_moving_target->targ_->pts_ = target_to_add->pts_;
@@ -298,7 +298,7 @@ bool CeresBlocks::addMovingTarget(shared_ptr< Target > target_to_add, int scene_
     temp_moving_target->targ_->ar_target_parameters_ = target_to_add->ar_target_parameters_;
   }
   temp_moving_target->targ_->setTransformInterface(target_to_add->getTransformInterface());
-  boost::shared_ptr< TransformInterface > the_interface = target_to_add->getTransformInterface();
+  boost::shared_ptr<TransformInterface> the_interface = target_to_add->getTransformInterface();
   if (the_interface->isRefFrameInitialized())
   {
     std::string ref_frame;
@@ -310,9 +310,9 @@ bool CeresBlocks::addMovingTarget(shared_ptr< Target > target_to_add, int scene_
   return (true);
 }
 
-const boost::shared_ptr< Camera > CeresBlocks::getCameraByName(const std::string& camera_name)
+const boost::shared_ptr<Camera> CeresBlocks::getCameraByName(const std::string& camera_name)
 {
-  boost::shared_ptr< Camera > cam = boost::make_shared< Camera >();
+  boost::shared_ptr<Camera> cam = boost::make_shared<Camera>();
   // ROS_INFO_STREAM("Found "<<static_cameras_.size() <<" static cameras");
   for (int i = 0; i < static_cameras_.size(); i++)
   {
@@ -339,12 +339,12 @@ const boost::shared_ptr< Camera > CeresBlocks::getCameraByName(const std::string
   // return true;
 }
 
-const boost::shared_ptr< Target > CeresBlocks::getTargetByName(const std::string& target_name, int scene_id)
+const boost::shared_ptr<Target> CeresBlocks::getTargetByName(const std::string& target_name, int scene_id)
 {
-  boost::shared_ptr< Target > target = boost::make_shared< Target >();
+  boost::shared_ptr<Target> target = boost::make_shared<Target>();
   bool found = false;
   // ROS_INFO_STREAM("Found "<<static_cameras_.size() <<" static cameras");
-  BOOST_FOREACH (shared_ptr< Target > targ, static_targets_)
+  BOOST_FOREACH (shared_ptr<Target> targ, static_targets_)
   {
     if (targ->target_name_ == target_name)
     {
@@ -354,7 +354,7 @@ const boost::shared_ptr< Target > CeresBlocks::getTargetByName(const std::string
     }
   }
   // ROS_INFO_STREAM("Found "<<moving_cameras_.size() <<" static cameras");
-  BOOST_FOREACH (shared_ptr< MovingTarget > mtarg, moving_targets_)
+  BOOST_FOREACH (shared_ptr<MovingTarget> mtarg, moving_targets_)
   {
     if (mtarg->targ_->target_name_ == target_name && mtarg->scene_id_ == scene_id)
     {
@@ -373,7 +373,7 @@ const boost::shared_ptr< Target > CeresBlocks::getTargetByName(const std::string
 void CeresBlocks::displayStaticCameras()
 {
   if (static_cameras_.size() != 0) ROS_INFO("Static Cameras");
-  BOOST_FOREACH (shared_ptr< Camera > cam, static_cameras_)
+  BOOST_FOREACH (shared_ptr<Camera> cam, static_cameras_)
   {
     Pose6d pose(cam->camera_parameters_.position[0], cam->camera_parameters_.position[1],
                 cam->camera_parameters_.position[2], cam->camera_parameters_.angle_axis[0],
@@ -392,7 +392,7 @@ void CeresBlocks::displayMovingCameras()
   double quat[4];
 
   if (moving_cameras_.size() != 0) ROS_INFO("Moving Cameras");
-  BOOST_FOREACH (shared_ptr< MovingCamera > mcam, moving_cameras_)
+  BOOST_FOREACH (shared_ptr<MovingCamera> mcam, moving_cameras_)
   {
     if (mcam->scene_id == 0)
     {
@@ -411,7 +411,7 @@ void CeresBlocks::displayStaticTargets()
   double R[9];
 
   if (static_targets_.size() != 0) ROS_INFO("Static Targets:");
-  BOOST_FOREACH (shared_ptr< Target > targ, static_targets_)
+  BOOST_FOREACH (shared_ptr<Target> targ, static_targets_)
   {
     showPose(targ->pose_, targ->target_name_);
   }
@@ -421,7 +421,7 @@ void CeresBlocks::displayMovingTargets()
   double R[9];
 
   if (moving_targets_.size() != 0) ROS_INFO("Moving Targets:");
-  BOOST_FOREACH (shared_ptr< MovingTarget > mtarg, moving_targets_)
+  BOOST_FOREACH (shared_ptr<MovingTarget> mtarg, moving_targets_)
   {
     if (mtarg->scene_id_ == 0)
     {  // only show first pose, not all
@@ -452,19 +452,19 @@ bool CeresBlocks::writeAllStaticTransforms(string filePath)
   outputFile.close();
 
   bool rtn = true;
-  BOOST_FOREACH (shared_ptr< Camera > cam, static_cameras_)
+  BOOST_FOREACH (shared_ptr<Camera> cam, static_cameras_)
   {
     rtn = cam->transform_interface_->store(filePath);
   }
-  BOOST_FOREACH (shared_ptr< MovingCamera > mcam, moving_cameras_)
+  BOOST_FOREACH (shared_ptr<MovingCamera> mcam, moving_cameras_)
   {
     rtn = mcam->cam->transform_interface_->store(filePath);
   }
-  BOOST_FOREACH (shared_ptr< Target > targ, static_targets_)
+  BOOST_FOREACH (shared_ptr<Target> targ, static_targets_)
   {
     rtn = targ->transform_interface_->store(filePath);
   }
-  BOOST_FOREACH (shared_ptr< MovingTarget > mtarg, moving_targets_)
+  BOOST_FOREACH (shared_ptr<MovingTarget> mtarg, moving_targets_)
   {
     rtn = mtarg->targ_->transform_interface_->store(filePath);
   }
@@ -489,11 +489,11 @@ bool CeresBlocks::writeAllStaticTransforms(string filePath)
 
 void CeresBlocks::pushTransforms()
 {
-  BOOST_FOREACH (shared_ptr< Camera > cam, static_cameras_)
+  BOOST_FOREACH (shared_ptr<Camera> cam, static_cameras_)
   {
     cam->pushTransform();
   }
-  BOOST_FOREACH (shared_ptr< MovingCamera > mcam, moving_cameras_)
+  BOOST_FOREACH (shared_ptr<MovingCamera> mcam, moving_cameras_)
   {
     if (mcam->scene_id == 0)
     {  // only push a moving camera's transform once, which is always scene 0
@@ -505,11 +505,11 @@ void CeresBlocks::pushTransforms()
       mcam->cam->pushTransform();
     }
   }
-  BOOST_FOREACH (shared_ptr< Target > targ, static_targets_)
+  BOOST_FOREACH (shared_ptr<Target> targ, static_targets_)
   {
     targ->pushTransform();
   }
-  BOOST_FOREACH (shared_ptr< MovingTarget > mtarg, moving_targets_)
+  BOOST_FOREACH (shared_ptr<MovingTarget> mtarg, moving_targets_)
   {
     if (mtarg->scene_id_ == 0)
     {  // only push a moving target once which is for the scene 0
@@ -519,22 +519,22 @@ void CeresBlocks::pushTransforms()
 }
 void CeresBlocks::pullTransforms(int scene_id)
 {
-  BOOST_FOREACH (shared_ptr< Camera > cam, static_cameras_)
+  BOOST_FOREACH (shared_ptr<Camera> cam, static_cameras_)
   {
     cam->pullTransform();
   }
-  BOOST_FOREACH (shared_ptr< MovingCamera > mcam, moving_cameras_)
+  BOOST_FOREACH (shared_ptr<MovingCamera> mcam, moving_cameras_)
   {
     if (mcam->scene_id == scene_id)
     {  // only pull transforms for cameras in current scene
       mcam->cam->pullTransform();
     }
   }
-  BOOST_FOREACH (shared_ptr< Target > targ, static_targets_)
+  BOOST_FOREACH (shared_ptr<Target> targ, static_targets_)
   {
     targ->pullTransform();
   }
-  BOOST_FOREACH (shared_ptr< MovingTarget > mtarg, moving_targets_)
+  BOOST_FOREACH (shared_ptr<MovingTarget> mtarg, moving_targets_)
   {
     if (mtarg->scene_id_ == scene_id)
     {  // only pull transforms for targets in current scene
@@ -545,19 +545,19 @@ void CeresBlocks::pullTransforms(int scene_id)
 void CeresBlocks::setReferenceFrame(std::string ref_frame)
 {
   reference_frame_ = ref_frame;
-  BOOST_FOREACH (shared_ptr< Camera > cam, static_cameras_)
+  BOOST_FOREACH (shared_ptr<Camera> cam, static_cameras_)
   {
     cam->setTIReferenceFrame(ref_frame);
   }
-  BOOST_FOREACH (shared_ptr< MovingCamera > mcam, moving_cameras_)
+  BOOST_FOREACH (shared_ptr<MovingCamera> mcam, moving_cameras_)
   {
     mcam->cam->setTIReferenceFrame(ref_frame);
   }
-  BOOST_FOREACH (shared_ptr< Target > targ, static_targets_)
+  BOOST_FOREACH (shared_ptr<Target> targ, static_targets_)
   {
     targ->setTIReferenceFrame(ref_frame);
   }
-  BOOST_FOREACH (shared_ptr< MovingTarget > mtarg, moving_targets_)
+  BOOST_FOREACH (shared_ptr<MovingTarget> mtarg, moving_targets_)
   {
     mtarg->targ_->setTIReferenceFrame(ref_frame);
   }

--- a/industrial_extrinsic_cal/src/ceres_cost_utils_test.cpp
+++ b/industrial_extrinsic_cal/src/ceres_cost_utils_test.cpp
@@ -72,7 +72,7 @@ struct CameraReprjErrorWithDistortion
   {
   }
 
-  template < typename T >
+  template <typename T>
   bool operator()(const T* const c_p1, /** extrinsic parameters */
                   const T* c_p2,       /** intrinsic parameters */
                   const T* point,      /** point being projected, yes this is has 3 parameters */
@@ -136,7 +136,7 @@ struct CameraReprjErrorWithDistortion
   /** the client code. */
   static ceres::CostFunction* Create(const double o_x, const double o_y)
   {
-    return (new ceres::AutoDiffCostFunction< CameraReprjErrorWithDistortion, 2, 6, 9, 3 >(
+    return (new ceres::AutoDiffCostFunction<CameraReprjErrorWithDistortion, 2, 6, 9, 3>(
         new CameraReprjErrorWithDistortion(o_x, o_y)));
   }
   double ox_; /** observed x location of object in image */
@@ -149,7 +149,7 @@ struct CameraReprjErrorNoDistortion
   {
   }
 
-  template < typename T >
+  template <typename T>
   bool operator()(const T* const c_p1, /** extrinsic parameters */
                   const T* c_p2,       /** intrinsic parameters */
                   const T* point,      /** point being projected, yes this is has 3 parameters */
@@ -198,7 +198,7 @@ struct CameraReprjErrorNoDistortion
   /** the client code. */
   static ceres::CostFunction* Create(const double o_x, const double o_y)
   {
-    return (new ceres::AutoDiffCostFunction< CameraReprjErrorNoDistortion, 2, 6, 4, 3 >(
+    return (new ceres::AutoDiffCostFunction<CameraReprjErrorNoDistortion, 2, 6, 4, 3>(
         new CameraReprjErrorNoDistortion(o_x, o_y)));
   }
   double ox_; /** observed x location of object in image */
@@ -215,7 +215,7 @@ struct TargetCameraReprjErrorNoDistortion
   {
   }
 
-  template < typename T >
+  template <typename T>
   bool operator()(const T* const c_p1,  /** extrinsic parameters */
                   const T* const c_p2,  /** intrinsic parameters */
                   const T* const c_p3,  /** 6Dof transform of target points into world frame */
@@ -287,7 +287,7 @@ struct TargetCameraReprjErrorNoDistortion
   /** the client code. */
   static ceres::CostFunction* Create(const double o_x, const double o_y)
   {
-    return (new ceres::AutoDiffCostFunction< TargetCameraReprjErrorNoDistortion, 2, 6, 4, 6, 3 >(
+    return (new ceres::AutoDiffCostFunction<TargetCameraReprjErrorNoDistortion, 2, 6, 4, 6, 3>(
         new CameraReprjError(o_x, o_y)));
   }
   double ox_; /** observed x location of object in image */
@@ -301,7 +301,7 @@ struct TargetCameraReprjErrorProjModelAsClassVars
   {
   }
 
-  template < typename T >
+  template <typename T>
   bool operator()(const T* const c_p1,  /** extrinsic parameters */
                   const T* const c_p2,  /** 6Dof transform of target points into world frame */
                   const T* const point, /** point described in target frame that is being seen */
@@ -373,7 +373,7 @@ struct TargetCameraReprjErrorProjModelAsClassVars
   /** the client code. */
   static ceres::CostFunction* Create(const double o_x, const double o_y, double fx, double fy, double cx, double cy)
   {
-    return (new ceres::AutoDiffCostFunction< TargetCameraReprjErrorProjModelAsClassVars, 2, 6, 6, 3 >(
+    return (new ceres::AutoDiffCostFunction<TargetCameraReprjErrorProjModelAsClassVars, 2, 6, 6, 3>(
         new CameraReprjError(o_x, o_y, fx, fy, cx, cy)));
   }
   double ox_;    /** observed x location of object in image */

--- a/industrial_extrinsic_cal/src/circle_detector.cpp
+++ b/industrial_extrinsic_cal/src/circle_detector.cpp
@@ -94,8 +94,8 @@ protected:
     double confidence;
   };
 
-  virtual void detect(InputArray image, std::vector< KeyPoint >& keypoints, InputArray mask = noArray());
-  virtual void findCircles(InputArray image, InputArray binaryImage, std::vector< Center >& centers) const;
+  virtual void detect(InputArray image, std::vector<KeyPoint>& keypoints, InputArray mask = noArray());
+  virtual void findCircles(InputArray image, InputArray binaryImage, std::vector<Center>& centers) const;
 
   Params params;
 };
@@ -121,15 +121,15 @@ CircleDetector::Params::Params()
 
   filterByCircularity = false;
   minCircularity = 0.8f;
-  maxCircularity = std::numeric_limits< float >::max();
+  maxCircularity = std::numeric_limits<float>::max();
 
   filterByInertia = true;
   minInertiaRatio = 0.1f;
-  maxInertiaRatio = std::numeric_limits< float >::max();
+  maxInertiaRatio = std::numeric_limits<float>::max();
 
   filterByConvexity = true;
   minConvexity = 0.95f;
-  maxConvexity = std::numeric_limits< float >::max();
+  maxConvexity = std::numeric_limits<float>::max();
 }
 
 void CircleDetector::Params::read(const cv::FileNode& fn)
@@ -205,7 +205,7 @@ void CircleDetectorImpl::write(cv::FileStorage& fs) const
   params.write(fs);
 }
 
-void CircleDetectorImpl::findCircles(InputArray _image, InputArray _binaryImage, std::vector< Center >& centers) const
+void CircleDetectorImpl::findCircles(InputArray _image, InputArray _binaryImage, std::vector<Center>& centers) const
 {
   //  CV_INSTRUMENT_REGION()
 
@@ -215,7 +215,7 @@ void CircleDetectorImpl::findCircles(InputArray _image, InputArray _binaryImage,
   (void)image;
   centers.clear();
 
-  vector< vector< Point > > contours;
+  vector<vector<Point> > contours;
   Mat tmpBinaryImage = binaryImage.clone();
   findContours(tmpBinaryImage, contours, CV_RETR_LIST, CV_CHAIN_APPROX_NONE);
 
@@ -269,7 +269,7 @@ void CircleDetectorImpl::findCircles(InputArray _image, InputArray _binaryImage,
 
     if (params.filterByConvexity)
     {
-      vector< Point > hull;
+      vector<Point> hull;
       convexHull(Mat(contours[contourIdx]), hull);
       double area = contourArea(Mat(contours[contourIdx]));
       double hullArea = contourArea(Mat(hull));
@@ -288,8 +288,7 @@ void CircleDetectorImpl::findCircles(InputArray _image, InputArray _binaryImage,
     // one more filter by color of central pixel
     if (params.filterByColor)
     {
-      if (binaryImage.at< uchar >(cvRound(center.location.y), cvRound(center.location.x)) != params.circleColor)
-        continue;
+      if (binaryImage.at<uchar>(cvRound(center.location.y), cvRound(center.location.x)) != params.circleColor) continue;
     }
 
     // compute circle radius
@@ -316,7 +315,7 @@ void CircleDetectorImpl::findCircles(InputArray _image, InputArray _binaryImage,
 #endif
 }
 
-void CircleDetectorImpl::detect(InputArray _image, std::vector< KeyPoint >& keypoints, InputArray mask)
+void CircleDetectorImpl::detect(InputArray _image, std::vector<KeyPoint>& keypoints, InputArray mask)
 {
   Mat image = _image.getMat();
 
@@ -330,7 +329,7 @@ void CircleDetectorImpl::detect(InputArray _image, std::vector< KeyPoint >& keyp
   else
     grayscaleImage = image;
 
-  vector< vector< Center > > centers;
+  vector<vector<Center> > centers;
   for (double thresh = params.minThreshold; thresh < params.maxThreshold; thresh += params.thresholdStep)
   {
     Mat binarizedImage;
@@ -341,9 +340,9 @@ void CircleDetectorImpl::detect(InputArray _image, std::vector< KeyPoint >& keyp
 //    cvtColor( binarizedImage, keypointsImage, CV_GRAY2RGB );
 #endif
 
-    vector< Center > curCenters;
+    vector<Center> curCenters;
     findCircles(grayscaleImage, binarizedImage, curCenters);
-    vector< vector< Center > > newCenters;
+    vector<vector<Center> > newCenters;
     for (size_t i = 0; i < curCenters.size(); i++)
     {
 #ifdef DEBUG_CIRCLE_DETECTOR
@@ -355,7 +354,7 @@ void CircleDetectorImpl::detect(InputArray _image, std::vector< KeyPoint >& keyp
       {
         double dist = norm(centers[j][centers[j].size() / 2].location - curCenters[i].location);
         //				isNew = dist >= params.minDistBetweenCircles && dist >= centers[j][ centers[j].size() / 2 ].radius &&
-        //dist >= curCenters[i].radius;
+        // dist >= curCenters[i].radius;
         double rad_diff = fabs(centers[j][centers[j].size() / 2].radius - curCenters[i].radius);
         isNew = dist >= params.minDistBetweenCircles || rad_diff >= params.minRadiusDiff;
         if (!isNew)
@@ -375,7 +374,7 @@ void CircleDetectorImpl::detect(InputArray _image, std::vector< KeyPoint >& keyp
       }
       if (isNew)
       {
-        newCenters.push_back(vector< Center >(1, curCenters[i]));
+        newCenters.push_back(vector<Center>(1, curCenters[i]));
         // centers.push_back(vector<Center> (1, curCenters[i]));
       }
     }
@@ -415,9 +414,9 @@ void CircleDetectorImpl::detect(InputArray _image, std::vector< KeyPoint >& keyp
 #endif
 }
 
-Ptr< CircleDetector > CircleDetector::create(const CircleDetector::Params& params)
+Ptr<CircleDetector> CircleDetector::create(const CircleDetector::Params& params)
 {
-  return makePtr< CircleDetectorImpl >(params);
+  return makePtr<CircleDetectorImpl>(params);
 }
 
 }  // end  namespace cv

--- a/industrial_extrinsic_cal/src/nodes/calibration_service.cpp
+++ b/industrial_extrinsic_cal/src/nodes/calibration_service.cpp
@@ -29,7 +29,7 @@ using industrial_extrinsic_cal::CovarianceVariableRequest;
 class CalibrationServiceNode
 {
 public:
-  typedef actionlib::SimpleActionServer< industrial_extrinsic_cal::calibrationAction > CalibrationActionServer;
+  typedef actionlib::SimpleActionServer<industrial_extrinsic_cal::calibrationAction> CalibrationActionServer;
 
   explicit CalibrationServiceNode(const ros::NodeHandle& nh)
     : nh_(nh)
@@ -95,7 +95,7 @@ private:
 bool CalibrationServiceNode::covarianceCallback(industrial_extrinsic_cal::covariance::Request& req,
                                                 industrial_extrinsic_cal::covariance::Response& res)
 {
-  std::vector< CovarianceVariableRequest > requests;
+  std::vector<CovarianceVariableRequest> requests;
   CovarianceVariableRequest request1, request2;
 
   request1.request_type = industrial_extrinsic_cal::intToCovRequest(req.request_type1);

--- a/industrial_extrinsic_cal/src/nodes/camera_observer_scene_trigger.cpp
+++ b/industrial_extrinsic_cal/src/nodes/camera_observer_scene_trigger.cpp
@@ -91,8 +91,7 @@ bool CameraObserverTrigger::executeCallBack(industrial_extrinsic_cal::camera_obs
   industrial_extrinsic_cal::ROSCameraObserver camera_observer(req.image_topic);
   camera_observer.clearObservations();
   camera_observer.clearTargets();
-  boost::shared_ptr< industrial_extrinsic_cal::Target > target =
-      boost::make_shared< industrial_extrinsic_cal::Target >();
+  boost::shared_ptr<industrial_extrinsic_cal::Target> target = boost::make_shared<industrial_extrinsic_cal::Target>();
   target->target_name_ = "junk";
   target->target_frame_ = "whocares";
   target->target_type_ = target_type_;

--- a/industrial_extrinsic_cal/src/nodes/manual_calt_adjuster.cpp
+++ b/industrial_extrinsic_cal/src/nodes/manual_calt_adjuster.cpp
@@ -43,13 +43,13 @@ int main(int argc, char** argv)
   industrial_extrinsic_cal::store_mutable_joint_states::Response
       store_response; /**< response to store when  part of a mutable set */
 
-  get_client = nh.serviceClient< industrial_extrinsic_cal::get_mutable_joint_states >("get_mutable_joint_states");
-  set_client = nh.serviceClient< industrial_extrinsic_cal::set_mutable_joint_states >("set_mutable_joint_states");
-  store_client = nh.serviceClient< industrial_extrinsic_cal::store_mutable_joint_states >("store_mutable_joint_states");
+  get_client = nh.serviceClient<industrial_extrinsic_cal::get_mutable_joint_states>("get_mutable_joint_states");
+  set_client = nh.serviceClient<industrial_extrinsic_cal::set_mutable_joint_states>("set_mutable_joint_states");
+  store_client = nh.serviceClient<industrial_extrinsic_cal::store_mutable_joint_states>("store_mutable_joint_states");
 
   std::string base_name;
   double delta_t, delta_d;
-  std::vector< double > joint_values;
+  std::vector<double> joint_values;
   if (argc == 4)
   {
     base_name = argv[1];

--- a/industrial_extrinsic_cal/src/nodes/mono_ex_cal.cpp
+++ b/industrial_extrinsic_cal/src/nodes/mono_ex_cal.cpp
@@ -107,7 +107,7 @@ struct Camera_reprj_error
   {
   }
 
-  template < typename T >
+  template <typename T>
   bool operator()(const T* const c_p1,  // extrinsic parameters
                   const T* c_p2,        // intrinsic parameters
                   const T* point,       // point being projected, yes this is has 3 parameters
@@ -171,7 +171,7 @@ struct Camera_reprj_error
   // the client code.
   static ceres::CostFunction* Create(const double o_x, const double o_y)
   {
-    return (new ceres::AutoDiffCostFunction< Camera_reprj_error, 2, 6, 9, 3 >(new Camera_reprj_error(o_x, o_y)));
+    return (new ceres::AutoDiffCostFunction<Camera_reprj_error, 2, 6, 9, 3>(new Camera_reprj_error(o_x, o_y)));
   }
   double Ox;  // observed x location of object in image
   double Oy;  // observed y location of object in image
@@ -245,7 +245,7 @@ int main(int argc, char** argv)
     printf("couldn't read num_points\n");
     exit(1);
   }
-  std::vector< point > Pts;
+  std::vector<point> Pts;
   for (int i = 0; i < num_points; i++)
   {
     point p;
@@ -268,7 +268,7 @@ int main(int argc, char** argv)
   {
     printf("WARNING, num_points NOT EQUAL to num_observations\n");
   }
-  std::vector< observation > Ob;
+  std::vector<observation> Ob;
   for (int i = 0; i < num_observations; i++)
   {
     if (fscanf(observations_fp, "%lf %lf", &o.x, &o.y) != 2)

--- a/industrial_extrinsic_cal/src/nodes/mutable_joint_state_publisher.cpp
+++ b/industrial_extrinsic_cal/src/nodes/mutable_joint_state_publisher.cpp
@@ -49,7 +49,7 @@ MutableJointStatePublisher::MutableJointStatePublisher(ros::NodeHandle nh) : nh_
 
   // advertise the topic for continious publication of all the mutable joint states
   int queue_size = 10;
-  joint_state_pub_ = nh_.advertise< sensor_msgs::JointState >("mutable_joint_states", queue_size);
+  joint_state_pub_ = nh_.advertise<sensor_msgs::JointState>("mutable_joint_states", queue_size);
   if (!joint_state_pub_)
   {
     ROS_ERROR("ADVERTISE DID NOT RETURN A VALID PUBLISHER");
@@ -111,7 +111,7 @@ bool MutableJointStatePublisher::storeCallBack(industrial_extrinsic_cal::store_m
   std::ofstream fout(new_file_name.c_str());
   YAML::Emitter yaml_emitter;
   yaml_emitter << YAML::BeginMap;
-  for (std::map< std::string, double >::iterator it = joints_.begin(); it != joints_.end(); ++it)
+  for (std::map<std::string, double>::iterator it = joints_.begin(); it != joints_.end(); ++it)
   {
     yaml_emitter << YAML::Key << it->first.c_str() << YAML::Value << it->second;
     ROS_INFO("mutable joint %s has value %lf", it->first.c_str(), it->second);
@@ -153,7 +153,7 @@ bool MutableJointStatePublisher::loadFromYamlFile()
   if (joints_.size() == 0) ROS_ERROR("mutable_joint_state_publisher has no joints");
 
   // output so we know they have been read in correctly
-  for (std::map< std::string, double >::iterator it = joints_.begin(); it != joints_.end(); ++it)
+  for (std::map<std::string, double>::iterator it = joints_.begin(); it != joints_.end(); ++it)
   {
     ROS_INFO("mutable joint %s has value %lf", it->first.c_str(), it->second);
   }
@@ -169,7 +169,7 @@ bool MutableJointStatePublisher::publishJointStates()
   joint_states.position.clear();
   joint_states.velocity.clear();
   joint_states.effort.clear();
-  for (std::map< string, double >::iterator it = joints_.begin(); it != joints_.end(); ++it)
+  for (std::map<string, double>::iterator it = joints_.begin(); it != joints_.end(); ++it)
   {
     joint_states.name.push_back(it->first);
     joint_states.position.push_back(it->second);

--- a/industrial_extrinsic_cal/src/nodes/nist_analysis.cpp
+++ b/industrial_extrinsic_cal/src/nodes/nist_analysis.cpp
@@ -45,7 +45,7 @@ using industrial_extrinsic_cal::Cost_function;
 typedef boost::minstd_rand base_gen_type;
 base_gen_type gen(42);
 boost::normal_distribution<> normal_dist(0, 1);  // zero mean unit variance
-boost::variate_generator< base_gen_type&, boost::normal_distribution<> > randn(gen, normal_dist);
+boost::variate_generator<base_gen_type&, boost::normal_distribution<> > randn(gen, normal_dist);
 
 typedef struct observation
 {
@@ -57,7 +57,7 @@ typedef struct scene
 {
   int scene_id;
   Pose6d target_pose;
-  std::vector< std::string > camera_names;
+  std::vector<std::string> camera_names;
 } Scene;
 
 /*! Brief defines a camera with extra structures to maintain statistics */
@@ -66,7 +66,7 @@ class CameraWithHistory : public Camera
 public:
   int height;
   int width;
-  vector< Pose6d > pose_history;
+  vector<Pose6d> pose_history;
   double pose_position_mean_error;
   double pose_position_sigma;
   double pose_orientation_mean_error;
@@ -80,9 +80,9 @@ class Point3dWithHistory
 {
 public:
   Point3d point;
-  vector< double > x_history;
-  vector< double > y_history;
-  vector< double > z_history;
+  vector<double> x_history;
+  vector<double> y_history;
+  vector<double> z_history;
   double mean_x;
   double mean_y;
   double mean_z;
@@ -98,36 +98,36 @@ void printAATasH(double x, double y, double z, double tx, double ty, double tz);
 void printAATasHI(double x, double y, double z, double tx, double ty, double tz);
 void printAAasEuler(double x, double y, double z);
 void printCamera(CameraWithHistory C, string words);
-void computeObservations(vector< CameraWithHistory >& cameras, vector< Point3dWithHistory >& points, double noise,
-                         double max_dist, vector< ObservationDataPoint >& observations);
-void perturbCameras(vector< CameraWithHistory >& cameras, double position_noise, double degrees_noise);
-void perturbPoints(vector< Point3dWithHistory >& points, double position_noise);
+void computeObservations(vector<CameraWithHistory>& cameras, vector<Point3dWithHistory>& points, double noise,
+                         double max_dist, vector<ObservationDataPoint>& observations);
+void perturbCameras(vector<CameraWithHistory>& cameras, double position_noise, double degrees_noise);
+void perturbPoints(vector<Point3dWithHistory>& points, double position_noise);
 void perturbPose(Pose6d& pose, double position_noise, double degree_noise);
-void independentlyPerturbCameras(vector< CameraWithHistory >& cameras);
-void copyCamerasWoHistory(vector< CameraWithHistory >& original_cameras, vector< CameraWithHistory >& cameras);
-void copyPoints(vector< Point3dWithHistory >& original_points, vector< Point3dWithHistory >& points);
-void addPoseToHistory(vector< CameraWithHistory >& cameras, vector< CameraWithHistory >& original_cameras);
-void computeHistoricPoseStatistics(vector< CameraWithHistory >& cameras);
-void addPointsToHistory(vector< Point3dWithHistory >& points, vector< Point3dWithHistory >& original_points);
-void computeHistoricPointStatistics(vector< Point3dWithHistory >& points);
-void compareCameras(vector< CameraWithHistory >& C1, vector< CameraWithHistory >& C2);
-void compareObservations(vector< ObservationDataPoint >& O1, vector< ObservationDataPoint >& O2);
-bool parseScenes(std::string& scene_file_name, std::vector< Scene >& scenes);
-void showScenes(vector< Scene >& scenes);
-void addTargetPoints(int rows, int cols, double spacing, vector< Point3dWithHistory >& points, Pose6d& target_pose);
-void computeObservationsFromScenes(vector< Scene >& scenes,  // pose of target, and which cameras observed it
-                                   vector< CameraWithHistory >& cameras,  // list of cameras
+void independentlyPerturbCameras(vector<CameraWithHistory>& cameras);
+void copyCamerasWoHistory(vector<CameraWithHistory>& original_cameras, vector<CameraWithHistory>& cameras);
+void copyPoints(vector<Point3dWithHistory>& original_points, vector<Point3dWithHistory>& points);
+void addPoseToHistory(vector<CameraWithHistory>& cameras, vector<CameraWithHistory>& original_cameras);
+void computeHistoricPoseStatistics(vector<CameraWithHistory>& cameras);
+void addPointsToHistory(vector<Point3dWithHistory>& points, vector<Point3dWithHistory>& original_points);
+void computeHistoricPointStatistics(vector<Point3dWithHistory>& points);
+void compareCameras(vector<CameraWithHistory>& C1, vector<CameraWithHistory>& C2);
+void compareObservations(vector<ObservationDataPoint>& O1, vector<ObservationDataPoint>& O2);
+bool parseScenes(std::string& scene_file_name, std::vector<Scene>& scenes);
+void showScenes(vector<Scene>& scenes);
+void addTargetPoints(int rows, int cols, double spacing, vector<Point3dWithHistory>& points, Pose6d& target_pose);
+void computeObservationsFromScenes(vector<Scene>& scenes,               // pose of target, and which cameras observed it
+                                   vector<CameraWithHistory>& cameras,  // list of cameras
                                    double target_pos_noise,  // perturb position of target by this amount then compute
                                    double target_degree_noise,  // peturb orientation of target by this amount then
                                                                 // compute
                                    double image_noise,          // amount of noise to add to each observation
-                                   vector< ObservationDataPoint >& observations,  // returned data
-                                   vector< Point3dWithHistory >& points);         // returned target points
+                                   vector<ObservationDataPoint>& observations,  // returned data
+                                   vector<Point3dWithHistory>& points);         // returned target points
 ObservationDataPoint predictObservationOfPoint(CameraWithHistory& C, Point3dWithHistory& P, Pose6d& target_pose,
                                                int scene_id, int point_id, double image_noise,
                                                bool& results_within_image);
-void computeObservationsOfPoints(vector< CameraWithHistory >& cameras, vector< Point3dWithHistory >& points,
-                                 Pose6d& target_pose, int scene_id, vector< ObservationDataPoint >& observations,
+void computeObservationsOfPoints(vector<CameraWithHistory>& cameras, vector<Point3dWithHistory>& points,
+                                 Pose6d& target_pose, int scene_id, vector<ObservationDataPoint>& observations,
                                  double camera_position_noise = 0.0, double camera_degree_noise = 0.0,
                                  double image_noise = 0.0);
 
@@ -135,20 +135,20 @@ int main(int argc, char** argv)
 {
   ros::init(argc, argv, "nist_analysis");
 
-  vector< Point3d > original_points_nh;                // original as read in, no history
-  vector< Point3dWithHistory > original_points;        // working copy of original points
-  vector< shared_ptr< Camera > > original_cameras_sp;  // cameras with given poses
-  vector< CameraWithHistory > original_cameras;        // cameras with given poses
+  vector<Point3d> original_points_nh;               // original as read in, no history
+  vector<Point3dWithHistory> original_points;       // working copy of original points
+  vector<shared_ptr<Camera> > original_cameras_sp;  // cameras with given poses
+  vector<CameraWithHistory> original_cameras;       // cameras with given poses
 
-  vector< Point3dWithHistory > points;                 // working copy of original points
-  vector< Point3d > original_field_points_nh;          // test points for accuracy estimation
-  vector< Point3dWithHistory > original_field_points;  // test points for accuracy estimation
-  vector< Point3dWithHistory > field_points;           // working copy of original field points
+  vector<Point3dWithHistory> points;                 // working copy of original points
+  vector<Point3d> original_field_points_nh;          // test points for accuracy estimation
+  vector<Point3dWithHistory> original_field_points;  // test points for accuracy estimation
+  vector<Point3dWithHistory> field_points;           // working copy of original field points
 
-  vector< CameraWithHistory > cameras;                         // working copy of original cameras
-  vector< ObservationDataPoint > original_observations;        // noisless observations of original points
-  vector< ObservationDataPoint > original_field_observations;  // noisless observations field points
-  vector< ObservationDataPoint > observations;                 // working observations
+  vector<CameraWithHistory> cameras;                         // working copy of original cameras
+  vector<ObservationDataPoint> original_observations;        // noisless observations of original points
+  vector<ObservationDataPoint> original_field_observations;  // noisless observations field points
+  vector<ObservationDataPoint> observations;                 // working observations
 
   // TODO use a parameter file for these, or make them arguments
   // hard coded constants
@@ -185,7 +185,7 @@ int main(int argc, char** argv)
   // copy each into a history capable version
   // NOTE: pullTransform() is called which installs the results from extrinsic calibration in the camera data
   std::string ref_frame("world");
-  BOOST_FOREACH (shared_ptr< Camera >& current_camera, original_cameras_sp)
+  BOOST_FOREACH (shared_ptr<Camera>& current_camera, original_cameras_sp)
   {
     CameraWithHistory temp_camera;
     temp_camera.setTransformInterface(current_camera->getTransformInterface());
@@ -205,7 +205,7 @@ int main(int argc, char** argv)
   // parse the scenes.
   // This is the output from the extrinsic calibration script
   // every scene has an id, a location of the target, and a list of cameras that observed the target
-  std::vector< Scene > scenes;
+  std::vector<Scene> scenes;
   parseScenes(scene_file_name, scenes);
   if (SHOW_DEBUG) showScenes(scenes);
 
@@ -542,8 +542,8 @@ void printCamera(CameraWithHistory C, string words)
   printf("cx = %8.3lf cy = %8.3lf\n", C.camera_parameters_.center_x, C.camera_parameters_.center_y);
 }
 
-void computeObservations(vector< CameraWithHistory >& cameras, vector< Point3dWithHistory >& points, double noise,
-                         double max_dist, vector< ObservationDataPoint >& observations)
+void computeObservations(vector<CameraWithHistory>& cameras, vector<Point3dWithHistory>& points, double noise,
+                         double max_dist, vector<ObservationDataPoint>& observations)
 {
   double pnoise = noise / sqrt(1.58085);  // magic number found by trial and error
   int n_observations = 0;
@@ -606,7 +606,7 @@ void computeObservations(vector< CameraWithHistory >& cameras, vector< Point3dWi
   }        // end for each camera
 }  // end compute observations
 
-void perturbCameras(vector< CameraWithHistory >& cameras, double position_noise, double degrees_noise)
+void perturbCameras(vector<CameraWithHistory>& cameras, double position_noise, double degrees_noise)
 {
   double pos_noise = position_noise / sqrt(2.274625);
   double radian_noise = degrees_noise * 3.1415 / (180.0 * sqrt(2.58047));
@@ -621,7 +621,7 @@ void perturbCameras(vector< CameraWithHistory >& cameras, double position_noise,
   }
 }
 
-void perturbPoints(vector< Point3dWithHistory >& points, double position_noise)
+void perturbPoints(vector<Point3dWithHistory>& points, double position_noise)
 {
   double pos_noise = position_noise / sqrt(2.274625);
   BOOST_FOREACH (Point3dWithHistory& P, points)
@@ -632,7 +632,7 @@ void perturbPoints(vector< Point3dWithHistory >& points, double position_noise)
   }
 }
 
-void independentlyPerturbCameras(vector< CameraWithHistory >& cameras)
+void independentlyPerturbCameras(vector<CameraWithHistory>& cameras)
 {
   BOOST_FOREACH (CameraWithHistory& C, cameras)
   {
@@ -647,7 +647,7 @@ void independentlyPerturbCameras(vector< CameraWithHistory >& cameras)
   }
 }
 
-void copyCamerasWoHistory(vector< CameraWithHistory >& original_cameras, vector< CameraWithHistory >& cameras)
+void copyCamerasWoHistory(vector<CameraWithHistory>& original_cameras, vector<CameraWithHistory>& cameras)
 {
   cameras.clear();
   BOOST_FOREACH (CameraWithHistory& C, original_cameras)
@@ -659,7 +659,7 @@ void copyCamerasWoHistory(vector< CameraWithHistory >& original_cameras, vector<
   }
 }
 
-void copyPoints(vector< Point3dWithHistory >& original_points, vector< Point3dWithHistory >& points)
+void copyPoints(vector<Point3dWithHistory>& original_points, vector<Point3dWithHistory>& points)
 {
   points.clear();
   BOOST_FOREACH (Point3dWithHistory& P, original_points)
@@ -668,7 +668,7 @@ void copyPoints(vector< Point3dWithHistory >& original_points, vector< Point3dWi
   }
 }
 
-void addPoseToHistory(vector< CameraWithHistory >& cameras, vector< CameraWithHistory >& original_cameras)
+void addPoseToHistory(vector<CameraWithHistory>& cameras, vector<CameraWithHistory>& original_cameras)
 {
   if (cameras.size() != original_cameras.size()) ROS_ERROR_STREAM("number of cameras in vectors do not match");
 
@@ -685,7 +685,7 @@ void addPoseToHistory(vector< CameraWithHistory >& cameras, vector< CameraWithHi
   }
 }
 
-void computeHistoricPoseStatistics(vector< CameraWithHistory >& cameras)
+void computeHistoricPoseStatistics(vector<CameraWithHistory>& cameras)
 {
   // calculate statistics of test case
   double mean_x, mean_y, mean_z, mean_ax, mean_ay, mean_az;
@@ -760,7 +760,7 @@ void computeHistoricPoseStatistics(vector< CameraWithHistory >& cameras)
   }  // end for each camera
 }
 
-void computeHistoricPointStatistics(vector< Point3dWithHistory >& points)
+void computeHistoricPointStatistics(vector<Point3dWithHistory>& points)
 {
   // calculate statistics of test case
   double mean_x, mean_y, mean_z;
@@ -827,7 +827,7 @@ void computeHistoricPointStatistics(vector< Point3dWithHistory >& points)
   }  // end for each point
 }
 
-void compareCameras(vector< CameraWithHistory >& C1, vector< CameraWithHistory >& C2)
+void compareCameras(vector<CameraWithHistory>& C1, vector<CameraWithHistory>& C2)
 {
   if (C1.size() != C2.size())
   {
@@ -883,7 +883,7 @@ void compareCameras(vector< CameraWithHistory >& C1, vector< CameraWithHistory >
            sigma_angle * 180 / 3.1415);
 }
 
-void compareObservations(vector< ObservationDataPoint >& O1, vector< ObservationDataPoint >& O2)
+void compareObservations(vector<ObservationDataPoint>& O1, vector<ObservationDataPoint>& O2)
 {
   if (O1.size() != O2.size())
   {
@@ -919,7 +919,7 @@ void compareObservations(vector< ObservationDataPoint >& O1, vector< Observation
   ROS_INFO("mean distance between observations = %9.5lf pixels sigma= %9.5lf ", mean_dist, sigma_dist);
 }
 
-void addPointsToHistory(vector< Point3dWithHistory >& points, vector< Point3dWithHistory >& original_points)
+void addPointsToHistory(vector<Point3dWithHistory>& points, vector<Point3dWithHistory>& original_points)
 {
   if (points.size() != original_points.size()) ROS_ERROR_STREAM("number of points in vectors do not match");
 
@@ -931,7 +931,7 @@ void addPointsToHistory(vector< Point3dWithHistory >& points, vector< Point3dWit
   }
 }
 
-bool parseScenes(std::string& scene_file_name, std::vector< Scene >& scenes)
+bool parseScenes(std::string& scene_file_name, std::vector<Scene>& scenes)
 {
   FILE* fp = fopen(scene_file_name.c_str(), "r");
   if (fp == NULL)
@@ -983,7 +983,7 @@ bool parseScenes(std::string& scene_file_name, std::vector< Scene >& scenes)
   return (true);
 }
 
-void show_scenes(vector< Scene >& scenes)
+void show_scenes(vector<Scene>& scenes)
 {
   BOOST_FOREACH (Scene S, scenes)
   {
@@ -1007,8 +1007,8 @@ void perturbPose(Pose6d& pose, double position_noise, double degree_noise)
   pose.ay += radian_noise * randn();
 }
 
-void computeObservationsOfPoints(vector< CameraWithHistory >& cameras, vector< Point3dWithHistory >& points,
-                                 Pose6d& target_pose, int scene_id, vector< ObservationDataPoint >& observations,
+void computeObservationsOfPoints(vector<CameraWithHistory>& cameras, vector<Point3dWithHistory>& points,
+                                 Pose6d& target_pose, int scene_id, vector<ObservationDataPoint>& observations,
                                  double camera_position_noise, double camera_degree_noise, double image_noise)
 
 {
@@ -1029,14 +1029,14 @@ void computeObservationsOfPoints(vector< CameraWithHistory >& cameras, vector< P
     }
   }
 }
-void computeObservationsFromScenes(vector< Scene >& scenes,  // pose of target, and which cameras observed it
-                                   vector< CameraWithHistory >& cameras,  // list of cameras
+void computeObservationsFromScenes(vector<Scene>& scenes,               // pose of target, and which cameras observed it
+                                   vector<CameraWithHistory>& cameras,  // list of cameras
                                    double target_pos_noise,  // perturb position of target by this amount then compute
                                    double target_degree_noise,  // peturb orientation of target by this amount then
                                                                 // compute
                                    double image_noise,          // amount of noise to add to each observation
-                                   vector< ObservationDataPoint >& observations,  // returned data
-                                   vector< Point3dWithHistory >& points)          // returned target points
+                                   vector<ObservationDataPoint>& observations,  // returned data
+                                   vector<Point3dWithHistory>& points)          // returned target points
 {
   observations.clear();
   BOOST_FOREACH (CameraWithHistory& C, cameras)
@@ -1126,7 +1126,7 @@ ObservationDataPoint predictObservationOfPoint(CameraWithHistory& C, Point3dWith
   return (obs);
 }
 
-void addTargetPoints(int rows, int cols, double spacing, vector< Point3dWithHistory >& points, Pose6d& target_pose)
+void addTargetPoints(int rows, int cols, double spacing, vector<Point3dWithHistory>& points, Pose6d& target_pose)
 {
   for (int i = 0; i < rows; i++)
   {

--- a/industrial_extrinsic_cal/src/nodes/ros_robot_scene_trigger_action_server.cpp
+++ b/industrial_extrinsic_cal/src/nodes/ros_robot_scene_trigger_action_server.cpp
@@ -30,8 +30,8 @@ protected:
   ros::NodeHandle nh_;
 
 public:
-  typedef actionlib::SimpleActionServer< industrial_extrinsic_cal::robot_joint_values_triggerAction > JointValuesServer;
-  typedef actionlib::SimpleActionServer< industrial_extrinsic_cal::robot_pose_triggerAction > PoseServer;
+  typedef actionlib::SimpleActionServer<industrial_extrinsic_cal::robot_joint_values_triggerAction> JointValuesServer;
+  typedef actionlib::SimpleActionServer<industrial_extrinsic_cal::robot_pose_triggerAction> PoseServer;
 
   ServersNode(std::string name)
     : joint_value_server_(nh_, name + "_joint_values", boost::bind(&ServersNode::jointValueCallBack, this, _1), false)
@@ -54,10 +54,10 @@ public:
   void jointValueCallBack(const industrial_extrinsic_cal::robot_joint_values_triggerGoalConstPtr& goal)
   {
     // TODO send both values and names and make sure they match. This is critical or else robots will crash into stuff
-    std::vector< double > group_variable_values;
+    std::vector<double> group_variable_values;
     moveit::core::RobotStatePtr current_state = move_group_->getCurrentState();
     double* joint_value = current_state->getVariablePositions();
-    std::vector< std::string > var_names = current_state->getVariableNames();
+    std::vector<std::string> var_names = current_state->getVariableNames();
     if (var_names.size() == 7)
     {
       ROS_INFO("%d variables %s %s %s %s %s %s %s", (int)var_names.size(), var_names[0].c_str(), var_names[1].c_str(),
@@ -100,7 +100,7 @@ public:
               current_pose.pose.position.y, current_pose.pose.position.z, current_pose.pose.orientation.x,
               current_pose.pose.orientation.y, current_pose.pose.orientation.z, current_pose.pose.orientation.w);
     geometry_msgs::Pose target_pose;
-    std::vector< geometry_msgs::Pose > poses;
+    std::vector<geometry_msgs::Pose> poses;
     target_pose.position.x = goal->pose.position.x;
     target_pose.position.y = goal->pose.position.y;
     target_pose.position.z = goal->pose.position.z;

--- a/industrial_extrinsic_cal/src/nodes/ros_scene_trigger_server.cpp
+++ b/industrial_extrinsic_cal/src/nodes/ros_scene_trigger_server.cpp
@@ -22,7 +22,7 @@
 #include <actionlib/server/simple_action_server.h>
 #include <industrial_extrinsic_cal/manual_triggerAction.h>
 
-typedef actionlib::SimpleActionServer< industrial_extrinsic_cal::manual_triggerAction > Server;
+typedef actionlib::SimpleActionServer<industrial_extrinsic_cal::manual_triggerAction> Server;
 
 void execute(const industrial_extrinsic_cal::manual_triggerGoalConstPtr& goal, Server* as)
 {

--- a/industrial_extrinsic_cal/src/observation_scene.cpp
+++ b/industrial_extrinsic_cal/src/observation_scene.cpp
@@ -29,7 +29,7 @@ void ObservationScene::addObservationToScene(ObservationCmd new_obs_cmd)
   bool camera_already_in_scene = false;
   BOOST_FOREACH (ObservationCmd command, observation_command_list_)
   {
-    BOOST_FOREACH (shared_ptr< Camera > camera, cameras_in_scene_)
+    BOOST_FOREACH (shared_ptr<Camera> camera, cameras_in_scene_)
     {
       if (camera->camera_name_ == new_obs_cmd.camera->camera_name_)
       {
@@ -47,15 +47,15 @@ void ObservationScene::addObservationToScene(ObservationCmd new_obs_cmd)
   observation_command_list_.push_back(new_obs_cmd);
 }
 
-void ObservationScene::addCameraToScene(boost::shared_ptr< Camera > camera_in_scene)
+void ObservationScene::addCameraToScene(boost::shared_ptr<Camera> camera_in_scene)
 {
   cameras_in_scene_.push_back(camera_in_scene);
   ROS_DEBUG_STREAM("Added camera " << camera_in_scene->camera_name_
                                    << " to cameras_in_scene list of size: " << cameras_in_scene_.size());
 }
 
-void ObservationScene::populateObsCmdList(boost::shared_ptr< Camera > camera, boost::shared_ptr< Target > target,
-                                          Roi roi, Cost_function cost_type)
+void ObservationScene::populateObsCmdList(boost::shared_ptr<Camera> camera, boost::shared_ptr<Target> target, Roi roi,
+                                          Cost_function cost_type)
 {
   ObservationCmd current_obs_cmd;
   current_obs_cmd.camera = camera;

--- a/industrial_extrinsic_cal/src/points_yaml_parser.cpp
+++ b/industrial_extrinsic_cal/src/points_yaml_parser.cpp
@@ -15,7 +15,7 @@ using YAML::Node;
 
 namespace industrial_extrinsic_cal
 {
-bool parsePoints(std::string& points_input_file, vector< Point3d >& points)
+bool parsePoints(std::string& points_input_file, vector<Point3d>& points)
 {
   // parse points
   bool return_value = true;
@@ -31,7 +31,7 @@ bool parsePoints(std::string& points_input_file, vector< Point3d >& points)
     const YAML::Node& points_node = parseNode(points_doc, "points");
     for (int j = 0; j < points_node.size(); j++)
     {
-      vector< double > temp_pnt;
+      vector<double> temp_pnt;
       parseVectorD(points_node[j], "pnt", temp_pnt);
       Point3d temp_pnt3d;
       temp_pnt3d.x = temp_pnt[0];

--- a/industrial_extrinsic_cal/src/points_yaml_parser_indigo.cpp
+++ b/industrial_extrinsic_cal/src/points_yaml_parser_indigo.cpp
@@ -15,7 +15,7 @@ using YAML::Node;
 
 namespace industrial_extrinsic_cal
 {
-void parsePoints(ifstream& points_input_file, vector< Point3d >& points)
+void parsePoints(ifstream& points_input_file, vector<Point3d>& points)
 {
   // parse points
   try
@@ -28,8 +28,8 @@ void parsePoints(ifstream& points_input_file, vector< Point3d >& points)
     for (int j = 0; j < points_node.size(); j++)
     {
       const YAML::Node pnt_node = points_node[j]("pnt");
-      vector< float > temp_pnt;
-      temp_pnt = t_node.at< vector< float > >();
+      vector<float> temp_pnt;
+      temp_pnt = t_node.at<vector<float> >();
       Point3d temp_pnt3d;
       temp_pnt3d.x = temp_pnt[0];
       temp_pnt3d.y = temp_pnt[1];

--- a/industrial_extrinsic_cal/src/ros_camera_observer.cpp
+++ b/industrial_extrinsic_cal/src/ros_camera_observer.cpp
@@ -37,10 +37,10 @@ ROSCameraObserver::ROSCameraObserver(const std::string& camera_topic, const std:
   , camera_name_(camera_name)
 {
   image_topic_ = camera_topic;
-  results_pub_ = nh_.advertise< sensor_msgs::Image >("observer_results_image", 100);
-  debug_pub_ = nh_.advertise< sensor_msgs::Image >("observer_raw_image", 100);
+  results_pub_ = nh_.advertise<sensor_msgs::Image>("observer_results_image", 100);
+  debug_pub_ = nh_.advertise<sensor_msgs::Image>("observer_raw_image", 100);
   std::string set_camera_info_service = camera_name_ + "/set_camera_info";
-  client_ = nh_.serviceClient< sensor_msgs::SetCameraInfo >(set_camera_info_service);
+  client_ = nh_.serviceClient<sensor_msgs::SetCameraInfo>(set_camera_info_service);
 
   ros::NodeHandle pnh("~");
   pnh.getParam("image_directory", image_directory_);
@@ -64,15 +64,15 @@ ROSCameraObserver::ROSCameraObserver(const std::string& camera_topic, const std:
 
   std::string recon_node_name = "~/" + camera_name;
   rnh_ = new ros::NodeHandle(recon_node_name.c_str());
-  server_ = new dynamic_reconfigure::Server< industrial_extrinsic_cal::circle_grid_finderConfig >(*rnh_);
+  server_ = new dynamic_reconfigure::Server<industrial_extrinsic_cal::circle_grid_finderConfig>(*rnh_);
 
-  dynamic_reconfigure::Server< industrial_extrinsic_cal::circle_grid_finderConfig >::CallbackType f;
+  dynamic_reconfigure::Server<industrial_extrinsic_cal::circle_grid_finderConfig>::CallbackType f;
 
   f = boost::bind(&ROSCameraObserver::dynReConfCallBack, this, _1, _2);
   server_->setCallback(f);
 }
 
-bool ROSCameraObserver::addTarget(boost::shared_ptr< Target > targ, Roi& roi, Cost_function cost_type)
+bool ROSCameraObserver::addTarget(boost::shared_ptr<Target> targ, Roi& roi, Cost_function cost_type)
 {
   // TODO make a list of targets so that the camera may make more than one set of observations at a time
   // This was what was inteneded by the interface definition, I'm not sure why the first implementation didn't do it.
@@ -168,7 +168,7 @@ int ROSCameraObserver::getObservations(CameraObservations& cam_obs)
 
   ROS_DEBUG("image_roi_ size = %d %d", image_roi_.rows, image_roi_.cols);
   observation_pts_.clear();
-  std::vector< cv::KeyPoint > key_points;
+  std::vector<cv::KeyPoint> key_points;
   ROS_DEBUG("Pattern type %d, rows %d, cols %d", pattern_, pattern_rows_, pattern_cols_);
 
   cv::Point large_point;
@@ -246,7 +246,7 @@ int ROSCameraObserver::getObservations(CameraObservations& cam_obs)
     case pattern_options::ModifiedCircleGrid:
     {  // contain the scope of automatic variables
       // modified circle grids have one circle at the origin which is 1.5 times larger in diameter than the rest
-      std::vector< cv::Point2f > centers;
+      std::vector<cv::Point2f> centers;
       if (use_circle_detector_)
       {
         ROS_DEBUG("using circle_detector, to find %dx%d modified circle grid", pattern_rows_, pattern_cols_);
@@ -286,7 +286,7 @@ int ROSCameraObserver::getObservations(CameraObservations& cam_obs)
         // their keypoints
         // Should OpenCV change their method, the keypoint locations may not match, this has a risk of failing with
         // updates to OpenCV
-        std::vector< cv::KeyPoint > keypoints;
+        std::vector<cv::KeyPoint> keypoints;
 
         if (use_circle_detector_) circle_detector_ptr_->detect(image_roi_, keypoints);
         if (!use_circle_detector_) blob_detector_ptr_->detect(image_roi_, keypoints);
@@ -534,8 +534,8 @@ int ROSCameraObserver::getObservations(CameraObservations& cam_obs)
       dilate(red_binary_image, red_binary_image, dilation_element);
       dilate(yellow_binary_image, yellow_binary_image, dilation_element);
       dilate(green_binary_image, green_binary_image, dilation_element);
-      std::vector< cv::Point2f > centers;
-      std::vector< cv::KeyPoint > keypoints;
+      std::vector<cv::Point2f> centers;
+      std::vector<cv::KeyPoint> keypoints;
       if (!use_circle_detector_) blob_detector_ptr_->detect(red_binary_image, keypoints);
       if (use_circle_detector_) circle_detector_ptr_->detect(red_binary_image, keypoints);
       ROS_ERROR("Red keypoints: %d", (int)keypoints.size());
@@ -716,7 +716,7 @@ void ROSCameraObserver::triggerCamera()
     while (!done)
     {
       sensor_msgs::ImageConstPtr recent_image =
-          ros::topic::waitForMessage< sensor_msgs::Image >(image_topic_, ros::Duration(5.0));
+          ros::topic::waitForMessage<sensor_msgs::Image>(image_topic_, ros::Duration(5.0));
       if (!recent_image)
       {
         ROS_ERROR("No image acquired on topic '%s'", image_topic_.c_str());
@@ -772,7 +772,7 @@ bool ROSCameraObserver::pushCameraInfo(double& fx, double& fy, double& cx, doubl
   // must pull to get all the header information that we don't compute
   std::string camera_info_topic = camera_name_ + "/camera_info";
   const sensor_msgs::CameraInfoConstPtr& info_msg =
-      ros::topic::waitForMessage< sensor_msgs::CameraInfo >(camera_info_topic);
+      ros::topic::waitForMessage<sensor_msgs::CameraInfo>(camera_info_topic);
   srv_.request.camera_info.distortion_model = info_msg->distortion_model;
   srv_.request.camera_info.header = info_msg->header;
   srv_.request.camera_info.height = info_msg->height;
@@ -841,7 +841,7 @@ bool ROSCameraObserver::pullCameraInfo(double& fx, double& fy, double& cx, doubl
   std::string camera_info_topic = topic + "/camera_info";
 
   const sensor_msgs::CameraInfoConstPtr& info_msg =
-      ros::topic::waitForMessage< sensor_msgs::CameraInfo >(camera_info_topic);
+      ros::topic::waitForMessage<sensor_msgs::CameraInfo>(camera_info_topic);
   if (info_msg->K[0] == 0)
   {
     ROS_ERROR("camera info msg not correct");
@@ -869,7 +869,7 @@ bool ROSCameraObserver::pullCameraInfo(double& fx, double& fy, double& cx, doubl
   }
   std::string camera_info_topic = "/" + camera_name_ + "/camera_info";
   const sensor_msgs::CameraInfoConstPtr& info_msg =
-      ros::topic::waitForMessage< sensor_msgs::CameraInfo >(camera_info_topic, ros::Duration(10.0));
+      ros::topic::waitForMessage<sensor_msgs::CameraInfo>(camera_info_topic, ros::Duration(10.0));
   if (info_msg == NULL)
   {
     ROS_ERROR("camera info message not available for camera %s on topic %s", camera_name_.c_str(),
@@ -920,11 +920,11 @@ void ROSCameraObserver::dynReConfCallBack(industrial_extrinsic_cal::circle_grid_
 
   circle_params.filterByInertia = false;
   circle_params.minInertiaRatio = 0.1f;
-  circle_params.maxInertiaRatio = std::numeric_limits< float >::max();
+  circle_params.maxInertiaRatio = std::numeric_limits<float>::max();
 
   circle_params.filterByConvexity = false;
   circle_params.minConvexity = 0.95f;
-  circle_params.maxConvexity = std::numeric_limits< float >::max();
+  circle_params.maxConvexity = std::numeric_limits<float>::max();
 
   circle_detector_ptr_ = cv::CircleDetector::create(circle_params);
 
@@ -949,11 +949,11 @@ void ROSCameraObserver::dynReConfCallBack(industrial_extrinsic_cal::circle_grid_
 
   blob_params.filterByInertia = false;
   blob_params.minInertiaRatio = 0.1f;
-  blob_params.maxInertiaRatio = std::numeric_limits< float >::max();
+  blob_params.maxInertiaRatio = std::numeric_limits<float>::max();
 
   blob_params.filterByConvexity = false;
   blob_params.minConvexity = 0.95f;
-  blob_params.maxConvexity = std::numeric_limits< float >::max();
+  blob_params.maxConvexity = std::numeric_limits<float>::max();
 
   blob_detector_ptr_ = cv::SimpleBlobDetector::create(blob_params);
 

--- a/industrial_extrinsic_cal/src/ros_transform_interface.cpp
+++ b/industrial_extrinsic_cal/src/ros_transform_interface.cpp
@@ -349,10 +349,10 @@ ROSCameraHousingCalTInterface::ROSCameraHousingCalTInterface(const string& trans
   ref_frame_initialized_ = false;  // still need to initialize ref_frame_
   nh_ = new ros::NodeHandle;
 
-  get_client_ = nh_->serviceClient< industrial_extrinsic_cal::get_mutable_joint_states >("get_mutable_joint_states");
-  set_client_ = nh_->serviceClient< industrial_extrinsic_cal::set_mutable_joint_states >("set_mutable_joint_states");
+  get_client_ = nh_->serviceClient<industrial_extrinsic_cal::get_mutable_joint_states>("get_mutable_joint_states");
+  set_client_ = nh_->serviceClient<industrial_extrinsic_cal::set_mutable_joint_states>("set_mutable_joint_states");
   store_client_ =
-      nh_->serviceClient< industrial_extrinsic_cal::store_mutable_joint_states >("store_mutable_joint_states");
+      nh_->serviceClient<industrial_extrinsic_cal::store_mutable_joint_states>("store_mutable_joint_states");
 
   get_request_.joint_names.push_back(housing_frame + "_x_joint");
   get_request_.joint_names.push_back(housing_frame + "_y_joint");
@@ -462,10 +462,10 @@ ROSSimpleCalTInterface::ROSSimpleCalTInterface(const string& transform_frame, co
   ref_frame_initialized_ = false;  // still need to initialize ref_frame_
   nh_ = new ros::NodeHandle;
 
-  get_client_ = nh_->serviceClient< industrial_extrinsic_cal::get_mutable_joint_states >("get_mutable_joint_states");
-  set_client_ = nh_->serviceClient< industrial_extrinsic_cal::set_mutable_joint_states >("set_mutable_joint_states");
+  get_client_ = nh_->serviceClient<industrial_extrinsic_cal::get_mutable_joint_states>("get_mutable_joint_states");
+  set_client_ = nh_->serviceClient<industrial_extrinsic_cal::set_mutable_joint_states>("set_mutable_joint_states");
   store_client_ =
-      nh_->serviceClient< industrial_extrinsic_cal::store_mutable_joint_states >("store_mutable_joint_states");
+      nh_->serviceClient<industrial_extrinsic_cal::store_mutable_joint_states>("store_mutable_joint_states");
 
   get_request_.joint_names.push_back(transform_frame + "_x_joint");
   get_request_.joint_names.push_back(transform_frame + "_y_joint");
@@ -552,10 +552,10 @@ ROSSimpleCameraCalTInterface::ROSSimpleCameraCalTInterface(const string& transfo
   ref_frame_initialized_ = false;  // still need to initialize ref_frame_
   nh_ = new ros::NodeHandle;
 
-  get_client_ = nh_->serviceClient< industrial_extrinsic_cal::get_mutable_joint_states >("get_mutable_joint_states");
-  set_client_ = nh_->serviceClient< industrial_extrinsic_cal::set_mutable_joint_states >("set_mutable_joint_states");
+  get_client_ = nh_->serviceClient<industrial_extrinsic_cal::get_mutable_joint_states>("get_mutable_joint_states");
+  set_client_ = nh_->serviceClient<industrial_extrinsic_cal::set_mutable_joint_states>("set_mutable_joint_states");
   store_client_ =
-      nh_->serviceClient< industrial_extrinsic_cal::store_mutable_joint_states >("store_mutable_joint_states");
+      nh_->serviceClient<industrial_extrinsic_cal::store_mutable_joint_states>("store_mutable_joint_states");
 
   get_request_.joint_names.push_back(transform_frame + "_x_joint");
   get_request_.joint_names.push_back(transform_frame + "_y_joint");

--- a/industrial_extrinsic_cal/src/target.cpp
+++ b/industrial_extrinsic_cal/src/target.cpp
@@ -27,11 +27,11 @@ void Target::pullTransform()
 {
   pose_ = transform_interface_->pullTransform();
 }
-void Target::setTransformInterface(boost::shared_ptr< TransformInterface > transform_interface)
+void Target::setTransformInterface(boost::shared_ptr<TransformInterface> transform_interface)
 {
   transform_interface_ = transform_interface;
 }
-boost::shared_ptr< TransformInterface > Target::getTransformInterface()
+boost::shared_ptr<TransformInterface> Target::getTransformInterface()
 {
   return (transform_interface_);
 }

--- a/industrial_extrinsic_cal/src/targets_yaml_parser.cpp
+++ b/industrial_extrinsic_cal/src/targets_yaml_parser.cpp
@@ -21,9 +21,9 @@ using YAML::Node;
 namespace industrial_extrinsic_cal
 {
 // prototypes
-int parseTargetPoints(const Node& node, std::vector< Point3d >& points);
+int parseTargetPoints(const Node& node, std::vector<Point3d>& points);
 
-bool parseTargets(std::string& target_file, vector< boost::shared_ptr< Target > >& targets)
+bool parseTargets(std::string& target_file, vector<boost::shared_ptr<Target> >& targets)
 {
   bool rtn = true;
   Node target_doc;
@@ -42,7 +42,7 @@ bool parseTargets(std::string& target_file, vector< boost::shared_ptr< Target > 
     {
       for (unsigned int i = 0; i < target_parameters.size(); i++)
       {
-        shared_ptr< Target > temp_target = parseSingleTarget(target_parameters[i]);
+        shared_ptr<Target> temp_target = parseSingleTarget(target_parameters[i]);
         temp_target->is_moving_ = false;
         targets.push_back(temp_target);
         n_static++;
@@ -56,7 +56,7 @@ bool parseTargets(std::string& target_file, vector< boost::shared_ptr< Target > 
     {
       for (unsigned int i = 0; i < target_parameters2.size(); i++)
       {
-        shared_ptr< Target > temp_target = parseSingleTarget(target_parameters2[i]);
+        shared_ptr<Target> temp_target = parseSingleTarget(target_parameters2[i]);
         temp_target->is_moving_ = true;
         targets.push_back(temp_target);
         n_moving++;
@@ -78,10 +78,10 @@ bool parseTargets(std::string& target_file, vector< boost::shared_ptr< Target > 
   return (rtn);
 }
 
-shared_ptr< Target > parseSingleTarget(const Node& node)
+shared_ptr<Target> parseSingleTarget(const Node& node)
 {
-  shared_ptr< Target > temp_target = make_shared< Target >();
-  shared_ptr< TransformInterface > temp_ti;
+  shared_ptr<Target> temp_target = make_shared<Target>();
+  shared_ptr<TransformInterface> temp_ti;
   try
   {
     bool success = true;
@@ -140,7 +140,7 @@ shared_ptr< Target > parseSingleTarget(const Node& node)
     }
     else
     {
-      shared_ptr< TransformInterface > temp_ti =
+      shared_ptr<TransformInterface> temp_ti =
           parseTransformInterface(node, transform_interface, temp_target->target_frame_, pose);
       temp_target->setTransformInterface(temp_ti);  // install the transform interface
       if (transform_available)
@@ -178,12 +178,12 @@ shared_ptr< Target > parseSingleTarget(const Node& node)
   return (temp_target);
 }  // end parse_single_target
 
-int parseTargetPoints(const Node& node, std::vector< Point3d >& points)
+int parseTargetPoints(const Node& node, std::vector<Point3d>& points)
 {
   points.clear();
   for (int i = 0; i < (int)node.size(); i++)
   {
-    std::vector< double > temp_pnt;
+    std::vector<double> temp_pnt;
     parseVectorD(node[i], "pnt", temp_pnt);
     Point3d temp_pnt3d;
     temp_pnt3d.x = temp_pnt[0];

--- a/industrial_extrinsic_cal/src/targets_yaml_parser_indigo.cpp
+++ b/industrial_extrinsic_cal/src/targets_yaml_parser_indigo.cpp
@@ -21,9 +21,9 @@ using YAML::Node;
 namespace industrial_extrinsic_cal
 {
 // prototypes
-int parse_target_points(const Node& node, std::vector< Point3d > points);
+int parse_target_points(const Node& node, std::vector<Point3d> points);
 
-void parse_targets(ifstream& targets_input_file, vector< boost::shared_ptr< Target > >& targets)
+void parse_targets(ifstream& targets_input_file, vector<boost::shared_ptr<Target> >& targets)
 {
   try
   {
@@ -35,7 +35,7 @@ void parse_targets(ifstream& targets_input_file, vector< boost::shared_ptr< Targ
     ROS_INFO_STREAM("Found " << target_parameters.size() << " static targets ");
     for (unsigned int i = 0; i < target_parameters.size(); i++)
     {
-      shared_ptr< Target > temp_target = parse_single_target(target_parameters[i]);
+      shared_ptr<Target> temp_target = parse_single_target(target_parameters[i]);
       targets.push_back(temp_target);
     }
 
@@ -44,7 +44,7 @@ void parse_targets(ifstream& targets_input_file, vector< boost::shared_ptr< Targ
     ROS_INFO_STREAM("Found " << target_parameters.size() << " moving targets ");
     for (unsigned int i = 0; i < target_parameters.size(); i++)
     {
-      shared_ptr< Target > temp_target = parse_single_target(target_parameters[i]);
+      shared_ptr<Target> temp_target = parse_single_target(target_parameters[i]);
       temp_target->is_moving_ = true;
       targets.push_back(temp_target);
     }
@@ -56,33 +56,33 @@ void parse_targets(ifstream& targets_input_file, vector< boost::shared_ptr< Targ
   ROS_INFO_STREAM("Successfully read in " << (int)targets.size() << " targets");
 }  // end of parse_targets
 
-shared_ptr< Target > parse_single_target(const Node& node)
+shared_ptr<Target> parse_single_target(const Node& node)
 {
-  shared_ptr< Target > temp_target = make_shared< Target >();
-  shared_ptr< TransformInterface > temp_ti;
+  shared_ptr<Target> temp_target = make_shared<Target>();
+  shared_ptr<TransformInterface> temp_ti;
   try
   {
-    temp_target->target_name_ = node["target_name"].at< std::string >();
-    temp_target->target_frame_ = node["target_frame"].at< std::string >();
-    temp_target->target_type_ = node["target_type"].at< std::string >();
+    temp_target->target_name_ = node["target_name"].at<std::string>();
+    temp_target->target_frame_ = node["target_frame"].at<std::string>();
+    temp_target->target_type_ = node["target_type"].at<std::string>();
     switch (temp_target->target_type_)
     {
       case pattern_options::Chessboard:
-        temp_target->checker_board_parameters_.pattern_rows = node["target_rows"].at< int >();
-        temp_target->checker_board_parameters_.pattern_cols = node["target_cols"].at< int >();
+        temp_target->checker_board_parameters_.pattern_rows = node["target_rows"].at<int>();
+        temp_target->checker_board_parameters_.pattern_cols = node["target_cols"].at<int>();
         ROS_DEBUG_STREAM("TargetRows: " << temp_target->checker_board_parameters_.pattern_rows);
         break;
       case pattern_options::CircleGrid:
-        temp_target->circle_grid_parameters_.pattern_rows = node["target_rows"].at< int >();
-        temp_target->circle_grid_parameters_.pattern_cols = node["target_cols"].at< int >();
-        temp_target->circle_grid_parameters_.circle_diameter = ["circle_dia"].at< double >();
+        temp_target->circle_grid_parameters_.pattern_rows = node["target_rows"].at<int>();
+        temp_target->circle_grid_parameters_.pattern_cols = node["target_cols"].at<int>();
+        temp_target->circle_grid_parameters_.circle_diameter = ["circle_dia"].at<double>();
         temp_target->circle_grid_parameters_.is_symmetric = true;
         ROS_DEBUG_STREAM("TargetRows: " << temp_target->circle_grid_parameters_.pattern_rows);
         break;
       case pattern_options::ModifiedCircleGrid:
-        temp_target->circle_grid_parameters_.pattern_rows = node["target_rows"].at< int >();
-        temp_target->circle_grid_parameters_.pattern_cols = node["target_cols"].at< int >();
-        temp_target->circle_grid_parameters_.circle_diameter = ["circle_dia"].at< double >();
+        temp_target->circle_grid_parameters_.pattern_rows = node["target_rows"].at<int>();
+        temp_target->circle_grid_parameters_.pattern_cols = node["target_cols"].at<int>();
+        temp_target->circle_grid_parameters_.circle_diameter = ["circle_dia"].at<double>();
         temp_target->circle_grid_parameters_.is_symmetric = true;
         ROS_DEBUG_STREAM("TargetRows: " << temp_target->circle_grid_parameters_.pattern_rows);
         break;
@@ -95,12 +95,12 @@ shared_ptr< Target > parse_single_target(const Node& node)
     }  // end of target type
     temp_target->pose_ = parsePose(node);
     std::string transform_interface;
-    transform_interface = node["transform_interface"].at< std::string >();
-    shared_ptr< TransformInterface > temp_ti =
+    transform_interface = node["transform_interface"].at<std::string>();
+    shared_ptr<TransformInterface> temp_ti =
         parseTransformInterface(node, transform_interface, temp_target->target_frame_);
     temp_target->setTransformInterface(temp_ti);  // install the transform interface
 
-    temp_target->num_points_ = node["num_points"].at< int >();
+    temp_target->num_points_ = node["num_points"].at<int>();
     const Node points_node = node("points");
     int num_points = parse_target_points(points_node, temp_target->pts_);
     if (num_points != temp_target->num_points_)
@@ -125,15 +125,15 @@ shared_ptr< Target > parse_single_target(const Node& node)
   return (temp_target);
 }  // end parse_single_target
 
-int parse_target_points(const Node& node, std::vector< Point3d > points)
+int parse_target_points(const Node& node, std::vector<Point3d> points)
 {
   ROS_DEBUG_STREAM("FoundPoints: " << node.size());
   points.clear();
   for (int i = 0; i < (int)node.size(); i++)
   {
     const YAML::Node pnt_node = node[i]("pnt");
-    std::vector< float > temp_pnt;
-    temp_pnt = pnt_node.at< std::vector< double > >();
+    std::vector<float> temp_pnt;
+    temp_pnt = pnt_node.at<std::vector<double> >();
     Point3d temp_pnt3d;
     temp_pnt3d.x = temp_pnt[0];
     temp_pnt3d.y = temp_pnt[1];

--- a/industrial_extrinsic_cal/test/ceres_utest.cpp
+++ b/industrial_extrinsic_cal/test/ceres_utest.cpp
@@ -86,11 +86,11 @@ Observation projectPoint(CameraParameters C, Point3d P)
 }
 
 // GLOBAL VARIABLES FOR TESTING
-std::vector< Point3d > created_points;
+std::vector<Point3d> created_points;
 double aa[3];  // angle axis known/set
 double p[3];   // point rotated known/set
-std::vector< Point3d > transformed_points;
-std::vector< Observation > observations;
+std::vector<Point3d> transformed_points;
+std::vector<Observation> observations;
 CameraParameters C;
 
 TEST(IndustrialExtrinsicCalCeresSuite, rotationProduct)

--- a/industrial_extrinsic_cal/test/utest.cpp
+++ b/industrial_extrinsic_cal/test/utest.cpp
@@ -39,17 +39,17 @@ TEST(IndustrialExtrinsicCalSuite, loadCamera)
                                                    yaml_path + caljob_file);
   EXPECT_TRUE(cal_job.load());  // read in cameras, targets, and scenes
   industrial_extrinsic_cal::CeresBlocks* cblocks = cal_job.getBlocks();
-  std::vector< industrial_extrinsic_cal::ObservationScene >* scenes = cal_job.getScenes();
+  std::vector<industrial_extrinsic_cal::ObservationScene>* scenes = cal_job.getScenes();
   // now, compare the data in these to that expected
   EXPECT_EQ((int)scenes->size(), 2);
   EXPECT_EQ((*scenes)[0].get_id(), 0);
   EXPECT_EQ((*scenes)[1].get_id(), 1);
 
   // cursury check to see if the targets were loaded by names
-  boost::shared_ptr< industrial_extrinsic_cal::Target > T1 = boost::make_shared< industrial_extrinsic_cal::Target >();
-  boost::shared_ptr< industrial_extrinsic_cal::Target > T2 = boost::make_shared< industrial_extrinsic_cal::Target >();
-  boost::shared_ptr< industrial_extrinsic_cal::Target > T3 = boost::make_shared< industrial_extrinsic_cal::Target >();
-  boost::shared_ptr< industrial_extrinsic_cal::Target > T4 = boost::make_shared< industrial_extrinsic_cal::Target >();
+  boost::shared_ptr<industrial_extrinsic_cal::Target> T1 = boost::make_shared<industrial_extrinsic_cal::Target>();
+  boost::shared_ptr<industrial_extrinsic_cal::Target> T2 = boost::make_shared<industrial_extrinsic_cal::Target>();
+  boost::shared_ptr<industrial_extrinsic_cal::Target> T3 = boost::make_shared<industrial_extrinsic_cal::Target>();
+  boost::shared_ptr<industrial_extrinsic_cal::Target> T4 = boost::make_shared<industrial_extrinsic_cal::Target>();
   T1 = cblocks->getTargetByName("Chessboard");
   EXPECT_EQ(T1->target_name_, "Chessboard");
   T2 = cblocks->getTargetByName("CircleGrid");
@@ -60,10 +60,10 @@ TEST(IndustrialExtrinsicCalSuite, loadCamera)
   EXPECT_EQ(T4->target_name_, "Balls");
 
   // cursury check to see if the cameras were loaded by names
-  boost::shared_ptr< industrial_extrinsic_cal::Camera > C1 = boost::make_shared< industrial_extrinsic_cal::Camera >();
-  boost::shared_ptr< industrial_extrinsic_cal::Camera > C2 = boost::make_shared< industrial_extrinsic_cal::Camera >();
-  boost::shared_ptr< industrial_extrinsic_cal::Camera > C3 = boost::make_shared< industrial_extrinsic_cal::Camera >();
-  boost::shared_ptr< industrial_extrinsic_cal::Camera > C4 = boost::make_shared< industrial_extrinsic_cal::Camera >();
+  boost::shared_ptr<industrial_extrinsic_cal::Camera> C1 = boost::make_shared<industrial_extrinsic_cal::Camera>();
+  boost::shared_ptr<industrial_extrinsic_cal::Camera> C2 = boost::make_shared<industrial_extrinsic_cal::Camera>();
+  boost::shared_ptr<industrial_extrinsic_cal::Camera> C3 = boost::make_shared<industrial_extrinsic_cal::Camera>();
+  boost::shared_ptr<industrial_extrinsic_cal::Camera> C4 = boost::make_shared<industrial_extrinsic_cal::Camera>();
   C1 = cblocks->getCameraByName("asus1");
   EXPECT_EQ(C1->camera_name_, "asus1");
   C2 = cblocks->getCameraByName("asus2");

--- a/intrinsic_cal/src/rail_cal.cpp
+++ b/intrinsic_cal/src/rail_cal.cpp
@@ -64,8 +64,8 @@ private:
   ros::ServiceServer rail_cal_server_;
   ros::Subscriber rgb_sub_;
   ros::Publisher rgb_pub_;
-  shared_ptr< Target > target_;
-  shared_ptr< Camera > camera_;
+  shared_ptr<Target> target_;
+  shared_ptr<Camera> camera_;
   double focal_length_x_;
   double focal_length_y_;
   double center_x_;
@@ -157,7 +157,7 @@ RailCalService::RailCalService(ros::NodeHandle nh)
 
   u_int32_t queue_size = 5;
   rgb_sub_ = nh_.subscribe("color_image", queue_size, &RailCalService::cameraCallback, this);
-  rgb_pub_ = nh_.advertise< sensor_msgs::Image >("color_image_center", 1);
+  rgb_pub_ = nh_.advertise<sensor_msgs::Image>("color_image_center", 1);
 
   if (!use_quaternion)
   {
@@ -168,9 +168,9 @@ RailCalService::RailCalService(ros::NodeHandle nh)
   }
 
   bool is_moving = true;
-  camera_ = boost::make_shared< industrial_extrinsic_cal::Camera >("my_camera", camera_parameters_, is_moving);
-  camera_->trigger_ = boost::make_shared< NoWaitTrigger >();
-  camera_->camera_observer_ = boost::make_shared< ROSCameraObserver >(image_topic_, camera_name_);
+  camera_ = boost::make_shared<industrial_extrinsic_cal::Camera>("my_camera", camera_parameters_, is_moving);
+  camera_->trigger_ = boost::make_shared<NoWaitTrigger>();
+  camera_->camera_observer_ = boost::make_shared<ROSCameraObserver>(image_topic_, camera_name_);
   if (!camera_->camera_observer_->pullCameraInfo(
           camera_->camera_parameters_.focal_length_x, camera_->camera_parameters_.focal_length_y,
           camera_->camera_parameters_.center_x, camera_->camera_parameters_.center_y,
@@ -341,7 +341,7 @@ bool RailCalService::executeCallBack(intrinsic_cal::rail_ical_run::Request& req,
 
 void RailCalService::initMCircleTarget(int rows, int cols, double circle_dia, double spacing)
 {
-  target_ = boost::make_shared< industrial_extrinsic_cal::Target >();
+  target_ = boost::make_shared<industrial_extrinsic_cal::Target>();
   target_->is_moving_ = true;
   target_->target_name_ = "modified_circle_target";
   target_->target_frame_ = "target_frame";

--- a/rgbd_depth_correction/include/depth_calibration/depth_calibration.h
+++ b/rgbd_depth_correction/include/depth_calibration/depth_calibration.h
@@ -38,9 +38,9 @@
 
 #include "ceres/ceres.h"
 
-template < typename T >
+template <typename T>
 void calculateResidualError(T& a, T& b, T& c, T& d, T& dk, T pt[3], T dp[2], T& error);
-template < typename T >
+template <typename T>
 inline void calculateResidualError(T& a, T& b, T& c, T& d, T& dk, T pt[3], T dp[2], T& residual)
 {
   // depth correction amount
@@ -71,7 +71,7 @@ public:
   {
   }
 
-  template < typename T >
+  template <typename T>
 
   bool operator()(const T* const d_params, /** depth coefficients */
                   T* residual) const
@@ -101,7 +101,7 @@ public:
   static ceres::CostFunction* Create(const double a, const double b, const double c, const double d, const double dk,
                                      const pcl::PointXYZ pt)
   {
-    return (new ceres::AutoDiffCostFunction< DepthError, 1, 2 >(new DepthError(a, b, c, d, dk, pt)));
+    return (new ceres::AutoDiffCostFunction<DepthError, 1, 2>(new DepthError(a, b, c, d, dk, pt)));
   }
 
   double a_;         /** plane equation parameter a */
@@ -172,13 +172,13 @@ private:
   ros::NodeHandle nh_; /**< @brief ROS node handle */
   bool save_data_;     /**< @brief Flag to determine whether to save calibration results or not */
 
-  typedef message_filters::sync_policies::ApproximateTime< sensor_msgs::PointCloud2, sensor_msgs::Image > PolicyType;
-  typedef message_filters::Subscriber< sensor_msgs::PointCloud2 > PointCloudSubscriberType;
-  typedef message_filters::Subscriber< sensor_msgs::Image > ImageSubscriberType;
-  typedef message_filters::Synchronizer< PolicyType > SynchronizerType;
-  boost::shared_ptr< PointCloudSubscriberType > point_cloud_sub_; /**< @brief Point cloud subscriber */
-  boost::shared_ptr< ImageSubscriberType > image_sub_;            /**< @brief RGB image subscriber */
-  boost::shared_ptr< SynchronizerType > synchronizer_; /**< @brief Syncronizer for point cloud and image data */
+  typedef message_filters::sync_policies::ApproximateTime<sensor_msgs::PointCloud2, sensor_msgs::Image> PolicyType;
+  typedef message_filters::Subscriber<sensor_msgs::PointCloud2> PointCloudSubscriberType;
+  typedef message_filters::Subscriber<sensor_msgs::Image> ImageSubscriberType;
+  typedef message_filters::Synchronizer<PolicyType> SynchronizerType;
+  boost::shared_ptr<PointCloudSubscriberType> point_cloud_sub_; /**< @brief Point cloud subscriber */
+  boost::shared_ptr<ImageSubscriberType> image_sub_;            /**< @brief RGB image subscriber */
+  boost::shared_ptr<SynchronizerType> synchronizer_; /**< @brief Syncronizer for point cloud and image data */
 
   ros::ServiceClient get_target_pose_;       /**< @brief Service to call target locator to get target pose */
   ros::ServiceServer calibrate_depth_;       /**< @brief Service to compute depth coefficients d1 and d2 */
@@ -191,25 +191,24 @@ private:
                             calculations */
   std::string filename_; /**< @brief Name of the calibration files to save */
   std::string filepath_; /**< @brief Pathway to the location to save calibration files */
-  geometry_msgs::Pose
-      target_initial_pose_; /**< @brief The initial pose guess of the calibration target for the target finder service
-                               */
+  geometry_msgs::Pose target_initial_pose_; /**< @brief The initial pose guess of the calibration target for the target
+                                             * finder service
+                                               */
 
   double std_dev_error_;          /**< @brief The standard deviation error allowed for finding the target pose */
   double depth_error_threshold_;  /**< @brief The depth error allowed for calculating the pixel depth error map */
   boost::mutex data_lock_;        /**< @brief Lock for data subscription */
   sensor_msgs::Image last_image_; /**< @brief The last color image received */
-  pcl::PointCloud< pcl::PointXYZ > last_cloud_; /**< @brief The last point cloud received */
-  pcl::PointCloud< pcl::PointXYZ >
-      correction_cloud_; /**< @brief The point cloud containing the depth correction values */
-  std::vector< pcl::PointCloud< pcl::PointXYZ >, Eigen::aligned_allocator< pcl::PointCloud< pcl::PointXYZ > > >
-      saved_clouds_;
+  pcl::PointCloud<pcl::PointXYZ> last_cloud_;       /**< @brief The last point cloud received */
+  pcl::PointCloud<pcl::PointXYZ> correction_cloud_; /**< @brief The point cloud containing the depth correction values
+                                                       */
+  std::vector<pcl::PointCloud<pcl::PointXYZ>, Eigen::aligned_allocator<pcl::PointCloud<pcl::PointXYZ> > > saved_clouds_;
   /**< @brief The vector of stored point clouds used to compute the distance coefficients */
-  std::vector< std::vector< double > >
-      plane_equations_;                 /**< @brief A vector of plane equations for each point cloud in saved_clouds_ */
-  std::vector< cv::Mat > saved_images_; /**< @brief A vector of rgb images for each point cloud in saved_clouds_ */
-  std::vector< geometry_msgs::Pose > saved_target_poses_; /**< @brief A vector of target poses for each point cloud in
-                                                             saved_clouds_ */
+  std::vector<std::vector<double> > plane_equations_; /**< @brief A vector of plane equations for each point cloud in
+                                                         saved_clouds_ */
+  std::vector<cv::Mat> saved_images_; /**< @brief A vector of rgb images for each point cloud in saved_clouds_ */
+  std::vector<geometry_msgs::Pose> saved_target_poses_; /**< @brief A vector of target poses for each point cloud in
+                                                           saved_clouds_ */
 
   /**
      * @brief Stores the calibration results in a YAML formated file
@@ -237,9 +236,9 @@ private:
      * @param[out] target_pose The pose of the target found from the last service call
      * @return True if the target was successfully found before the number of failures (num_attempts) was reached
      */
-  bool findAveragePlane(std::vector< double >& plane_eq, geometry_msgs::Pose& target_pose);
+  bool findAveragePlane(std::vector<double>& plane_eq, geometry_msgs::Pose& target_pose);
 
-  bool findAveragePointCloud(pcl::PointCloud< pcl::PointXYZ >& final_cloud);
+  bool findAveragePointCloud(pcl::PointCloud<pcl::PointXYZ>& final_cloud);
 };
 
 #endif  // DEPTH_CALIBRATION_H

--- a/rgbd_depth_correction/src/depth_correction.cpp
+++ b/rgbd_depth_correction/src/depth_correction.cpp
@@ -38,9 +38,9 @@ private:
   bool use_depth_exp_; /**< @brief Flag to determine whether to use the depth coefficients or not */
   double d1_, d2_;     /**< @brief The depth coefficients */
 
-  int version_; /**< @brief The version number found in the YAML file */
-  pcl::PointCloud< pcl::PointXYZ >
-      correction_cloud_; /**< @brief The depth correction point cloud containing the depth correction values */
+  int version_;                                     /**< @brief The version number found in the YAML file */
+  pcl::PointCloud<pcl::PointXYZ> correction_cloud_; /**< @brief The depth correction point cloud containing the depth
+                                                       correction values */
 
   ros::Subscriber pcl_sub_; /**< @brief PCL point cloud subscriber */
   ros::Publisher pcl_pub_;  /**< @brief PCL point cloud publisher for the corrected point cloud */
@@ -52,7 +52,7 @@ private:
      *
      * @param[in] cloud Latest point cloud received
      */
-  void pointcloudCallback(const pcl::PointCloud< pcl::PointXYZ >::ConstPtr& cloud);
+  void pointcloudCallback(const pcl::PointCloud<pcl::PointXYZ>::ConstPtr& cloud);
 
   /**
      * @brief Give a pathway and file name, reads the version number and loads the appropriate depth correction
@@ -78,7 +78,7 @@ private:
      *
      * @param[in] cloud The point cloud to be corrected and republished
      */
-  void correctionVersionOne(const pcl::PointCloud< pcl::PointXYZ >::ConstPtr& cloud);
+  void correctionVersionOne(const pcl::PointCloud<pcl::PointXYZ>::ConstPtr& cloud);
 
 public:
   /**
@@ -137,14 +137,14 @@ public:
 
     ROS_INFO("Done reading yaml file");
 
-    pcl_pub_ = nh.advertise< pcl::PointCloud< pcl::PointXYZ > >("out_cloud", 1);
+    pcl_pub_ = nh.advertise<pcl::PointCloud<pcl::PointXYZ> >("out_cloud", 1);
     pcl_sub_ = nh.subscribe("in_cloud", 1, &DepthCorrectionNodelet::pointcloudCallback, this);
 
     depth_change_ = nh.advertiseService("change_depth_factor", &DepthCorrectionNodelet::setEnableDepth, this);
   }
 };
 
-void DepthCorrectionNodelet::pointcloudCallback(const pcl::PointCloud< pcl::PointXYZ >::ConstPtr& cloud)
+void DepthCorrectionNodelet::pointcloudCallback(const pcl::PointCloud<pcl::PointXYZ>::ConstPtr& cloud)
 {
   switch (version_)
   {
@@ -210,9 +210,9 @@ void DepthCorrectionNodelet::loadVersionOne(const YAML::Node& doc, const std::st
   pcl::io::loadPCDFile(pcd_file, correction_cloud_);
 }
 
-void DepthCorrectionNodelet::correctionVersionOne(const pcl::PointCloud< pcl::PointXYZ >::ConstPtr& cloud)
+void DepthCorrectionNodelet::correctionVersionOne(const pcl::PointCloud<pcl::PointXYZ>::ConstPtr& cloud)
 {
-  pcl::PointCloud< pcl::PointXYZ > corrected_cloud = *cloud;
+  pcl::PointCloud<pcl::PointXYZ> corrected_cloud = *cloud;
   if (correction_cloud_.points.size() == cloud->points.size())
   {
     for (int i = 0; i < corrected_cloud.points.size(); ++i)
@@ -239,7 +239,7 @@ void DepthCorrectionNodelet::correctionVersionOne(const pcl::PointCloud< pcl::Po
                                   "performing depth correction");
   }
 
-  pcl::PointCloud< pcl::PointXYZ >::Ptr published_cloud = corrected_cloud.makeShared();
+  pcl::PointCloud<pcl::PointXYZ>::Ptr published_cloud = corrected_cloud.makeShared();
   pcl_pub_.publish(published_cloud);
 }
 

--- a/target_finder/src/nodes/call_service.cpp
+++ b/target_finder/src/nodes/call_service.cpp
@@ -34,7 +34,7 @@ class callService
 public:
   callService(ros::NodeHandle nh) : nh_(nh)
   {
-    client_ = nh_.serviceClient< target_finder::target_locater >("TargetLocateService");
+    client_ = nh_.serviceClient<target_finder::target_locater>("TargetLocateService");
     ros::NodeHandle pnh("~");
     if (!pnh.getParam("roi_width", roi_width_))
     {

--- a/target_finder/src/nodes/dual_camera_cs.cpp
+++ b/target_finder/src/nodes/dual_camera_cs.cpp
@@ -48,8 +48,8 @@ public:
     }
     ROS_INFO("C1 service = %s", c1_cs.c_str());
     ROS_INFO("C2 service = %s", c2_cs.c_str());
-    c1_client_ = nh_.serviceClient< target_finder::target_locater >(c1_cs.c_str());
-    c2_client_ = nh_.serviceClient< target_finder::target_locater >(c2_cs.c_str());
+    c1_client_ = nh_.serviceClient<target_finder::target_locater>(c1_cs.c_str());
+    c2_client_ = nh_.serviceClient<target_finder::target_locater>(c2_cs.c_str());
 
     if (!pnh.getParam("c1_roi_width", c1_roi_width_))
     {

--- a/target_finder/src/nodes/grid_generator.cpp
+++ b/target_finder/src/nodes/grid_generator.cpp
@@ -78,7 +78,7 @@ int main(int argc, char** argv)
     ROS_ERROR("Must set param:  transform_interface");
   }
   // generate points
-  std::vector< Point3d > pts;
+  std::vector<Point3d> pts;
   pts.clear();
   for (int i = 0; i < rows; i++)
   {

--- a/target_finder/src/nodes/target_locator.cpp
+++ b/target_finder/src/nodes/target_locator.cpp
@@ -55,7 +55,7 @@ public:
 private:
   ros::NodeHandle nh_;
   ros::ServiceServer target_locate_server_;
-  shared_ptr< Target > target_;
+  shared_ptr<Target> target_;
   string image_topic_;
   string camera_name_;
   int target_type_;
@@ -212,7 +212,7 @@ bool TargetLocatorService::executeCallBack(target_locater::Request& req, target_
 
 void TargetLocatorService::initMCircleTarget(int rows, int cols, double circle_dia, double spacing)
 {
-  target_ = make_shared< industrial_extrinsic_cal::Target >();
+  target_ = make_shared<industrial_extrinsic_cal::Target>();
   target_->is_moving_ = true;
   target_->target_name_ = "modified_circle_target";
   target_->target_frame_ = "target_frame";
@@ -239,7 +239,7 @@ void TargetLocatorService::initMCircleTarget(int rows, int cols, double circle_d
 
 void TargetLocatorService::initBallsTarget()
 {
-  target_ = make_shared< industrial_extrinsic_cal::Target >();
+  target_ = make_shared<industrial_extrinsic_cal::Target>();
   target_->target_name_ = "four_ball_target";
   target_->target_frame_ = "target_frame";
   target_->target_type_ = 4;


### PR DESCRIPTION
There used to be an issue with formatting templated arguments where clang would not put a space in between the close angle brackets (>>) which would cause build failures.  That is why I originally set spaces in angled brackets to true.  They must have fixed the formatting issue.  I have removed the spaces now and tested to make sure that the code still builds.