### PR TITLE
Covariance update

### DIFF
--- a/optimizations/src/camera_intrinsic.cpp
+++ b/optimizations/src/camera_intrinsic.cpp
@@ -134,7 +134,16 @@ CameraIntrinsicResult optimize(const CameraIntrinsicProblem& params)
   result.initial_cost_per_obs = summary.initial_cost / summary.num_residuals;
   result.final_cost_per_obs = summary.final_cost / summary.num_residuals;
 
-  result.covariance = computeCovariance(problem, param_blocks, param_labels);
+  try
+  {
+    std::map<const double*, std::vector<int>> param_masks;
+    ceres::Covariance::Options cov_options = DefaultCovarianceOptions();
+    cov_options.null_space_rank = -1;  // automatically drop terms below min_reciprocal_condition_number
+    result.covariance = computeCovariance(problem, param_blocks, param_labels);
+  }
+  catch (const ICalException& ex)
+  {
+  }
 
   return result;
 }

--- a/optimizations/src/dh_chain_kinematic_calibration.cpp
+++ b/optimizations/src/dh_chain_kinematic_calibration.cpp
@@ -265,9 +265,16 @@ KinematicCalibrationResult optimize(const KinematicCalibrationProblem2D3D& param
   else
     result.target_chain_dh_offsets = target_chain_dh_offsets;
 
-  ceres::Covariance::Options cov_options = DefaultCovarianceOptions();
-  cov_options.null_space_rank = -1;  // automatically drop terms below min_reciprocal_condition_number
-  result.covariance = computeCovariance(problem, param_labels, param_masks, cov_options);
+  // Optionally compute the covariance
+  try
+  {
+    ceres::Covariance::Options cov_options = DefaultCovarianceOptions();
+    cov_options.null_space_rank = -1;  // automatically drop terms below min_reciprocal_condition_number
+    result.covariance = computeCovariance(problem, param_labels, param_masks, cov_options);
+  }
+  catch (const ICalException& ex)
+  {
+  }
 
   return result;
 }

--- a/optimizations/src/extrinsic_hand_eye.cpp
+++ b/optimizations/src/extrinsic_hand_eye.cpp
@@ -174,7 +174,17 @@ ExtrinsicHandEyeResult optimize(const ExtrinsicHandEyeProblem3D3D& params)
   param_labels[internal_camera_to_wrist.values.data()] = labels_camera_mount_to_camera;
   param_labels[internal_base_to_target.values.data()] = labels_target_mount_to_target;
 
-  result.covariance = computeCovariance(problem, param_labels);
+  // Optionally compute covariance
+  try
+  {
+    std::map<const double*, std::vector<int>> param_masks;
+    ceres::Covariance::Options cov_options = DefaultCovarianceOptions();
+    cov_options.null_space_rank = -1;  // automatically drop terms below min_reciprocal_condition_number
+    result.covariance = computeCovariance(problem, param_labels, param_masks, cov_options);
+  }
+  catch (const ICalException& ex)
+  {
+  }
 
   return result;
 }

--- a/optimizations/src/extrinsic_multi_static_camera.cpp
+++ b/optimizations/src/extrinsic_multi_static_camera.cpp
@@ -3,9 +3,9 @@
 #include <industrial_calibration/optimizations/ceres_math_utilities.h>
 #include <industrial_calibration/optimizations/covariance_analysis.h>
 #include <industrial_calibration/core/types.h>
+#include <industrial_calibration/core/exceptions.h>
 
 #include <ceres/ceres.h>
-#include <iostream>
 
 namespace industrial_calibration
 {
@@ -91,7 +91,17 @@ ExtrinsicMultiStaticCameraMovingTargetResult optimize(const ExtrinsicMultiStatic
   }
   param_labels[internal_wrist_to_target.values.data()] = labels_wrist_to_target;
 
-  result.covariance = computeCovariance(problem, param_blocks, param_labels);
+  // Optionally compute covariance
+  try
+  {
+    std::map<const double*, std::vector<int>> param_masks;
+    ceres::Covariance::Options cov_options = DefaultCovarianceOptions();
+    cov_options.null_space_rank = -1;  // automatically drop terms below min_reciprocal_condition_number
+    result.covariance = computeCovariance(problem, param_blocks, param_labels, param_masks, cov_options);
+  }
+  catch (const ICalException& ex)
+  {
+  }
 
   return result;
 }

--- a/optimizations/src/pnp.cpp
+++ b/optimizations/src/pnp.cpp
@@ -73,9 +73,20 @@ PnPResult optimize(const PnPProblem& params)
   param_labels[cam_to_tgt_translation.data()] = labels_camera_to_target_guess_translation;
   param_labels[cam_to_tgt_angle_axis.data()] = labels_camera_to_target_guess_quaternion;
 
-  result.covariance = computeCovariance(
-      problem, std::vector<const double*>({ cam_to_tgt_translation.data(), cam_to_tgt_angle_axis.data() }),
-      param_labels);
+  // Optionally compute covariance
+  try
+  {
+    std::map<const double*, std::vector<int>> param_masks;
+    ceres::Covariance::Options cov_options = DefaultCovarianceOptions();
+    cov_options.null_space_rank = -1;  // automatically drop terms below min_reciprocal_condition_number
+
+    result.covariance = computeCovariance(
+        problem, std::vector<const double*>({ cam_to_tgt_translation.data(), cam_to_tgt_angle_axis.data() }),
+        param_labels, param_masks, cov_options);
+  }
+  catch (const ICalException& ex)
+  {
+  }
 
   return result;
 }


### PR DESCRIPTION
This PR updates the optimizations to compute covariance with options that make the computation more robust to rank deficiency. It also adds try-catch blocks around the covariance computation to still return results from successful optimizations where the covariance can't be computed for some reason