### PR TITLE
Added serialization to ROS format for camera intrinsic calibration app

### DIFF
--- a/gui/include/industrial_calibration/gui/camera_intrinsic_calibration_widget.h
+++ b/gui/include/industrial_calibration/gui/camera_intrinsic_calibration_widget.h
@@ -48,13 +48,21 @@ public:
    * @brief Saves the calibration results
    * @throws Exception on failure
    */
-  void saveResults(const std::string& file);
+  void saveResults(const std::string& file) const;
+
+  /**
+   * @brief Saves the calibration results to a YAML file in a format compatible with ROS
+   * @details Format definition https://wiki.ros.org/camera_calibration_parsers#File_formats
+   * @throws Exception on failure
+   */
+  void saveROSFormat(const std::string& file) const;
 
 private:
   void onLoadConfig();
   void onLoadObservations();
   void onCalibrate();
   void onSaveResults();
+  void onSaveROSFormat();
 
   void loadTargetFinder();
   void drawImage(QTreeWidgetItem* item, int col);

--- a/gui/src/app/camera_intrinsic_calibration_app.cpp
+++ b/gui/src/app/camera_intrinsic_calibration_app.cpp
@@ -18,8 +18,12 @@ int main(int argc, char** argv)
   w.setWindowTitle("Camera Intrinsic Calibration");
   w.setWindowIcon(QIcon(":/icons/icon.jpg"));
 
-  // Attempt to run headless if the configuration file (argv[1]), observation file (argv[2]), and results file (argv[3])
-  // are specified
+  /* Attempt to run headless if all files are specified:
+   *   argv[1]: configuration file
+   *   argv[2]: observation file
+   *   argv[3]: results file (industrial_calibration)
+   *   argv[4]: results file (ROS) - optional
+   */
   if (argc > 3)
   {
     try
@@ -28,6 +32,8 @@ int main(int argc, char** argv)
       w.loadObservations(argv[2]);
       w.calibrate();
       w.saveResults(argv[3]);
+      if (argc > 4) w.saveROSFormat(argv[4]);
+
       QMessageBox::StandardButton ret = QMessageBox::question(nullptr, "Calibration",
                                                               "Successfully completed calibration and saved results. "
                                                               "View results in the GUI?");

--- a/gui/src/camera_intrinsic_calibration_widget.ui
+++ b/gui/src/camera_intrinsic_calibration_widget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>429</width>
+    <width>641</width>
     <height>558</height>
    </rect>
   </property>
@@ -131,7 +131,7 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>429</width>
+     <width>641</width>
      <height>22</height>
     </rect>
    </property>
@@ -139,19 +139,19 @@
     <property name="title">
      <string>Edit</string>
     </property>
-    <widget class="QMenu" name="menuInitial_Guesses">
-     <property name="title">
-      <string>Initial guesses</string>
-     </property>
-    </widget>
+    <property name="toolTipsVisible">
+     <bool>true</bool>
+    </property>
     <addaction name="action_edit_target_finder"/>
     <addaction name="action_camera_intrinsics"/>
-    <addaction name="menuInitial_Guesses"/>
     <addaction name="action_use_extrinsic_guesses"/>
    </widget>
-   <widget class="QMenu" name="menuCalibrate_2">
+   <widget class="QMenu" name="menuCalibrate">
     <property name="title">
      <string>Calibration</string>
+    </property>
+    <property name="toolTipsVisible">
+     <bool>true</bool>
     </property>
     <addaction name="action_calibrate"/>
    </widget>
@@ -159,13 +159,17 @@
     <property name="title">
      <string>File</string>
     </property>
+    <property name="toolTipsVisible">
+     <bool>true</bool>
+    </property>
     <addaction name="action_load_configuration"/>
     <addaction name="action_load_data"/>
     <addaction name="action_save"/>
+    <addaction name="action_save_ros_format"/>
    </widget>
    <addaction name="menuFile"/>
    <addaction name="menuEdit"/>
-   <addaction name="menuCalibrate_2"/>
+   <addaction name="menuCalibrate"/>
   </widget>
   <widget class="QStatusBar" name="statusbar"/>
   <widget class="QToolBar" name="toolBar">
@@ -188,14 +192,14 @@
    <addaction name="separator"/>
    <addaction name="action_calibrate"/>
    <addaction name="action_save"/>
+   <addaction name="action_save_ros_format"/>
   </widget>
   <action name="action_load_configuration">
    <property name="icon">
-    <iconset theme="document-open">
-     <normaloff>.</normaloff>.</iconset>
+    <iconset theme="document-open"/>
    </property>
    <property name="text">
-    <string>Load configuration</string>
+    <string>Load configuration...</string>
    </property>
    <property name="toolTip">
     <string>Load calibration configuration file</string>
@@ -203,8 +207,7 @@
   </action>
   <action name="action_edit_target_finder">
    <property name="icon">
-    <iconset theme="edit-find">
-     <normaloff>.</normaloff>.</iconset>
+    <iconset theme="edit-find"/>
    </property>
    <property name="text">
     <string>Target finder</string>
@@ -215,11 +218,10 @@
   </action>
   <action name="action_load_data">
    <property name="icon">
-    <iconset theme="document-new">
-     <normaloff>.</normaloff>.</iconset>
+    <iconset theme="document-new"/>
    </property>
    <property name="text">
-    <string>Load observations</string>
+    <string>Load observations...</string>
    </property>
    <property name="toolTip">
     <string>Load observations file</string>
@@ -227,8 +229,7 @@
   </action>
   <action name="action_calibrate">
    <property name="icon">
-    <iconset theme="media-playback-start">
-     <normaloff>.</normaloff>.</iconset>
+    <iconset theme="media-playback-start"/>
    </property>
    <property name="text">
     <string>Calibrate</string>
@@ -239,11 +240,10 @@
   </action>
   <action name="action_save">
    <property name="icon">
-    <iconset theme="document-save">
-     <normaloff>.</normaloff>.</iconset>
+    <iconset theme="document-save"/>
    </property>
    <property name="text">
-    <string>Save calibration</string>
+    <string>Save calibration...</string>
    </property>
    <property name="toolTip">
     <string>Save calibration</string>
@@ -254,8 +254,7 @@
     <bool>true</bool>
    </property>
    <property name="icon">
-    <iconset theme="user-available">
-     <normaloff>.</normaloff>.</iconset>
+    <iconset theme="user-available"/>
    </property>
    <property name="text">
     <string>Use target pose guesses</string>
@@ -266,8 +265,7 @@
   </action>
   <action name="action_camera_intrinsics">
    <property name="icon">
-    <iconset theme="camera-photo">
-     <normaloff>.</normaloff>.</iconset>
+    <iconset theme="camera-photo"/>
    </property>
    <property name="text">
     <string>Camera intrinsics</string>
@@ -281,7 +279,7 @@
     <bool>true</bool>
    </property>
    <property name="icon">
-    <iconset resource="../resources/resources.qrc">
+    <iconset>
      <normaloff>:/icons/opencv.svg</normaloff>:/icons/opencv.svg</iconset>
    </property>
    <property name="text">
@@ -292,6 +290,17 @@
    </property>
    <property name="menuRole">
     <enum>QAction::NoRole</enum>
+   </property>
+  </action>
+  <action name="action_save_ros_format">
+   <property name="icon">
+    <iconset theme="document-save-as"/>
+   </property>
+   <property name="text">
+    <string>Save calibration (ROS)...</string>
+   </property>
+   <property name="toolTip">
+    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Save the calibration results to a &lt;a href=&quot;https://wiki.ros.org/camera_calibration_parsers#File_formats&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#007af4;&quot;&gt;format comptible with ROS&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
    </property>
   </action>
  </widget>
@@ -307,8 +316,6 @@
   <tabstop>double_spin_box_homography_threshold</tabstop>
   <tabstop>text_edit_results</tabstop>
  </tabstops>
- <resources>
-  <include location="../resources/resources.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
This PR adds a button to the camera intrinsic calibration GUI to save the results to a YAML file in a [format compatible with ROS](https://wiki.ros.org/camera_calibration_parsers#File_formats)