### PR TITLE
Handle covariance calculation failure cleanly

### DIFF
--- a/optimizations/include/industrial_calibration/optimizations/covariance_types.h
+++ b/optimizations/include/industrial_calibration/optimizations/covariance_types.h
@@ -59,6 +59,10 @@ struct CovarianceResult
    * @return
    */
   std::string printCorrelationCoeffAboveThreshold(const std::double_t& threshold) const;
+
+  /** @brief Error message from the computation of the covariance result
+   */
+  std::string error_message;
 };
 
 }  // namespace industrial_calibration

--- a/optimizations/src/camera_intrinsic.cpp
+++ b/optimizations/src/camera_intrinsic.cpp
@@ -212,6 +212,7 @@ CameraIntrinsicResult optimize(const CameraIntrinsicProblem& params)
   result.initial_cost_per_obs = summary.initial_cost / summary.num_residuals;
   result.final_cost_per_obs = summary.final_cost / summary.num_residuals;
 
+  // Optionally compute covariance
   try
   {
     std::map<const double*, std::vector<int>> param_masks;

--- a/optimizations/src/camera_intrinsic.cpp
+++ b/optimizations/src/camera_intrinsic.cpp
@@ -222,6 +222,7 @@ CameraIntrinsicResult optimize(const CameraIntrinsicProblem& params)
   }
   catch (const ICalException& ex)
   {
+    result.covariance.error_message = ex.what();
   }
 
   return result;

--- a/optimizations/src/covariance_types.cpp
+++ b/optimizations/src/covariance_types.cpp
@@ -51,18 +51,18 @@ std::string CovarianceResult::toString() const
 
 std::string CovarianceResult::printCorrelationCoeffAboveThreshold(const std::double_t& threshold) const
 {
+  if (!error_message.empty())
+    return error_message;
+
   auto above_thresh = getCorrelationCoeffOutsideThreshold(threshold);
 
   if (above_thresh.size() == 0)
-  {
     return std::string("No correlation coefficients with magnitude > " + std::to_string(threshold) + "\n");
-  }
 
   std::string out("\nCorrelation Coeff. > " + std::to_string(threshold) + ":\n");
   for (auto corr : above_thresh)
-  {
     out.append(corr.toString() + "\n");
-  }
+
   return out;
 }
 

--- a/optimizations/src/dh_chain_kinematic_calibration.cpp
+++ b/optimizations/src/dh_chain_kinematic_calibration.cpp
@@ -474,9 +474,15 @@ KinematicCalibrationResult optimize(const KinematicCalibrationProblemPose6D& par
   else
     result.target_chain_dh_offsets = target_chain_dh_offsets;
 
-  ceres::Covariance::Options cov_options = DefaultCovarianceOptions();
-  cov_options.null_space_rank = -1;  // automatically drop terms below min_reciprocal_condition_number
-  result.covariance = computeCovariance(problem, param_labels, param_masks, cov_options);
+  try
+  {
+    ceres::Covariance::Options cov_options = DefaultCovarianceOptions();
+    cov_options.null_space_rank = -1;  // automatically drop terms below min_reciprocal_condition_number
+    result.covariance = computeCovariance(problem, param_labels, param_masks, cov_options);
+  }
+  catch (const ICalException& ex)
+  {
+  }
 
   return result;
 }

--- a/optimizations/src/dh_chain_kinematic_calibration.cpp
+++ b/optimizations/src/dh_chain_kinematic_calibration.cpp
@@ -278,6 +278,7 @@ KinematicCalibrationResult optimize(const KinematicCalibrationProblem2D3D& param
   }
   catch (const ICalException& ex)
   {
+    result.covariance.error_message = ex.what();
   }
 
   return result;
@@ -482,6 +483,7 @@ KinematicCalibrationResult optimize(const KinematicCalibrationProblemPose6D& par
   }
   catch (const ICalException& ex)
   {
+    result.covariance.error_message = ex.what();
   }
 
   return result;

--- a/optimizations/src/extrinsic_hand_eye.cpp
+++ b/optimizations/src/extrinsic_hand_eye.cpp
@@ -107,11 +107,21 @@ ExtrinsicHandEyeResult optimize(const ExtrinsicHandEyeProblem2D3D& params)
     labels_target_mount_to_target.emplace_back(params.label_target_mount_to_target + "_" + label_isometry);
   }
 
-  std::map<const double*, std::vector<std::string>> param_labels;
-  param_labels[internal_camera_to_wrist.values.data()] = labels_camera_mount_to_camera;
-  param_labels[internal_base_to_target.values.data()] = labels_target_mount_to_target;
+  // Optionally compute covariance
+  try
+  {
+    std::map<const double*, std::vector<std::string>> param_labels;
+    param_labels[internal_camera_to_wrist.values.data()] = labels_camera_mount_to_camera;
+    param_labels[internal_base_to_target.values.data()] = labels_target_mount_to_target;
 
-  result.covariance = computeCovariance(problem, param_labels);
+    std::map<const double*, std::vector<int>> param_masks;
+    ceres::Covariance::Options cov_options = DefaultCovarianceOptions();
+    cov_options.null_space_rank = -1;  // automatically drop terms below min_reciprocal_condition_number
+    result.covariance = computeCovariance(problem, param_labels, param_masks, cov_options);
+  }
+  catch (const ICalException& ex)
+  {
+  }
 
   return result;
 }
@@ -170,13 +180,13 @@ ExtrinsicHandEyeResult optimize(const ExtrinsicHandEyeProblem3D3D& params)
     labels_target_mount_to_target.emplace_back(params.label_target_mount_to_target + "_" + label_isometry);
   }
 
-  std::map<const double*, std::vector<std::string>> param_labels;
-  param_labels[internal_camera_to_wrist.values.data()] = labels_camera_mount_to_camera;
-  param_labels[internal_base_to_target.values.data()] = labels_target_mount_to_target;
-
   // Optionally compute covariance
   try
   {
+    std::map<const double*, std::vector<std::string>> param_labels;
+    param_labels[internal_camera_to_wrist.values.data()] = labels_camera_mount_to_camera;
+    param_labels[internal_base_to_target.values.data()] = labels_target_mount_to_target;
+
     std::map<const double*, std::vector<int>> param_masks;
     ceres::Covariance::Options cov_options = DefaultCovarianceOptions();
     cov_options.null_space_rank = -1;  // automatically drop terms below min_reciprocal_condition_number

--- a/optimizations/src/extrinsic_hand_eye.cpp
+++ b/optimizations/src/extrinsic_hand_eye.cpp
@@ -121,6 +121,7 @@ ExtrinsicHandEyeResult optimize(const ExtrinsicHandEyeProblem2D3D& params)
   }
   catch (const ICalException& ex)
   {
+    result.covariance.error_message = ex.what();
   }
 
   return result;
@@ -194,6 +195,7 @@ ExtrinsicHandEyeResult optimize(const ExtrinsicHandEyeProblem3D3D& params)
   }
   catch (const ICalException& ex)
   {
+    result.covariance.error_message = ex.what();
   }
 
   return result;

--- a/optimizations/src/extrinsic_multi_static_camera.cpp
+++ b/optimizations/src/extrinsic_multi_static_camera.cpp
@@ -101,6 +101,7 @@ ExtrinsicMultiStaticCameraMovingTargetResult optimize(const ExtrinsicMultiStatic
   }
   catch (const ICalException& ex)
   {
+    result.covariance.error_message = ex.what();
   }
 
   return result;

--- a/optimizations/src/pnp.cpp
+++ b/optimizations/src/pnp.cpp
@@ -141,9 +141,20 @@ PnPResult optimize(const PnPProblem3D& params)
   param_labels[cam_to_tgt_translation.data()] = labels_camera_to_target_guess_translation;
   param_labels[cam_to_tgt_angle_axis.data()] = labels_camera_to_target_guess_quaternion;
 
-  result.covariance = computeCovariance(
-      problem, std::vector<const double*>({ cam_to_tgt_translation.data(), cam_to_tgt_angle_axis.data() }),
-      param_labels);
+  // Optionally compute covariance
+  try
+  {
+    std::map<const double*, std::vector<int>> param_masks;
+    ceres::Covariance::Options cov_options = DefaultCovarianceOptions();
+    cov_options.null_space_rank = -1;  // automatically drop terms below min_reciprocal_condition_number
+
+    result.covariance = computeCovariance(
+        problem, std::vector<const double*>({ cam_to_tgt_translation.data(), cam_to_tgt_angle_axis.data() }),
+        param_labels, param_masks, cov_options);
+  }
+  catch (const ICalException& ex)
+  {
+  }
 
   return result;
 }

--- a/optimizations/src/pnp.cpp
+++ b/optimizations/src/pnp.cpp
@@ -86,6 +86,7 @@ PnPResult optimize(const PnPProblem& params)
   }
   catch (const ICalException& ex)
   {
+    result.covariance.error_message = ex.what();
   }
 
   return result;
@@ -154,6 +155,7 @@ PnPResult optimize(const PnPProblem3D& params)
   }
   catch (const ICalException& ex)
   {
+    result.covariance.error_message = ex.what();
   }
 
   return result;


### PR DESCRIPTION
This PR updates all optimizations to handle failure of the covariance computation cleanly. Now all optimizations catch exceptions thrown by the covariance calculation and write the error to a new `error_message` field in the `CovarianceResult` struct. The `CovarianceResult::printCorrelationCoeffAboveThreshold` method was also updated to print this error message if it exists.