### PR TITLE
Fix covariance parameter labeling and undefined correlation reporting

### DIFF
--- a/optimizations/CMakeLists.txt
+++ b/optimizations/CMakeLists.txt
@@ -1,3 +1,4 @@
+find_package(glog REQUIRED)
 find_package(Ceres REQUIRED)
 
 add_library(

--- a/optimizations/include/industrial_calibration/optimizations/camera_intrinsic.h
+++ b/optimizations/include/industrial_calibration/optimizations/camera_intrinsic.h
@@ -20,7 +20,7 @@ struct CameraIntrinsicProblem
   std::string label_extr = "pose";
   const std::array<std::string, 9> labels_intrinsic_params = { { "fx", "fy", "cx", "cy", "k1", "k2", "p1", "p2",
                                                                  "k3" } };
-  const std::array<std::string, 6> labels_isometry3d = { { "x", "y", "z", "rx", "ry", "rz" } };
+  const std::array<std::string, 6> labels_isometry3d = { { "rx", "ry", "rz", "x", "y", "z" } };
 };
 
 /**

--- a/optimizations/include/industrial_calibration/optimizations/extrinsic_hand_eye.h
+++ b/optimizations/include/industrial_calibration/optimizations/extrinsic_hand_eye.h
@@ -35,7 +35,7 @@ struct ExtrinsicHandEyeProblem2D3D
   Eigen::Isometry3d target_mount_to_target_guess;
   Eigen::Isometry3d camera_mount_to_camera_guess;
 
-  std::array<std::string, 6> labels_isometry3d = { { "x", "y", "z", "rx", "ry", "rz" } };
+  std::array<std::string, 6> labels_isometry3d = { { "rx", "ry", "rz", "x", "y", "z" } };
   std::string label_target_mount_to_target = "target_mount_to_target";
   std::string label_camera_mount_to_camera = "camera_mount_to_camera";
 
@@ -56,7 +56,7 @@ struct ExtrinsicHandEyeProblem3D3D
   Eigen::Isometry3d target_mount_to_target_guess;
   Eigen::Isometry3d camera_mount_to_camera_guess;
 
-  std::array<std::string, 6> labels_isometry3d = { { "x", "y", "z", "rx", "ry", "rz" } };
+  std::array<std::string, 6> labels_isometry3d = { { "rx", "ry", "rz", "x", "y", "z" } };
   std::string label_target_mount_to_target = "target_mount_to_target";
   std::string label_camera_mount_to_camera = "camera_mount_to_camera";
 

--- a/optimizations/include/industrial_calibration/optimizations/extrinsic_multi_static_camera.h
+++ b/optimizations/include/industrial_calibration/optimizations/extrinsic_multi_static_camera.h
@@ -50,7 +50,7 @@ struct ExtrinsicMultiStaticCameraMovingTargetProblem
   /** @brief Your best guess at the "base frame" to "camera frame" transform; one for each camera */
   VectorEigenIsometry base_to_camera_guess;
 
-  const std::array<std::string, 6> labels_isometry3d = { { "x", "y", "z", "rx", "ry", "rz" } };
+  const std::array<std::string, 6> labels_isometry3d = { { "rx", "ry", "rz", "x", "y", "z" } };
   std::string label_wrist_to_target = "wrist_to_target";
   std::string label_base_to_camera = "base_to_camera";
 
@@ -131,7 +131,7 @@ struct ExtrinsicMultiStaticCameraOnlyProblem
   /** @brief Your best guess at the "base frame" to "camera frame" transform; one for each camera */
   VectorEigenIsometry base_to_camera_guess;
 
-  std::array<std::string, 6> labels_isometry3d = { { "x", "y", "z", "rx", "ry", "rz" } };
+  std::array<std::string, 6> labels_isometry3d = { { "rx", "ry", "rz", "x", "y", "z" } };
   std::string label_base_to_target = "base_to_target";
   std::string label_base_to_camera = "base_to_camera";
 
@@ -209,7 +209,7 @@ struct ExtrinsicMultiStaticCameraMovingTargetWristOnlyProblem
    */
   VectorEigenIsometry base_to_camera_guess;
 
-  const std::array<std::string, 6> labels_isometry3d = { { "x", "y", "z", "rx", "ry", "rz" } };
+  const std::array<std::string, 6> labels_isometry3d = { { "rx", "ry", "rz", "x", "y", "z" } };
   std::string label_wrist_to_target = "wrist_to_target";
   std::string label_base_to_camera = "base_to_camera";
 

--- a/optimizations/src/covariance_analysis.cpp
+++ b/optimizations/src/covariance_analysis.cpp
@@ -1,6 +1,8 @@
 ﻿#include <industrial_calibration/optimizations/covariance_analysis.h>
 #include <industrial_calibration/core/exceptions.h>
 
+#include <cmath>
+#include <limits>
 #include <sstream>
 
 namespace industrial_calibration
@@ -13,25 +15,31 @@ Eigen::MatrixXd computeCorrelationsFromCovariance(const Eigen::MatrixXd& covaria
   Eigen::Index num_vars = covariance_matrix.rows();
 
   Eigen::MatrixXd out(num_vars, num_vars);
+  const double nan = std::numeric_limits<double>::quiet_NaN();
 
   for (Eigen::Index i = 0; i < num_vars; i++)
   {
-    double sigma_i = sqrt(fabs(covariance_matrix(i, i)));  // standard deviation at the diagonal element in row i
+    const double variance_i = covariance_matrix(i, i);
+    const bool variance_i_is_finite = std::isfinite(variance_i);
+    const bool variance_i_is_nonnegative = variance_i >= 0.0;
+    const double sigma_i = (variance_i_is_finite && variance_i_is_nonnegative) ? std::sqrt(variance_i) : nan;
 
     for (Eigen::Index j = 0; j < num_vars; j++)
     {
-      double sigma_j = sqrt(fabs(covariance_matrix(j, j)));  // standard deviation at the diagonal element in column j
+      const double variance_j = covariance_matrix(j, j);
+      const bool variance_j_is_finite = std::isfinite(variance_j);
+      const bool variance_j_is_nonnegative = variance_j >= 0.0;
+      const double sigma_j = (variance_j_is_finite && variance_j_is_nonnegative) ? std::sqrt(variance_j) : nan;
 
       if (i == j)  // if out(i,j) is a diagonal element
         out(static_cast<Eigen::Index>(i), static_cast<Eigen::Index>(j)) = sigma_i;
       else
       {
-        if (sigma_i < std::numeric_limits<double>::epsilon())
-          sigma_i = 1;
-        if (sigma_j < std::numeric_limits<double>::epsilon())
-          sigma_j = 1;
+        const bool sigma_i_is_usable = std::isfinite(sigma_i) && sigma_i > std::numeric_limits<double>::epsilon();
+        const bool sigma_j_is_usable = std::isfinite(sigma_j) && sigma_j > std::numeric_limits<double>::epsilon();
 
-        out(static_cast<Eigen::Index>(i), static_cast<Eigen::Index>(j)) = covariance_matrix(i, j) / (sigma_i * sigma_j);
+        out(static_cast<Eigen::Index>(i), static_cast<Eigen::Index>(j)) =
+            (sigma_i_is_usable && sigma_j_is_usable) ? (covariance_matrix(i, j) / (sigma_i * sigma_j)) : nan;
       }
     }
   }

--- a/optimizations/src/covariance_types.cpp
+++ b/optimizations/src/covariance_types.cpp
@@ -10,7 +10,11 @@ namespace industrial_calibration
 std::string NamedParam::toString() const
 {
   std::stringstream ss;
-  ss << names.first.c_str() << " " << names.second.c_str() << " " << value;
+  ss << names.first.c_str() << " " << names.second.c_str() << " ";
+  if (std::isfinite(value))
+    ss << value;
+  else
+    ss << "undefined";
   return ss.str();
 }
 

--- a/test/covariance_utest.cpp
+++ b/test/covariance_utest.cpp
@@ -669,6 +669,51 @@ TEST(CovarianceAnalysis, CovarianceAnalysisFunctions)
                CovarianceException);
 }
 
+TEST(CovarianceAnalysis, CorrelationsWithZeroVarianceAreUndefined)
+{
+  Eigen::Matrix2d covariance;
+  covariance << 0.0, 2.0, 2.0, 4.0;
+
+  const Eigen::MatrixXd correlations = computeCorrelationsFromCovariance(covariance);
+
+  EXPECT_DOUBLE_EQ(correlations(0, 0), 0.0);
+  EXPECT_DOUBLE_EQ(correlations(1, 1), 2.0);
+  EXPECT_TRUE(std::isnan(correlations(0, 1)));
+  EXPECT_TRUE(std::isnan(correlations(1, 0)));
+}
+
+TEST(CovarianceAnalysis, CorrelationsWithNegativeVarianceAreUndefined)
+{
+  Eigen::Matrix2d covariance;
+  covariance << -1.0, 0.5, 0.5, 9.0;
+
+  const Eigen::MatrixXd correlations = computeCorrelationsFromCovariance(covariance);
+
+  EXPECT_TRUE(std::isnan(correlations(0, 0)));
+  EXPECT_DOUBLE_EQ(correlations(1, 1), 3.0);
+  EXPECT_TRUE(std::isnan(correlations(0, 1)));
+  EXPECT_TRUE(std::isnan(correlations(1, 0)));
+}
+
+TEST(CovarianceAnalysis, UndefinedCorrelationsAreLabeledInReports)
+{
+  CovarianceResult result;
+
+  NamedParam std_dev;
+  std_dev.names = std::make_pair(std::string("x"), std::string(""));
+  std_dev.value = 0.0;
+  result.standard_deviations.push_back(std_dev);
+
+  NamedParam corr;
+  corr.names = std::make_pair(std::string("x"), std::string("y"));
+  corr.value = std::numeric_limits<double>::quiet_NaN();
+  result.correlation_coeffs.push_back(corr);
+
+  const std::string report = result.toString();
+  EXPECT_NE(report.find("x y undefined"), std::string::npos);
+  EXPECT_EQ(report.find("x y nan"), std::string::npos);
+}
+
 int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);

--- a/test/extrinsic_hand_eye_utest.cpp
+++ b/test/extrinsic_hand_eye_utest.cpp
@@ -173,6 +173,27 @@ TYPED_TEST(HandEyeTest, PerfectInitialConditions)
   EXPECT_EQ(result.covariance.covariances.size(), 66);
   EXPECT_EQ(result.covariance.correlation_coeffs.size(), 66);
 
+  const std::array<std::string, 6> expected_camera_labels = {
+    { "camera_mount_to_camera_rx", "camera_mount_to_camera_ry", "camera_mount_to_camera_rz", "camera_mount_to_camera_x",
+      "camera_mount_to_camera_y", "camera_mount_to_camera_z" }
+  };
+  const std::array<std::string, 6> expected_target_labels = {
+    { "target_mount_to_target_rx", "target_mount_to_target_ry", "target_mount_to_target_rz", "target_mount_to_target_x",
+      "target_mount_to_target_y", "target_mount_to_target_z" }
+  };
+
+  const bool camera_block_first = result.covariance.standard_deviations.front().names.first.find("camera_mount_to_"
+                                                                                                 "camera_") == 0;
+  const auto& first_expected_block = camera_block_first ? expected_camera_labels : expected_target_labels;
+  const auto& second_expected_block = camera_block_first ? expected_target_labels : expected_camera_labels;
+
+  for (std::size_t i = 0; i < expected_camera_labels.size(); ++i)
+  {
+    EXPECT_EQ(result.covariance.standard_deviations[i].names.first, first_expected_block[i]);
+    EXPECT_EQ(result.covariance.standard_deviations[i + expected_camera_labels.size()].names.first,
+              second_expected_block[i]);
+  }
+
   this->printResults(result);
 }
 

--- a/test/extrinsic_multi_static_camera_utest.cpp
+++ b/test/extrinsic_multi_static_camera_utest.cpp
@@ -158,6 +158,16 @@ TEST(ExtrinsicMultiStaticCamera, single_camera)
   EXPECT_EQ(opt_result.covariance.covariances.size(), 66);
   EXPECT_EQ(opt_result.covariance.correlation_coeffs.size(), 66);
 
+  const std::array<std::string, 12> expected_labels = {
+    { "base_to_camera0_rx", "base_to_camera0_ry", "base_to_camera0_rz", "base_to_camera0_x", "base_to_camera0_y",
+      "base_to_camera0_z", "wrist_to_target_rx", "wrist_to_target_ry", "wrist_to_target_rz", "wrist_to_target_x",
+      "wrist_to_target_y", "wrist_to_target_z" }
+  };
+  for (std::size_t i = 0; i < expected_labels.size(); ++i)
+  {
+    EXPECT_EQ(opt_result.covariance.standard_deviations[i].names.first, expected_labels[i]);
+  }
+
   printResults(opt_result);
 }
 


### PR DESCRIPTION
Align Pose6d covariance labels with the actual parameter storage order
across hand-eye and multi-static calibration paths.

Stop fabricating finite correlation coefficients when variances are
zero or invalid, and report non-finite correlation values as
"undefined" in covariance output.

Add regression coverage for label ordering, degenerate covariance
handling, and report formatting.