### PR TITLE
Use ceres binary dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
-sudo: required 
-dist: xenial 
-language: generic 
+sudo: required
+dist: xenial
+language: generic
 compiler:
   - gcc
 notifications:
@@ -11,12 +11,11 @@ env:
   global:
     - ROS_DISTRO=kinetic
     - UPSTREAM_WORKSPACE=file
-    - ROSINSTALL_FILENAME=industrial_calibration.rosinstall
     - NOT_TEST_INSTALL=true
   matrix:
     - ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
 install:
   - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
-script: 
+script:
   - source .ci_config/travis.sh
 

--- a/README.md
+++ b/README.md
@@ -25,32 +25,38 @@ Status: [![Build Status](https://travis-ci.org/ros-industrial/industrial_calibra
 
 Contains libraries/algorithms for calibration industrial systems
 
-# Requires
-# install ceres-solver(Note, there might be a .deb that works)
-#    follow instructions on http://ceres-solver.org/installation.html#linux
+## Requires
 
-# install openni2
+### Ceres Optimizer
+
+- With apt: `sudo apt install libceres-dev`
+- With [rosdep](http://docs.ros.org/independent/api/rosdep/html/):
+  `rosdep install industrial_extrinsic_cal` or
+  `rosdep install --from-paths industrial_calibration/`
+
+### Openni2
+```
 sudo apt-get install ros-kinetic-openni2-camera
 sudo apt-get install ros-kinetic-openni2-launch
+```
 
-# install moveit
-sudo apt-get install ros-kinetic-moveit
+### Moveit
+`sudo apt-get install ros-kinetic-moveit`
 
 # Examples
+
 ## Single Basler on a rail
 ```
 roslaunch robocyl_ical.launch
 roslaunch robo_cylinder.launch
 rosservice call /RobocylCalService "allowable_cost_per_observation: 0.25"
+```
 
 # Build
-Requires [wstool](http://wiki.ros.org/wstool)
 ```
 mkdir -p cal_ws/src
 cd cal_ws/src
-git clone -b kinetic https://github.com/ros-industrial/industrial_calibration.git
-wstool merge industrial_calibration/industrial_calibration.rosinstall
-wstool update
+git clone -b kinetic-devel https://github.com/ros-industrial/industrial_calibration.git
 cd ..
 catkin build
 ```

--- a/industrial_calibration.rosinstall
+++ b/industrial_calibration.rosinstall
@@ -1,1 +1,0 @@
-- git: {local-name: ceres-solver, uri: 'https://github.com/ceres-solver/ceres-solver.git', version: master}

--- a/industrial_extrinsic_cal/package.xml
+++ b/industrial_extrinsic_cal/package.xml
@@ -33,7 +33,7 @@
   <depend>tf</depend>
   <depend>tf_conversions</depend>
   <depend>yaml-cpp</depend>
-  <depend>ceres-solver</depend>
+  <depend>libceres-dev</depend>
 
   <build_depend>boost</build_depend>
   <build_depend>message_generation</build_depend>

--- a/intrinsic_cal/package.xml
+++ b/intrinsic_cal/package.xml
@@ -23,7 +23,7 @@
   <depend>roslib</depend>
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>
-  <depend>ceres-solver</depend>
+  <depend>libceres-dev</depend>
 
   <build_depend>message_generation</build_depend>
   <build_depend>robo_cylinder</build_depend>

--- a/rgbd_depth_correction/package.xml
+++ b/rgbd_depth_correction/package.xml
@@ -34,7 +34,7 @@
   <depend>tf_conversions</depend>
   <depend>target_finder</depend>
   <depend>yaml-cpp</depend>
-  <depend>ceres-solver</depend>
+  <depend>libceres-dev</depend>
 
   <exec_depend>image_view</exec_depend>
   <exec_depend>joint_state_publisher</exec_depend>

--- a/target_finder/package.xml
+++ b/target_finder/package.xml
@@ -26,7 +26,7 @@
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>
   <depend>tf</depend>
-  <depend>ceres-solver</depend>
+  <depend>libceres-dev</depend>
 
   <build_depend>boost</build_depend>
   <build_depend>message_generation</build_depend>


### PR DESCRIPTION
Past discussion in #109 and [#62](https://github.com/ros-industrial/industrial_calibration/pull/62#issuecomment-156073773) seemed to converge on using the ceres binary dependency, but `kinetic-devel` still has a dependency on `ceres-solver`. As it builds fine with the system ceres package, any reason we shouldn't switch this dependency?