### PR TITLE
Replace `xacro.py` to `xacro --inorder`

### DIFF
--- a/industrial_extrinsic_cal/launch/rangeNmono.launch
+++ b/industrial_extrinsic_cal/launch/rangeNmono.launch
@@ -72,7 +72,7 @@
 
 
    <!-- Load the xacro file of the cameras and target onto the parameter server as a robot description -->
-   <param name="$(arg robot1)/robot_description" command="$(find xacro)/xacro.py $(arg xacro_model)" />
+   <param name="$(arg robot1)/robot_description" command="$(find xacro)/xacro --inorder $(arg xacro_model)" />
    <param name="use_gui" value="$(arg gui)" />
 
    <!-- Launch robot state publishers for scene -->

--- a/industrial_extrinsic_cal/launch/range_camera_excal.launch
+++ b/industrial_extrinsic_cal/launch/range_camera_excal.launch
@@ -51,7 +51,7 @@
 
 
    <!-- Load the xacro file of the cameras and target onto the parameter server as a robot description -->
-   <param name="$(arg robot1)/robot_description" command="$(find xacro)/xacro.py $(arg xacro_model)" />
+   <param name="$(arg robot1)/robot_description" command="$(find xacro)/xacro --inorder $(arg xacro_model)" />
    <param name="use_gui" value="$(arg gui)" />
 
    <!-- Launch robot state publishers for scene -->

--- a/target_finder/launch/dual_tl_wg.launch
+++ b/target_finder/launch/dual_tl_wg.launch
@@ -100,7 +100,7 @@
    <arg name="xacro_model" default="$(find target_finder)/urdf/dual_camera_ical.xacro" />
 
    <!-- Load the xacro file of the cameras and target onto the parameter server as a robot description -->
-   <param name="$(arg robot1)/robot_description" command="$(find xacro)/xacro.py $(arg xacro_model)" />
+   <param name="$(arg robot1)/robot_description" command="$(find xacro)/xacro --inorder $(arg xacro_model)" />
    <param name="use_gui" value="$(arg gui)" />
 
    <!-- Launch robot state publishers for scene -->


### PR DESCRIPTION
This PR fixes https://github.com/ros-industrial/industrial_training/issues/220 issue.

Environment:
- OS: Ubuntu 16.04
- ROS: Kinetic