### PR TITLE
Resolved linker issue with kinematic_calibration.cpp

### DIFF
--- a/examples/kinematic_calibration.cpp
+++ b/examples/kinematic_calibration.cpp
@@ -3,7 +3,7 @@
 #include <industrial_calibration/optimizations/dh_chain_kinematic_calibration.h>
 #include <industrial_calibration/core/serialization.h>
 
-#if __GNUC__ >= 8
+#if __has_include(<filesystem>)
 #include <filesystem>
 using path = std::filesystem::path;
 #else


### PR DESCRIPTION
Resolves a linker error when building kinematic_calibration.cpp related to std::experimental::filesystem.

Part of the error resolved:
```kinematic_calibration.cpp:(.text+0x54e8): undefined reference to `std::experimental::filesystem::v1::__cxx11::path::_M_split_cmpts()'```