### PR TITLE
Hand-eye calibration analysis update and addition of 3D projection analysis

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,10 +39,11 @@ add_library(
   src/optimizations/analysis/camera_intrinsic_calibration_analysis.cpp
   src/optimizations/analysis/covariance_types.cpp
   src/optimizations/analysis/covariance_analysis.cpp
+  src/optimizations/analysis/extrinsic_hand_eye_calibration_analysis.cpp
   src/optimizations/analysis/homography_analysis.cpp
-  src/optimizations/analysis/statistics.cpp
   src/optimizations/analysis/noise_qualification.cpp
   src/optimizations/analysis/projection.cpp
+  src/optimizations/analysis/statistics.cpp
   # Target Finders
   src/target_finders/circle_detector.cpp
   src/target_finders/target_finder.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ add_library(
   src/optimizations/analysis/homography_analysis.cpp
   src/optimizations/analysis/statistics.cpp
   src/optimizations/analysis/noise_qualification.cpp
+  src/optimizations/analysis/projection.cpp
   # Target Finders
   src/target_finders/circle_detector.cpp
   src/target_finders/target_finder.cpp

--- a/examples/extrinsic_hand_eye.cpp
+++ b/examples/extrinsic_hand_eye.cpp
@@ -147,6 +147,9 @@ std::tuple<ExtrinsicHandEyeResult, ExtrinsicHandEyeAnalysisStats> run(const path
   printOptResults(opt_result.converged, opt_result.initial_cost_per_obs, opt_result.final_cost_per_obs);
   std::cout << std::endl;
 
+  // Compute the projected 3D error for comparison
+  std::cout << analyze3dProjectionError(problem, opt_result) << std::endl << std::endl;
+
   Eigen::Isometry3d c = opt_result.camera_mount_to_camera;
   printTransform(c, "Camera Mount", "Camera", "CAMERA MOUNT TO CAMERA");
   std::cout << std::endl;

--- a/examples/extrinsic_hand_eye.cpp
+++ b/examples/extrinsic_hand_eye.cpp
@@ -86,7 +86,7 @@ std::tuple<ExtrinsicHandEyeResult, ExtrinsicHandEyeAnalysisStats> run(const path
 
   // The target may not be identified in all images, so let's keep track the indices of the images for which the
   // target was identified
-  std::vector<cv::Mat> found_images;
+  std::vector<std::size_t> found_images;
   found_images.reserve(images.size());
 
   for (std::size_t i = 0; i < images.size(); ++i)
@@ -119,7 +119,7 @@ std::tuple<ExtrinsicHandEyeResult, ExtrinsicHandEyeAnalysisStats> run(const path
 
       // Add the observations to the problem
       problem.observations.push_back(obs);
-      found_images.push_back(images[i]);
+      found_images.push_back(i);
 
 #ifndef INDUSTRIAL_CALIBRATION_ENABLE_TESTING
       // Show the points we detected
@@ -169,7 +169,7 @@ std::tuple<ExtrinsicHandEyeResult, ExtrinsicHandEyeAnalysisStats> run(const path
 
 #ifndef INDUSTRIAL_CALIBRATION_ENABLE_TESTING
   // Reproject the target points into the image using the results of the calibration and visualize
-  for (std::size_t i = 0; i < found_images.size(); ++i)
+  for (std::size_t i = 0; i < problem.observations.size(); ++i)
   {
     const Observation2D3D& obs = problem.observations.at(i);
 
@@ -177,7 +177,7 @@ std::tuple<ExtrinsicHandEyeResult, ExtrinsicHandEyeAnalysisStats> run(const path
     Eigen::Isometry3d camera_to_target = opt_result.camera_mount_to_camera.inverse() * obs.to_camera_mount.inverse() *
                                          obs.to_target_mount * opt_result.target_mount_to_target;
 
-    reproject(camera_to_target, obs.correspondence_set, problem.intr, found_images[i]);
+    reproject(camera_to_target, obs.correspondence_set, problem.intr, images.at(found_images.at(i)));
   }
 #endif
 

--- a/examples/extrinsic_hand_eye.cpp
+++ b/examples/extrinsic_hand_eye.cpp
@@ -162,13 +162,7 @@ std::tuple<ExtrinsicHandEyeResult, ExtrinsicHandEyeAnalysisStats> run(const path
   // parameters We will then see how much this transform differs from the same transform calculated using the results
   // of the extrinsic calibration
   ExtrinsicHandEyeAnalysisStats stats = analyzeResults(problem, opt_result);
-
-  std::cout << "Difference in camera to target transform between extrinsic calibration and PnP optimization"
-            << std::endl;
-  std::cout << "Position:\n\tMean (m): " << stats.pos_diff_mean << "\n\tStd. Dev. (m): " << stats.pos_diff_stdev
-            << std::endl;
-  std::cout << "Orientation:\n\tMean (deg): " << stats.ori_diff_mean * 180.0 / M_PI
-            << "\n\tStd. Dev. (deg): " << stats.ori_diff_stdev * 180.0 / M_PI << std::endl;
+  std::cout << stats << std::endl << std::endl;
 
 #ifndef INDUSTRIAL_CALIBRATION_ENABLE_TESTING
   // Reproject the target points into the image using the results of the calibration and visualize

--- a/include/industrial_calibration/optimizations/analysis/extrinsic_hand_eye_calibration_analysis.h
+++ b/include/industrial_calibration/optimizations/analysis/extrinsic_hand_eye_calibration_analysis.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <ostream>
+
 namespace industrial_calibration
 {
 class ExtrinsicHandEyeProblem2D3D;
@@ -16,6 +18,7 @@ struct ExtrinsicHandEyeAnalysisStats
   double ori_diff_mean;
   double ori_diff_stdev;
 };
+std::ostream& operator<<(std::ostream& stream, const ExtrinsicHandEyeAnalysisStats& stats);
 
 /**
  * @brief Analyzes the results of the hand eye calibration by measuring the difference between the calibrated camera to
@@ -34,6 +37,7 @@ struct ExtrinsicHandEye3dProjectionStats
   double mean;
   double stdev;
 };
+std::ostream& operator<<(std::ostream& stream, const ExtrinsicHandEye3dProjectionStats& stats);
 
 ExtrinsicHandEye3dProjectionStats analyze3dProjectionError(const ExtrinsicHandEyeProblem2D3D& problem,
                                                            const ExtrinsicHandEyeResult& opt_result);

--- a/include/industrial_calibration/optimizations/analysis/extrinsic_hand_eye_calibration_analysis.h
+++ b/include/industrial_calibration/optimizations/analysis/extrinsic_hand_eye_calibration_analysis.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <industrial_calibration/optimizations/extrinsic_hand_eye.h>
+
+namespace industrial_calibration
+{
+/**
+ * @brief Position and orientation difference/standard deviation between the location of the camera as determined by the
+ * extrinsic calibration vs the per-observation PnP estimations
+ */
+struct ExtrinsicHandEyeAnalysisStats
+{
+  double pos_diff_mean;
+  double pos_diff_stdev;
+  double ori_diff_mean;
+  double ori_diff_stdev;
+};
+
+/**
+ * @brief Analyzes the results of the hand eye calibration by measuring the difference between the calibrated camera to
+ * target transform and a PnP optimization estimation of the same transform
+ */
+ExtrinsicHandEyeAnalysisStats analyzeResults(const ExtrinsicHandEyeProblem2D3D& problem,
+                                             const ExtrinsicHandEyeResult& opt_result);
+
+}  // namespace industrial_calibration

--- a/include/industrial_calibration/optimizations/analysis/extrinsic_hand_eye_calibration_analysis.h
+++ b/include/industrial_calibration/optimizations/analysis/extrinsic_hand_eye_calibration_analysis.h
@@ -1,9 +1,10 @@
 #pragma once
 
-#include <industrial_calibration/optimizations/extrinsic_hand_eye.h>
-
 namespace industrial_calibration
 {
+class ExtrinsicHandEyeProblem2D3D;
+class ExtrinsicHandEyeResult;
+
 /**
  * @brief Position and orientation difference/standard deviation between the location of the camera as determined by the
  * extrinsic calibration vs the per-observation PnP estimations
@@ -22,5 +23,19 @@ struct ExtrinsicHandEyeAnalysisStats
  */
 ExtrinsicHandEyeAnalysisStats analyzeResults(const ExtrinsicHandEyeProblem2D3D& problem,
                                              const ExtrinsicHandEyeResult& opt_result);
+
+/**
+ * @brief 3D reprojection error statistics (m)
+ */
+struct ExtrinsicHandEye3dProjectionStats
+{
+  double min;
+  double max;
+  double mean;
+  double stdev;
+};
+
+ExtrinsicHandEye3dProjectionStats analyze3dProjectionError(const ExtrinsicHandEyeProblem2D3D& problem,
+                                                           const ExtrinsicHandEyeResult& opt_result);
 
 }  // namespace industrial_calibration

--- a/include/industrial_calibration/optimizations/analysis/projection.h
+++ b/include/industrial_calibration/optimizations/analysis/projection.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <industrial_calibration/camera_intrinsics.h>
+#include <industrial_calibration/types.h>
+
+#include <Eigen/Dense>
+
+namespace industrial_calibration
+{
+/**
+ * @brief Computes the vector from an input point on a line to the point where the line intersects with the input plane
+ * See <a href=https://en.wikipedia.org/wiki/Line%E2%80%93plane_intersection>this link</a> for more information
+ * @param plane_normal Unit normal vector defining the plane
+ * @param plane_pt Point on the plane
+ * @param line Unit vector defining the line
+ * @param line_pt Point on the line
+ * @param epsilon
+ */
+Eigen::Vector3d computeLinePlaneIntersection(const Eigen::Vector3d& plane_normal, const Eigen::Vector3d& plane_pt,
+                                             const Eigen::Vector3d& line, const Eigen::Vector3d& line_pt,
+                                             const double epsilon = 1.0e-6);
+
+/**
+ * @brief Projects a set of 2D source points (e.g., from an image observation) onto a 3D plane (e.g., a flat calibration
+ * target)
+ * @param source Set of 2D points
+ * @param source_to_plane Matrix that transforms the source points into the frame of the plane (e.g., camera to target
+ * transform)
+ * @param k 3x3 camera projection matrix
+ * @return
+ */
+Eigen::MatrixX3d project3D(const Eigen::MatrixX2d& source, const Eigen::Isometry3d& source_to_plane,
+                           const Eigen::Matrix3d& k);
+
+/**
+ * @brief Projects the 2D target features from an observation onto the 3D plane of the calibrated target and computes
+ * the difference between the projections and the known target features
+ */
+Eigen::ArrayXd compute3DProjectionError(const Observation2D3D& obs, const CameraIntrinsics& intr,
+                                        const Eigen::Isometry3d& camera_mount_to_camera,
+                                        const Eigen::Isometry3d& target_mount_to_target);
+
+/**
+ * @brief Projects the 2D target features from a set of observations onto the 3D plane of the calibrated target and
+ * computes the difference between the projections and the known target features
+ */
+Eigen::ArrayXd compute3DProjectionError(const Observation2D3D::Set& obs, const CameraIntrinsics& intr,
+                                        const Eigen::Isometry3d& camera_mount_to_camera,
+                                        const Eigen::Isometry3d& target_mount_to_target);
+
+}  // namespace industrial_calibration

--- a/src/optimizations/analysis/extrinsic_hand_eye_calibration_analysis.cpp
+++ b/src/optimizations/analysis/extrinsic_hand_eye_calibration_analysis.cpp
@@ -1,5 +1,7 @@
 #include <industrial_calibration/optimizations/analysis/extrinsic_hand_eye_calibration_analysis.h>
 #include <industrial_calibration/optimizations/analysis/statistics.h>
+#include <industrial_calibration/optimizations/analysis/projection.h>
+#include <industrial_calibration/optimizations/extrinsic_hand_eye.h>
 #include <industrial_calibration/optimizations/pnp.h>
 
 namespace industrial_calibration
@@ -42,6 +44,22 @@ ExtrinsicHandEyeAnalysisStats analyzeResults(const ExtrinsicHandEyeProblem2D3D& 
   ExtrinsicHandEyeAnalysisStats stats;
   std::tie(stats.pos_diff_mean, stats.pos_diff_stdev) = computeStats(pos_diff_acc);
   std::tie(stats.ori_diff_mean, stats.ori_diff_stdev) = computeStats(ori_diff_acc);
+
+  return stats;
+}
+
+ExtrinsicHandEye3dProjectionStats analyze3dProjectionError(const ExtrinsicHandEyeProblem2D3D& problem,
+                                                           const ExtrinsicHandEyeResult& opt_result)
+{
+  Eigen::ArrayXd error = compute3DProjectionError(problem.observations, problem.intr, opt_result.camera_mount_to_camera,
+                                                  opt_result.target_mount_to_target);
+
+  // Compute stats
+  ExtrinsicHandEye3dProjectionStats stats;
+  stats.mean = error.mean();
+  stats.stdev = std::sqrt((error - error.mean()).square().sum() / (error.size() - 1));
+  stats.min = error.minCoeff();
+  stats.max = error.maxCoeff();
 
   return stats;
 }

--- a/src/optimizations/analysis/extrinsic_hand_eye_calibration_analysis.cpp
+++ b/src/optimizations/analysis/extrinsic_hand_eye_calibration_analysis.cpp
@@ -1,0 +1,49 @@
+#include <industrial_calibration/optimizations/analysis/extrinsic_hand_eye_calibration_analysis.h>
+#include <industrial_calibration/optimizations/analysis/statistics.h>
+#include <industrial_calibration/optimizations/pnp.h>
+
+namespace industrial_calibration
+{
+ExtrinsicHandEyeAnalysisStats analyzeResults(const ExtrinsicHandEyeProblem2D3D& problem,
+                                             const ExtrinsicHandEyeResult& opt_result)
+{
+  // Create accumulators to more easily calculate the mean and standard deviation of the position and orientation
+  // differences
+  std::vector<double> pos_diff_acc, ori_diff_acc;
+  pos_diff_acc.reserve(problem.observations.size());
+  ori_diff_acc.reserve(problem.observations.size());
+
+  // Iterate over all of the images in which an observation of the target was made
+  for (std::size_t i = 0; i < problem.observations.size(); ++i)
+  {
+    // Get the observation
+    const Observation2D3D& obs = problem.observations.at(i);
+
+    // Calculate the optimized transform from the camera to the target for the ith observation
+    Eigen::Isometry3d camera_to_target = opt_result.camera_mount_to_camera.inverse() * obs.to_camera_mount.inverse() *
+                                         obs.to_target_mount * opt_result.target_mount_to_target;
+
+    // Get the same transformation from a PnP optimization with the known camera intrinsic parameters
+    PnPProblem pnp;
+    pnp.camera_to_target_guess = camera_to_target;
+    pnp.correspondences = obs.correspondence_set;
+    pnp.intr = problem.intr;
+    PnPResult pnp_result = optimize(pnp);
+
+    // Calculate the difference between the two transforms
+    Eigen::Isometry3d diff = camera_to_target.inverse() * pnp_result.camera_to_target;
+
+    // Accumulate the differences
+    pos_diff_acc.push_back(diff.translation().norm());
+    ori_diff_acc.push_back(Eigen::Quaterniond(camera_to_target.linear())
+                               .angularDistance(Eigen::Quaterniond(pnp_result.camera_to_target.linear())));
+  }
+
+  ExtrinsicHandEyeAnalysisStats stats;
+  std::tie(stats.pos_diff_mean, stats.pos_diff_stdev) = computeStats(pos_diff_acc);
+  std::tie(stats.ori_diff_mean, stats.ori_diff_stdev) = computeStats(ori_diff_acc);
+
+  return stats;
+}
+
+}  // namespace industrial_calibration

--- a/src/optimizations/analysis/extrinsic_hand_eye_calibration_analysis.cpp
+++ b/src/optimizations/analysis/extrinsic_hand_eye_calibration_analysis.cpp
@@ -6,6 +6,15 @@
 
 namespace industrial_calibration
 {
+std::ostream& operator<<(std::ostream& stream, const ExtrinsicHandEyeAnalysisStats& stats)
+{
+  stream << "Difference in camera to target transform between extrinsic calibration and PnP optimization\n"
+         << "Position:\n\tMean (m): " << stats.pos_diff_mean << "\n\tStd. Dev. (m): " << stats.pos_diff_stdev << "\n"
+         << "Orientation:\n\tMean (deg): " << stats.ori_diff_mean * 180.0 / M_PI
+         << "\n\tStd. Dev. (deg): " << stats.ori_diff_stdev * 180.0 / M_PI;
+  return stream;
+}
+
 ExtrinsicHandEyeAnalysisStats analyzeResults(const ExtrinsicHandEyeProblem2D3D& problem,
                                              const ExtrinsicHandEyeResult& opt_result)
 {
@@ -46,6 +55,14 @@ ExtrinsicHandEyeAnalysisStats analyzeResults(const ExtrinsicHandEyeProblem2D3D& 
   std::tie(stats.ori_diff_mean, stats.ori_diff_stdev) = computeStats(ori_diff_acc);
 
   return stats;
+}
+
+std::ostream& operator<<(std::ostream& stream, const ExtrinsicHandEye3dProjectionStats& stats)
+{
+  stream << "3D reprojection error statistics:"
+         << "\n\tMean +/- Std. Dev. (m): " << stats.mean << " +/- " << stats.stdev << "\n\tMin (m): " << stats.min
+         << "\n\tMax (m): " << stats.max;
+  return stream;
 }
 
 ExtrinsicHandEye3dProjectionStats analyze3dProjectionError(const ExtrinsicHandEyeProblem2D3D& problem,

--- a/src/optimizations/analysis/projection.cpp
+++ b/src/optimizations/analysis/projection.cpp
@@ -1,0 +1,106 @@
+#include <industrial_calibration/optimizations/analysis/projection.h>
+
+namespace industrial_calibration
+{
+Eigen::Vector3d computeLinePlaneIntersection(const Eigen::Vector3d& plane_normal, const Eigen::Vector3d& plane_pt,
+                                             const Eigen::Vector3d& line, const Eigen::Vector3d& line_pt,
+                                             const double epsilon)
+{
+  double dp = line.dot(plane_normal);
+  if (std::abs(dp) < epsilon)
+    throw std::runtime_error("No intersection between line and plane because they are parallel");
+
+  // Solve for the distance from line_pt to the plane: d = ((plane_pt - line_pt) * plane_normal) / (line * plane_normal)
+  double d = (plane_pt - line_pt).dot(plane_normal) / dp;
+
+  // Compute a new point at distance d along line from line_pt
+  return line_pt + line * d;
+}
+
+Eigen::MatrixX3d project3D(const Eigen::MatrixX2d& source, const Eigen::Isometry3d& source_to_plane,
+                           const Eigen::Matrix3d& k)
+{
+  const Eigen::Index n = source.rows();
+
+  // Convert 2D source points to 3D homogeneous coordinates
+  Eigen::MatrixX3d source_3d(n, 3);
+  source_3d.block(0, 0, n, 2) = source;
+  source_3d.col(2) = Eigen::VectorXd::Ones(n);
+
+  // Using camera as reference frame
+  Eigen::Vector3d plane_normal = source_to_plane.matrix().col(2).head<3>();  // Plane z-axis in source frame
+  Eigen::Vector3d plane_pt = source_to_plane.translation();                  // Plane origin in source frame
+  Eigen::Vector3d camera_origin = Eigen::Vector3d::Zero();
+
+  // Create 3D unit vector rays for each 3D coorindate in the camera frame
+  Eigen::MatrixX3d rays_in_camera = (k.inverse() * source_3d.transpose()).transpose();
+  rays_in_camera.rowwise().normalize();
+
+  Eigen::MatrixX3d projected_source_3d(n, 3);
+  for (Eigen::Index i = 0; i < n; ++i)
+    projected_source_3d.row(i) =
+        computeLinePlaneIntersection(plane_normal, plane_pt, rays_in_camera.row(i), camera_origin);
+
+  // Transform the projected source points into the plane frame
+  //   First convert 3D projected source points into 4D homogeneous coordinates
+  Eigen::MatrixX4d projected_source_4d(n, 4);
+  projected_source_4d.block(0, 0, n, 3) = projected_source_3d;
+  projected_source_4d.col(3) = Eigen::VectorXd::Ones(n);
+  //   Apply the transform
+  Eigen::MatrixX4d projected_source_4d_in_plane =
+      (source_to_plane.inverse() * projected_source_4d.transpose()).transpose();
+
+  // Return only the 3D points in matrix form
+  return projected_source_4d_in_plane.block(0, 0, n, 3);
+}
+
+Eigen::ArrayXd compute3DProjectionError(const Observation2D3D& obs, const CameraIntrinsics& intr,
+                                        const Eigen::Isometry3d& camera_mount_to_camera,
+                                        const Eigen::Isometry3d& target_mount_to_target)
+{
+  Eigen::Matrix3d camera_matrix;
+  camera_matrix << intr.fx(), 0.0, intr.cx(), 0.0, intr.fy(), intr.cy(), 0.0, 0.0, 1.0;
+
+  // Calculate the optimized transform from the camera to the target for the ith observation
+  Eigen::Isometry3d camera_to_target =
+      camera_mount_to_camera.inverse() * obs.to_camera_mount.inverse() * obs.to_target_mount * target_mount_to_target;
+
+  // Convert the image and target features to matrices
+  const Eigen::Index n = static_cast<Eigen::Index>(obs.correspondence_set.size());
+  Eigen::MatrixX2d image_features(n, 2);
+  Eigen::MatrixX3d target_features(n, 3);
+  for (Eigen::Index i = 0; i < n; ++i)
+  {
+    image_features.row(i) = obs.correspondence_set[i].in_image;
+    target_features.row(i) = obs.correspondence_set[i].in_target;
+  }
+
+  // Project the image features onto the 3D target plane
+  Eigen::MatrixX3d projected_image_features_in_target = project3D(image_features, camera_to_target, camera_matrix);
+
+  // Compute the error
+  Eigen::ArrayXd error = (target_features - projected_image_features_in_target).rowwise().norm().array();
+
+  return error;
+}
+
+Eigen::ArrayXd compute3DProjectionError(const Observation2D3D::Set& observations, const CameraIntrinsics& intr,
+                                        const Eigen::Isometry3d& camera_mount_to_camera,
+                                        const Eigen::Isometry3d& target_mount_to_target)
+{
+  Eigen::ArrayXd error;
+
+  // Iterate over all of the images in which an observation of the target was made
+  for (const Observation2D3D& obs : observations)
+  {
+    Eigen::Index n = static_cast<Eigen::Index>(obs.correspondence_set.size());
+
+    // Append the projection error
+    error.conservativeResize(error.rows() + n);
+    error.tail(n) = compute3DProjectionError(obs, intr, camera_mount_to_camera, target_mount_to_target);
+  }
+
+  return error;
+}
+
+}  // namespace industrial_calibration


### PR DESCRIPTION
This PR moves several extrinsic hand-eye calibration analysis utilities out of the demo into a separate file that can be re-used by applications.

This PR also adds the capability of computing 3D reprojection error of the observed 2D image features onto the calibrated target plane. The intent of this PR is to give users additional feedback about the accuracy of the calibration in "world" units that can be more easily understood and interpreted, compared to the currently reported pixel error.

## Modified circle grid with Kinect camera example
```diff
Initial cost?: 117.243 (pixels per dot)
Final cost?: 1.14589 (pixels per dot)

+  3D reprojection error statistics:
+ 	 Mean +/- Std. Dev. (m): 0.00289945 +/- 0.0016792
+	 Min (m): 4.26119e-05
+ 	 Max (m): 0.0150042
```

## ChArUco with AVT GigE camera example
```diff
Did converge?: 1
Initial cost?: 15.7898 (pixels per dot)
Final cost?: 1.25148 (pixels per dot)

+  3D reprojection error statistics:
+ 	 Mean +/- Std. Dev. (m): 0.000955558 +/- 0.000596744
+   	 Min (m): 3.42386e-05
+ 	 Max (m): 0.00310996
```