### PR TITLE
Expose methods in calibration widgets

### DIFF
--- a/gui/include/industrial_calibration/gui/camera_intrinsic_calibration_widget.h
+++ b/gui/include/industrial_calibration/gui/camera_intrinsic_calibration_widget.h
@@ -26,17 +26,38 @@ public:
   explicit CameraIntrinsicCalibrationWidget(QWidget* parent = nullptr);
   ~CameraIntrinsicCalibrationWidget();
 
+  /**
+   * @brief Loads the calibration configuration from file
+   * @throws Exception on failure
+   */
   void loadConfig(const std::string& config_file);
+
+  /**
+   * @brief Loads the calibration observations from file
+   * @throws Exception on failure
+   */
   void loadObservations(const std::string& obserations_file);
 
-private:
-  void loadConfig();
-  void loadObservations();
+  /**
+   * @brief Performs the calibration
+   * @throws Exception on failure
+   */
   void calibrate();
+
+  /**
+   * @brief Saves the calibration results
+   * @throws Exception on failure
+   */
+  void saveResults(const std::string& file);
+
+private:
+  void onLoadConfig();
+  void onLoadObservations();
+  void onCalibrate();
+  void onSaveResults();
 
   void loadTargetFinder();
   void drawImage(QTreeWidgetItem* item, int col);
-  void saveResults();
 
   Ui::CameraIntrinsicCalibration* ui_;
   TargetFinderWidget* target_finder_widget_;

--- a/gui/include/industrial_calibration/gui/extrinsic_hand_eye_calibration_widget.h
+++ b/gui/include/industrial_calibration/gui/extrinsic_hand_eye_calibration_widget.h
@@ -27,17 +27,38 @@ public:
   explicit ExtrinsicHandEyeCalibrationWidget(QWidget* parent = nullptr);
   ~ExtrinsicHandEyeCalibrationWidget();
 
+  /**
+   * @brief Loads the calibration configuration from file
+   * @throws Exception on failure
+   */
   void loadConfig(const std::string& config_file);
+
+  /**
+   * @brief Loads the calibration observations from file
+   * @throws Exception on failure
+   */
   void loadObservations(const std::string& observations_file);
 
-private:
-  void loadConfig();
-  void loadObservations();
+  /**
+   * @brief Performs the calibration
+   * @throws Exception on failure
+   */
   void calibrate();
+
+  /**
+   * @brief Saves results of the calibration
+   * @throws Exception on failure
+   */
+  void saveResults(const std::string& file);
+
+private:
+  void onLoadConfig();
+  void onLoadObservations();
+  void onCalibrate();
+  void onSaveResults();
 
   void loadTargetFinder();
   void drawImage(QTreeWidgetItem* item, int col);
-  void saveResults();
 
   Ui::ExtrinsicHandEyeCalibration* ui_;
   TargetFinderWidget* target_finder_widget_;

--- a/gui/src/app/camera_intrinsic_calibration_app.cpp
+++ b/gui/src/app/camera_intrinsic_calibration_app.cpp
@@ -1,5 +1,7 @@
 #include <industrial_calibration/gui/camera_intrinsic_calibration_widget.h>
 #include <QApplication>
+#include <QMessageBox>
+#include <QTextStream>
 #include <signal.h>
 
 void handleSignal(int /*sig*/) { QApplication::instance()->quit(); }
@@ -15,11 +17,61 @@ int main(int argc, char** argv)
   industrial_calibration::CameraIntrinsicCalibrationWidget w;
   w.setWindowTitle("Camera Intrinsic Calibration");
   w.setWindowIcon(QIcon(":/icons/icon.jpg"));
-  w.showMaximized();
 
-  // Attempt to load configuration and observations files if available
-  if (argc > 1) w.loadConfig(argv[1]);
-  if (argc > 2) w.loadObservations(argv[2]);
+  // Attempt to run headless if the configuration file (argv[1]), observation file (argv[2]), and results file (argv[3])
+  // are specified
+  if (argc > 3)
+  {
+    try
+    {
+      w.loadConfig(argv[1]);
+      w.loadObservations(argv[2]);
+      w.calibrate();
+      w.saveResults(argv[3]);
+      QMessageBox::StandardButton ret = QMessageBox::question(nullptr, "Calibration",
+                                                              "Successfully completed calibration and saved results. "
+                                                              "View results in the GUI?");
+      if (ret == QMessageBox::StandardButton::Yes)
+      {
+        w.showMaximized();
+        return app.exec();
+      }
+    }
+    catch (const std::exception& ex)
+    {
+      QString question;
+      QTextStream ss(&question);
+      ss << "Error: " << ex.what() << "\n\nOpen GUI to fix?";
 
-  return app.exec();
+      QMessageBox::StandardButton ret = QMessageBox::question(nullptr, "Error", question);
+      if (ret == QMessageBox::StandardButton::Yes)
+      {
+        w.showMaximized();
+        return app.exec();
+      }
+    }
+  }
+  else
+  {
+    w.showMaximized();
+
+    // Attempt to load configuration and observations files if available
+    try
+    {
+      if (argc > 1)
+      {
+        w.loadConfig(argv[1]);
+        QMessageBox::information(nullptr, "Configuration", "Successfully loaded calibration configuration");
+      }
+      if (argc > 2) w.loadObservations(argv[2]);
+    }
+    catch (const std::exception& ex)
+    {
+      QMessageBox::warning(nullptr, "Error", ex.what());
+    }
+
+    return app.exec();
+  }
+
+  return 0;
 }

--- a/gui/src/app/extrinsic_hand_eye_calibration_app.cpp
+++ b/gui/src/app/extrinsic_hand_eye_calibration_app.cpp
@@ -1,5 +1,7 @@
 #include <industrial_calibration/gui/extrinsic_hand_eye_calibration_widget.h>
 #include <QApplication>
+#include <QMessageBox>
+#include <QTextStream>
 #include <signal.h>
 
 void handleSignal(int /*sig*/) { QApplication::instance()->quit(); }
@@ -15,11 +17,61 @@ int main(int argc, char** argv)
   industrial_calibration::ExtrinsicHandEyeCalibrationWidget w;
   w.setWindowTitle("Extrinsic Hand Eye Calibration");
   w.setWindowIcon(QIcon(":/icons/icon.jpg"));
-  w.showMaximized();
 
-  // Attempt to load configuration and observations files, if available
-  if (argc > 1) w.loadConfig(argv[1]);
-  if (argc > 2) w.loadObservations(argv[2]);
+  // Attempt to run headless if the configuration file (argv[1]), observation file (argv[2]), and results file (argv[3])
+  // are specified
+  if (argc > 3)
+  {
+    try
+    {
+      w.loadConfig(argv[1]);
+      w.loadObservations(argv[2]);
+      w.calibrate();
+      w.saveResults(argv[3]);
+      QMessageBox::StandardButton ret = QMessageBox::question(nullptr, "Calibration",
+                                                              "Successfully completed calibration and saved results. "
+                                                              "View results in the GUI?");
+      if (ret == QMessageBox::StandardButton::Yes)
+      {
+        w.showMaximized();
+        return app.exec();
+      }
+    }
+    catch (const std::exception& ex)
+    {
+      QString question;
+      QTextStream ss(&question);
+      ss << "Error: " << ex.what() << "\n\nOpen GUI to fix?";
 
-  return app.exec();
+      QMessageBox::StandardButton ret = QMessageBox::question(nullptr, "Error", question);
+      if (ret == QMessageBox::StandardButton::Yes)
+      {
+        w.show();
+        return app.exec();
+      }
+    }
+  }
+  else
+  {
+    w.showMaximized();
+
+    // Attempt to load configuration and observations files if available
+    try
+    {
+      if (argc > 1)
+      {
+        w.loadConfig(argv[1]);
+        QMessageBox::information(nullptr, "Configuration", "Successfully loaded calibration configuration");
+      }
+      if (argc > 2) w.loadObservations(argv[2]);
+    }
+    catch (const std::exception& ex)
+    {
+      QMessageBox::warning(nullptr, "Error", ex.what());
+    }
+
+    return app.exec();
+  }
+
+  return 0;
 }

--- a/gui/src/camera_intrinsic_calibration_widget.cpp
+++ b/gui/src/camera_intrinsic_calibration_widget.cpp
@@ -186,7 +186,7 @@ void CameraIntrinsicCalibrationWidget::onLoadConfig()
 
     loadConfig(config_file.toStdString());
 
-    QMessageBox::information(this, "Success", "Successfully loaded calibration configuration");
+    QMessageBox::information(this, "Configuration", "Successfully loaded calibration configuration");
   }
   catch (const std::exception& ex)
   {
@@ -204,7 +204,7 @@ void CameraIntrinsicCalibrationWidget::loadConfig(const std::string& config_file
     target_finder_widget_->configure(target_finder_config);
   }
 
-  // Intrinsices
+  // Intrinsics
   {
     auto intrinsics_config = getMember<YAML::Node>(node, "intrinsics_guess");
     camera_intrinsics_widget_->configure(intrinsics_config);
@@ -352,7 +352,7 @@ void CameraIntrinsicCalibrationWidget::onCalibrate()
     QApplication::restoreOverrideCursor();
 
     if (result_->converged)
-      QMessageBox::information(this, "Success", "Successfully completed calibration");
+      QMessageBox::information(this, "Calibration", "Successfully completed calibration");
     else
       QMessageBox::warning(this, "Error", "Calibration failed to converge");
   }

--- a/gui/src/camera_intrinsic_calibration_widget.cpp
+++ b/gui/src/camera_intrinsic_calibration_widget.cpp
@@ -215,6 +215,15 @@ void CameraIntrinsicCalibrationWidget::loadConfig(const std::string& config_file
 
   // Use extrinsic guesses
   ui_->action_use_extrinsic_guesses->setChecked(getMember<bool>(node, "use_extrinsic_guesses"));
+
+  // Optionally check for use of OpenCV algorithm
+  try
+  {
+    ui_->action_use_opencv->setChecked(getMember<bool>(node, "use_opencv"));
+  }
+  catch (const std::exception&)
+  {
+  }
 }
 
 void CameraIntrinsicCalibrationWidget::loadTargetFinder()

--- a/gui/src/extrinsic_hand_eye_calibration_widget.cpp
+++ b/gui/src/extrinsic_hand_eye_calibration_widget.cpp
@@ -141,7 +141,7 @@ void ExtrinsicHandEyeCalibrationWidget::onLoadConfig()
 
     loadConfig(config_file.toStdString());
 
-    QMessageBox::information(this, "Success", "Successfully loaded calibration configuration");
+    QMessageBox::information(this, "Configuration", "Successfully loaded calibration configuration");
   }
   catch (const std::exception& ex)
   {
@@ -303,7 +303,7 @@ void ExtrinsicHandEyeCalibrationWidget::onCalibrate()
     QApplication::restoreOverrideCursor();
 
     if (result_->converged)
-      QMessageBox::information(this, "Success", "Successfully completed calibration");
+      QMessageBox::information(this, "Calibration", "Successfully completed calibration");
     else
       QMessageBox::warning(this, "Error", "Calibration failed to converge");
   }


### PR DESCRIPTION
This PR exposes methods in the calibration widgets to allow them to be used in a headless context