### PR TITLE
Updated clang and cmake workflows to use 22.04 runner images

### DIFF
--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   clang_format:
     name: Clang Format
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/cmake_format.yml
+++ b/.github/workflows/cmake_format.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   cmake_lang:
     name: CMake Format
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -30,11 +30,11 @@ jobs:
         with:
           path: target_ws/src
       - name: Build
-        uses: tesseract-robotics/colcon-action@v6
+        uses: tesseract-robotics/colcon-action@v12
         with:
           ccache-enabled: false
           rosdep-enabled: true
-          ros-enabled: false
+          add-ros-ppa: true
           vcs-file: dependencies.repos
           target-path: target_ws/src
           target-args: '-DCMAKE_BUILD_TYPE=Debug -DINDUSTRIAL_CALIBRATION_ENABLE_TESTING=ON -DINDUSTRIAL_CALIBRATION_ENABLE_RUN_TESTING=OFF -DINDUSTRIAL_CALIBRATION_ENABLE_CLANG_TIDY=ON'


### PR DESCRIPTION
As of April 15, 2025, Ubuntu 20.04 LTS runner images have been [deprecated](https://github.com/actions/runner-images/issues/11101).

This updates the clang and cmake format workflows to use a 22.04 runner image. 