### PR TITLE
Updated file checks for application arguments

### DIFF
--- a/gui/src/app/camera_intrinsic_calibration_app.cpp
+++ b/gui/src/app/camera_intrinsic_calibration_app.cpp
@@ -1,4 +1,5 @@
 #include <industrial_calibration/gui/camera_intrinsic_calibration_widget.h>
+#include <filesystem>
 #include <QApplication>
 #include <QMessageBox>
 #include <QTextStream>
@@ -65,12 +66,12 @@ int main(int argc, char** argv)
     // Attempt to load configuration and observations files if available
     try
     {
-      if (argc > 1)
+      if (argc > 1 && std::filesystem::is_regular_file(argv[1]))
       {
         w.loadConfig(argv[1]);
         QMessageBox::information(nullptr, "Configuration", "Successfully loaded calibration configuration");
       }
-      if (argc > 2)
+      if (argc > 2 && std::filesystem::is_regular_file(argv[2]))
         w.loadObservations(argv[2]);
     }
     catch (const std::exception& ex)

--- a/gui/src/app/extrinsic_hand_eye_calibration_app.cpp
+++ b/gui/src/app/extrinsic_hand_eye_calibration_app.cpp
@@ -1,4 +1,5 @@
 #include <industrial_calibration/gui/extrinsic_hand_eye_calibration_widget.h>
+#include <filesystem>
 #include <QApplication>
 #include <QMessageBox>
 #include <QTextStream>
@@ -58,12 +59,12 @@ int main(int argc, char** argv)
     // Attempt to load configuration and observations files if available
     try
     {
-      if (argc > 1)
+      if (argc > 1 && std::filesystem::is_regular_file(argv[1]))
       {
         w.loadConfig(argv[1]);
         QMessageBox::information(nullptr, "Configuration", "Successfully loaded calibration configuration");
       }
-      if (argc > 2)
+      if (argc > 2 && std::filesystem::is_regular_file(argv[2]))
         w.loadObservations(argv[2]);
     }
     catch (const std::exception& ex)


### PR DESCRIPTION
This PR adds checks on the command line arguments to the calibration applications to ensure that the provided arguments are regular files before attempting to load and utilize them as such. This helps prevent problems when running the executables via `ros2 run` which always appends `--ros-args` to the end of the provided command line arguments