### PR TITLE
Change Ceres/OpenCV version message to STATUS type

### DIFF
--- a/industrial_extrinsic_cal/CMakeLists.txt
+++ b/industrial_extrinsic_cal/CMakeLists.txt
@@ -27,11 +27,11 @@ find_package(catkin REQUIRED COMPONENTS
 find_package(Boost REQUIRED)
 
 find_package(Ceres REQUIRED)
-message("-- Found Ceres version ${CERES_VERSION}: ${CERES_INCLUDE_DIRS}")
+message(STATUS "-- Found Ceres version ${CERES_VERSION}: ${CERES_INCLUDE_DIRS}")
 
 find_package(OpenCV REQUIRED)
 
-message("-- Found OpenCV version ${OpenCV_VERSION}: ${OpenCV_INCLUDE_DIRS}")
+message(STATUS "-- Found OpenCV version ${OpenCV_VERSION}: ${OpenCV_INCLUDE_DIRS}")
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(yaml_cpp REQUIRED yaml-cpp)

--- a/intrinsic_cal/CMakeLists.txt
+++ b/intrinsic_cal/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 find_package(Ceres REQUIRED)
-message("-- Found Ceres version ${CERES_VERSION}: ${CERES_INCLUDE_DIRS}")
+message(STATUS "-- Found Ceres version ${CERES_VERSION}: ${CERES_INCLUDE_DIRS}")
 
 #set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-fPIC")
 find_package(PkgConfig REQUIRED)

--- a/rgbd_depth_correction/CMakeLists.txt
+++ b/rgbd_depth_correction/CMakeLists.txt
@@ -24,7 +24,7 @@ find_package(catkin REQUIRED COMPONENTS
 find_package(Boost REQUIRED COMPONENTS thread)
 
 find_package(Ceres REQUIRED)
-message("-- Found Ceres version ${CERES_VERSION}: ${CERES_INCLUDE_DIRS}")
+message(STATUS "-- Found Ceres version ${CERES_VERSION}: ${CERES_INCLUDE_DIRS}")
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(yaml_cpp REQUIRED yaml-cpp)

--- a/target_finder/CMakeLists.txt
+++ b/target_finder/CMakeLists.txt
@@ -21,7 +21,7 @@ find_package(catkin REQUIRED COMPONENTS
 find_package(Boost REQUIRED)
 
 find_package(Ceres REQUIRED)
-message("-- Found Ceres version ${CERES_VERSION}: ${CERES_INCLUDE_DIRS}")
+message(STATUS "-- Found Ceres version ${CERES_VERSION}: ${CERES_INCLUDE_DIRS}")
 
 
 add_service_files(


### PR DESCRIPTION
This avoids it showing up as a build error in IDEs such as QTCreator. Here is the description of the types from the CMake Docs
(none)         = Important information
STATUS         = Incidental information