### PR TITLE
Check files for validity before writing

### DIFF
--- a/gui/src/camera_intrinsic_calibration_widget.cpp
+++ b/gui/src/camera_intrinsic_calibration_widget.cpp
@@ -413,6 +413,9 @@ void CameraIntrinsicCalibrationWidget::saveResults(const std::string& file) cons
                         "calibration");
 
   std::ofstream f(file);
+  if (!f)
+    throw ICalException("Failed to open file: '" + file + "' for writing");
+
   f << YAML::Node(*result_);
 }
 
@@ -452,6 +455,9 @@ void CameraIntrinsicCalibrationWidget::saveROSFormat(const std::string& file) co
 
   YAML::Node node = toROSFormat(*result_, image_width, image_height);
   std::ofstream f(file);
+  if (!f)
+    throw ICalException("Failed to open file: '" + file + "' for writing");
+
   f << node;
 }
 

--- a/gui/src/extrinsic_hand_eye_calibration_widget.cpp
+++ b/gui/src/extrinsic_hand_eye_calibration_widget.cpp
@@ -327,6 +327,9 @@ void ExtrinsicHandEyeCalibrationWidget::saveResults(const std::string& file)
                         "calibration");
 
   std::ofstream f(file);
+  if (!f)
+    throw ICalException("Failed to open file: '" + file + "' for writing");
+
   f << YAML::Node(*result_);
 }
 


### PR DESCRIPTION
This PR adds a check on file objects used for writing to ensure validity. In the case of saving a file from a Docker image into a read-only volume using these functions, currently no error is returned but the file does not get written.